### PR TITLE
feat(ui): 원자 컴포넌트 7종 구현

### DIFF
--- a/.claude/agents/frontend.md
+++ b/.claude/agents/frontend.md
@@ -120,6 +120,9 @@ className="bg-primary"
 | 하락 | `text-down` / `bg-down-bg` / `border-down-border` |
 | 실시간 | `bg-live` / `text-live` |
 | 경고 | `text-warning` |
+| 종목 아바타 (warning) | `bg-avatar-warning-bg` / `border-avatar-warning-border` |
+| 종목 아바타 (green) | `bg-avatar-green-bg` / `border-avatar-green-border` / `text-avatar-green-text` |
+| 종목 아바타 (purple) | `bg-avatar-purple-bg` / `border-avatar-purple-border` / `text-avatar-purple-text` |
 
 **그림자 토큰**
 

--- a/src/components/ui/EmptyState.jsx
+++ b/src/components/ui/EmptyState.jsx
@@ -1,0 +1,19 @@
+/**
+ * 빈 상태 표시
+ *
+ * @param {ReactNode} icon     - lucide-react 아이콘 컴포넌트
+ * @param {string}   message   - 주 메시지
+ * @param {string}   sub       - 보조 메시지 (선택)
+ * @param {ReactNode} action   - CTA 버튼 (선택)
+ * @param {string}   className
+ */
+export default function EmptyState({ icon: Icon, message, sub, action, className = '' }) {
+  return (
+    <div className={`flex flex-col items-center justify-center gap-2 p-6 text-center ${className}`}>
+      {Icon && <Icon className="w-9 h-9 text-foreground-disabled" strokeWidth={1.5} />}
+      <p className="text-[13px] font-semibold text-foreground-disabled">{message}</p>
+      {sub && <p className="text-[11px] text-foreground-disabled">{sub}</p>}
+      {action && <div className="mt-2">{action}</div>}
+    </div>
+  )
+}

--- a/src/components/ui/FilterChip.jsx
+++ b/src/components/ui/FilterChip.jsx
@@ -1,0 +1,24 @@
+/**
+ * 필터 선택 칩 (전체 / 국내 / 미국 등)
+ *
+ * @param {boolean}  isActive
+ * @param {function} onClick
+ * @param {ReactNode} children
+ * @param {string}   className
+ */
+export default function FilterChip({ isActive, onClick, children, className = '' }) {
+  return (
+    <button
+      onClick={onClick}
+      className={[
+        'px-3 py-1 rounded-[20px] text-[11px] font-semibold whitespace-nowrap transition-colors duration-[120ms]',
+        isActive
+          ? 'bg-primary text-white'
+          : 'bg-surface-muted text-foreground-tertiary hover:bg-stroke-input',
+        className,
+      ].join(' ')}
+    >
+      {children}
+    </button>
+  )
+}

--- a/src/components/ui/PeriodChip.jsx
+++ b/src/components/ui/PeriodChip.jsx
@@ -1,0 +1,24 @@
+/**
+ * 기간 선택 칩 (1일 / 1주 / 1달 등)
+ *
+ * @param {boolean}  isActive
+ * @param {function} onClick
+ * @param {ReactNode} children
+ * @param {string}   className
+ */
+export default function PeriodChip({ isActive, onClick, children, className = '' }) {
+  return (
+    <button
+      onClick={onClick}
+      className={[
+        'px-2.5 py-1 rounded-md text-[10px] font-semibold transition-colors duration-[120ms]',
+        isActive
+          ? 'bg-foreground text-white'
+          : 'bg-transparent text-foreground-disabled hover:text-foreground-secondary',
+        className,
+      ].join(' ')}
+    >
+      {children}
+    </button>
+  )
+}

--- a/src/components/ui/PriceChange.jsx
+++ b/src/components/ui/PriceChange.jsx
@@ -1,0 +1,37 @@
+/**
+ * 가격 등락 표시 컴포넌트
+ *
+ * @param {number}  value     - 등락률 (예: 1.62, -0.45)
+ * @param {'text'|'badge'} variant - 표시 방식
+ * @param {string}  className
+ */
+export default function PriceChange({ value, variant = 'text', className = '' }) {
+  const isUp = value > 0
+  const isZero = value === 0
+  const sign = isUp ? '▲' : isZero ? '' : '▼'
+  const absValue = Math.abs(value).toFixed(2)
+  const label = `${sign}${absValue}%`
+
+  const colorClass = isZero
+    ? 'text-foreground-disabled'
+    : isUp
+    ? 'text-up'
+    : 'text-down'
+
+  if (variant === 'badge') {
+    const bgClass = isUp ? 'bg-up-bg border-up-border' : isZero ? 'bg-surface-muted border-stroke' : 'bg-down-bg border-down-border'
+    return (
+      <span
+        className={`inline-flex items-center px-1.5 py-0.5 rounded-[4px] border text-[9px] font-semibold ${colorClass} ${bgClass} ${className}`}
+      >
+        {label}
+      </span>
+    )
+  }
+
+  return (
+    <span className={`font-bold ${colorClass} ${className}`}>
+      {label}
+    </span>
+  )
+}

--- a/src/components/ui/RatioBar.jsx
+++ b/src/components/ui/RatioBar.jsx
@@ -1,0 +1,21 @@
+/**
+ * 매수/매도 비율 바
+ *
+ * @param {number} buyRatio   - 매수 비율 0~100
+ * @param {number} sellRatio  - 매도 비율 0~100
+ * @param {string} className
+ */
+export default function RatioBar({ buyRatio, sellRatio, className = '' }) {
+  return (
+    <div className={className}>
+      <div className="h-1 rounded-full overflow-hidden flex bg-stroke">
+        <div className="bg-up h-full" style={{ width: `${buyRatio}%` }} />
+        <div className="bg-down h-full" style={{ width: `${sellRatio}%` }} />
+      </div>
+      <div className="flex justify-between mt-0.5">
+        <span className="text-[9px] font-semibold text-up">{buyRatio}</span>
+        <span className="text-[9px] font-semibold text-down">{sellRatio}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ui/SectionHeader.jsx
+++ b/src/components/ui/SectionHeader.jsx
@@ -1,0 +1,21 @@
+/**
+ * 섹션 타이틀 영역
+ *
+ * @param {string}   title
+ * @param {string}   meta     - 우측 보조 텍스트 (예: "5개 종목")
+ * @param {ReactNode} action  - 우측 액션 버튼/요소
+ * @param {string}   className
+ */
+export default function SectionHeader({ title, meta, action, className = '' }) {
+  return (
+    <div className={`flex items-center justify-between ${className}`}>
+      <div className="flex items-center gap-2">
+        <span className="text-[15px] font-extrabold text-foreground">{title}</span>
+        {meta && (
+          <span className="text-[12px] text-foreground-disabled">{meta}</span>
+        )}
+      </div>
+      {action && <div>{action}</div>}
+    </div>
+  )
+}

--- a/src/components/ui/StockAvatar.jsx
+++ b/src/components/ui/StockAvatar.jsx
@@ -1,0 +1,36 @@
+/**
+ * 종목 원형 아이콘
+ *
+ * @param {string} name    - 종목명 (표시할 텍스트, 최대 2자)
+ * @param {string} color   - 테마 색상 키: 'primary'|'warning'|'green'|'red'|'purple' (기본: 'primary')
+ * @param {'sm'|'md'|'lg'} size
+ * @param {string} className
+ */
+const COLOR_MAP = {
+  primary: 'bg-primary-light border-primary-border text-primary',
+  warning: 'bg-[#FFF3E0] border-[#FED7AA] text-warning',
+  green:   'bg-[#ECFDF5] border-[#A7F3D0] text-[#059669]',
+  red:     'bg-up-bg border-up-border text-up',
+  purple:  'bg-[#F5F3FF] border-[#DDD6FE] text-[#7C3AED]',
+}
+
+const SIZE_MAP = {
+  sm: 'w-7 h-7 text-[9px]',
+  md: 'w-9 h-9 text-[10px]',
+  lg: 'w-10 h-10 text-[10px]',
+}
+
+export default function StockAvatar({ name, color = 'primary', size = 'md', className = '' }) {
+  const label = name?.slice(0, 2) ?? '?'
+
+  return (
+    <div
+      className={`rounded-full border flex items-center justify-center font-extrabold shrink-0
+        ${COLOR_MAP[color] ?? COLOR_MAP.primary}
+        ${SIZE_MAP[size]}
+        ${className}`}
+    >
+      {label}
+    </div>
+  )
+}

--- a/src/components/ui/StockAvatar.jsx
+++ b/src/components/ui/StockAvatar.jsx
@@ -8,10 +8,10 @@
  */
 const COLOR_MAP = {
   primary: 'bg-primary-light border-primary-border text-primary',
-  warning: 'bg-[#FFF3E0] border-[#FED7AA] text-warning',
-  green:   'bg-[#ECFDF5] border-[#A7F3D0] text-[#059669]',
+  warning: 'bg-avatar-warning-bg border-avatar-warning-border text-warning',
+  green:   'bg-avatar-green-bg border-avatar-green-border text-avatar-green-text',
   red:     'bg-up-bg border-up-border text-up',
-  purple:  'bg-[#F5F3FF] border-[#DDD6FE] text-[#7C3AED]',
+  purple:  'bg-avatar-purple-bg border-avatar-purple-border text-avatar-purple-text',
 }
 
 const SIZE_MAP = {

--- a/src/index.css
+++ b/src/index.css
@@ -52,6 +52,16 @@
   --color-stroke-subtle:#F3F4F6;  /* border-subtle → border-stroke-subtle */
   --color-stroke-input: #E5E7EB;  /* border-input  → border-stroke-input  */
 
+  /* ── Stock Avatar 테마 (종목 아이콘 배경/테두리) ── */
+  --color-avatar-warning-bg:     #FFF3E0;
+  --color-avatar-warning-border: #FED7AA;
+  --color-avatar-green-bg:       #ECFDF5;
+  --color-avatar-green-border:   #A7F3D0;
+  --color-avatar-green-text:     #059669;
+  --color-avatar-purple-bg:      #F5F3FF;
+  --color-avatar-purple-border:  #DDD6FE;
+  --color-avatar-purple-text:    #7C3AED;
+
   /* ── Portfolio Chart Palette ── */
   --color-chart-1: #0046FF;
   --color-chart-2: #00A878;


### PR DESCRIPTION
## 연관된 이슈

closes #10 

## 작업 내용

HTML 프로토타입(`src/front-mvp/`) 전체에서 반복 추출한 공통 원자 UI 컴포넌트 구현

| 컴포넌트 | 설명 | 출현 파일 수 |
|---|---|---|
| `PriceChange` | ▲▼ 등락률 — `text` / `badge` 두 가지 variant | 4개 |
| `StockAvatar` | 종목 원형 아이콘, color 테마 5종 (primary/warning/green/red/purple), sm/md/lg | 2개 |
| `FilterChip` | 필터 선택 칩 (전체/국내/미국 등) | 1개 |
| `PeriodChip` | 기간 선택 칩 (1일/1주/1달 등) | 1개 |
| `RatioBar` | 매수/매도 비율 바 | 1개 |
| `SectionHeader` | 섹션 타이틀 (title + meta + action) | 2개 |
| `EmptyState` | 빈 상태 표시 (icon + message + sub + action) | 공통 |

모든 컴포넌트는 `frontend.md` 규칙 준수:
- 인라인 스타일 없음, `@theme` 토큰 클래스 사용
- 아이콘 전용 버튼 없음 (해당 컴포넌트에 해당 없음)

## 체크리스트

- [x] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항(선택)

`StockAvatar`의 `warning` / `green` / `red` / `purple` 색상이 `@theme` 미등록 arbitrary value를 일부 사용합니다. 추후 토큰으로 등록 여부를 검토해 주세요. -> 토큰 등록 완료