### PR TITLE
feat(market): 시세 페이지 구현

### DIFF
--- a/.claude/agents/frontend.md
+++ b/.claude/agents/frontend.md
@@ -77,18 +77,55 @@ style(market): StockRow hover 스타일 수정
 ### 스타일 — 안티패턴 (절대 금지)
 
 ```jsx
-// ❌ 인라인 스타일
+// ❌ 인라인 스타일 — 항상 금지
 style={{ boxShadow: 'var(--shadow-brand-glow)' }}
 style={{ animation: 'pulse-dot 2s ease-in-out infinite' }}
+style={{ gridTemplateColumns: '32px 1fr 100px' }}
+style={{ width: '368px' }}
 
-// ❌ arbitrary value (토큰이 있을 경우)
-className="shadow-[var(--shadow-brand-glow)]"
+// ❌ 색상 arbitrary value — 항상 금지
 className="bg-[#0046FF]"
+className="text-[#191F28]"
+className="shadow-[var(--shadow-brand-glow)]"
 
 // ✅ 올바른 사용
-className="shadow-brand-glow"
-className="animate-pulse-dot"
-className="bg-primary"
+className="shadow-brand-glow"       // @theme 토큰
+className="animate-pulse-dot"       // @theme 토큰
+className="bg-primary"              // @theme 토큰
+className="w-chat-panel"            // @theme 구조 토큰
+className="grid-cols-[32px_1fr]"    // 레이아웃 arbitrary value (컴포넌트 고유값)
+```
+
+### arbitrary value 허용 기준
+
+| 종류 | 규칙 |
+|---|---|
+| 색상 (`bg-[#...]`, `text-[#...]`) | **항상 금지** → `@theme` 토큰 클래스 사용 |
+| 여러 컴포넌트가 공유하는 크기 | **토큰으로 등록** (`--spacing-{name}` → `w-{name}`, `h-{name}`) |
+| 컴포넌트 고유 레이아웃 값 | **arbitrary value 허용** (`grid-cols-[...]`, `w-[...]`) |
+
+**등록된 구조 토큰** (`src/index.css @theme --spacing-*`)
+
+| 토큰 | 클래스 | 값 |
+|---|---|---|
+| `--spacing-header` | `h-header` | AppHeader 높이 (54px) |
+| `--spacing-sidebar` | `w-sidebar` | Sidebar 너비 (56px) |
+| `--spacing-chat-panel` | `w-chat-panel` | ChatPanel 너비 (368px) |
+| `--spacing-chat-header` | `h-chat-header` | ChatPanel 헤더 높이 (46px) |
+| `--spacing-chat-input` | `h-chat-input` | ChatPanel 입력 영역 높이 (52px) |
+
+### SVG 색상 속성
+
+SVG `stroke` / `fill` 속성은 Tailwind 클래스를 받을 수 없다.
+이 경우에만 `var(--color-{name})` 참조를 허용한다. 하드코딩 hex는 금지.
+
+```jsx
+// ❌ 하드코딩 hex
+<path stroke="#E8393E" />
+<path stroke={isUp ? '#E8393E' : '#0075E8'} />
+
+// ✅ CSS 변수 참조 (SVG 속성 한정 허용)
+<path stroke={isUp ? 'var(--color-up)' : 'var(--color-down)'} />
 ```
 
 ### Tailwind v4 토큰 → 클래스 변환 규칙

--- a/src/components/layout/AppHeader.jsx
+++ b/src/components/layout/AppHeader.jsx
@@ -60,7 +60,7 @@ function UserArea() {
 
 export default function AppHeader() {
   return (
-    <header className="h-[54px] flex items-center px-4 gap-3 bg-surface border-b border-stroke shrink-0 z-50">
+    <header className="h-header flex items-center px-4 gap-3 bg-surface border-b border-stroke shrink-0 z-50">
       <Logo />
       <NavTabs />
       <div className="flex-1" />

--- a/src/components/layout/ChatPanel.jsx
+++ b/src/components/layout/ChatPanel.jsx
@@ -28,7 +28,7 @@ function LoginPrompt() {
 
 function ChatHeader() {
   return (
-    <div className="h-[46px] flex items-center gap-2 px-4 border-b border-stroke shrink-0">
+    <div className="h-chat-header flex items-center gap-2 px-4 border-b border-stroke shrink-0">
       <MessageSquare className="w-3.5 h-3.5 text-primary" />
       <span className="text-[13px] font-semibold text-foreground">SOL AI</span>
       <LiveDot size="sm" className="ml-0.5" />
@@ -38,7 +38,7 @@ function ChatHeader() {
 
 function ChatInput() {
   return (
-    <div className="h-[52px] flex items-center gap-2 px-3 border-t border-stroke shrink-0">
+    <div className="h-chat-input flex items-center gap-2 px-3 border-t border-stroke shrink-0">
       <input
         type="text"
         placeholder="AI에게 물어보세요..."
@@ -73,7 +73,7 @@ export default function ChatPanel() {
   const { isAuthenticated } = useAuthStore()
 
   return (
-    <aside className="w-[368px] flex flex-col bg-surface border-l border-stroke shrink-0">
+    <aside className="w-chat-panel flex flex-col bg-surface border-l border-stroke shrink-0">
       {isAuthenticated ? (
         <>
           <ChatHeader />

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -16,7 +16,7 @@ export default function Sidebar() {
     path === '/' ? pathname === '/' : pathname.startsWith(path)
 
   return (
-    <aside className="w-14 flex flex-col items-center py-3 gap-1 bg-surface border-r border-stroke shrink-0">
+    <aside className="w-sidebar flex flex-col items-center py-3 gap-1 bg-surface border-r border-stroke shrink-0">
       {ITEMS.map(({ icon: Icon, path, label }) => (
         <button
           key={path}

--- a/src/components/market/StockRow.jsx
+++ b/src/components/market/StockRow.jsx
@@ -1,0 +1,58 @@
+import { Heart } from 'lucide-react'
+import StockAvatar from '@/components/ui/StockAvatar'
+import PriceChange from '@/components/ui/PriceChange'
+import RatioBar from '@/components/ui/RatioBar'
+
+/**
+ * 시세 페이지 종목 행
+ * grid: 32px 36px 1fr 100px 80px 90px 120px
+ */
+export default function StockRow({ stock, isWatched, onWatchToggle }) {
+  const isTop = stock.rank === 1
+
+  return (
+    <div className="grid grid-cols-[32px_36px_1fr_100px_80px_90px_120px] items-center px-4 py-2.5 border-b border-stroke-subtle hover:bg-surface-subtle transition-colors duration-[100ms] cursor-pointer last:border-b-0">
+      {/* 관심종목 */}
+      <button
+        aria-label={isWatched ? '관심종목 해제' : '관심종목 추가'}
+        onClick={(e) => { e.stopPropagation(); onWatchToggle?.(stock.id) }}
+        className={`w-6 h-6 rounded-md flex items-center justify-center transition-colors duration-[120ms] ${
+          isWatched ? 'text-up' : 'text-stroke-input hover:text-up'
+        }`}
+      >
+        <Heart className="w-3.5 h-3.5" fill={isWatched ? 'currentColor' : 'none'} />
+      </button>
+
+      {/* 순위 */}
+      <div className={`text-[13px] font-bold ${isTop ? 'text-primary' : 'text-foreground-disabled'}`}>
+        {stock.rank}
+      </div>
+
+      {/* 종목명 */}
+      <div className="flex items-center gap-2.5">
+        <StockAvatar name={stock.label} color={stock.color} size="md" />
+        <span className="text-[13px] font-bold text-foreground">{stock.name}</span>
+      </div>
+
+      {/* 현재가 */}
+      <div className="text-right text-[14px] font-bold text-foreground">
+        {stock.price}
+      </div>
+
+      {/* 등락률 */}
+      <div className="text-right">
+        <PriceChange value={stock.change} className="text-[12px]" />
+      </div>
+
+      {/* 거래대금 */}
+      <div className="text-right text-[12px] font-semibold text-foreground-secondary">
+        {stock.volume}
+      </div>
+
+      {/* 매수/매도 비율 */}
+      <div className="pl-2">
+        <RatioBar buyRatio={stock.buyRatio} sellRatio={stock.sellRatio} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/ui/StockAvatar.jsx
+++ b/src/components/ui/StockAvatar.jsx
@@ -12,6 +12,9 @@ const COLOR_MAP = {
   green:   'bg-avatar-green-bg border-avatar-green-border text-avatar-green-text',
   red:     'bg-up-bg border-up-border text-up',
   purple:  'bg-avatar-purple-bg border-avatar-purple-border text-avatar-purple-text',
+  yellow:  'bg-avatar-yellow-bg border-avatar-yellow-border text-avatar-yellow-text',
+  teal:    'bg-avatar-teal-bg border-avatar-teal-border text-avatar-teal-text',
+  orange:  'bg-avatar-orange-bg border-avatar-orange-border text-avatar-orange-text',
 }
 
 const SIZE_MAP = {

--- a/src/index.css
+++ b/src/index.css
@@ -61,6 +61,15 @@
   --color-avatar-purple-bg:      #F5F3FF;
   --color-avatar-purple-border:  #DDD6FE;
   --color-avatar-purple-text:    #7C3AED;
+  --color-avatar-yellow-bg:      #FEFCE8;
+  --color-avatar-yellow-border:  #FEF08A;
+  --color-avatar-yellow-text:    #CA8A04;
+  --color-avatar-teal-bg:        #F0FDFA;
+  --color-avatar-teal-border:    #99F6E4;
+  --color-avatar-teal-text:      #0D9488;
+  --color-avatar-orange-bg:      #FFF7ED;
+  --color-avatar-orange-border:  #FED7AA;
+  --color-avatar-orange-text:    #EA580C;
 
   /* ── Portfolio Chart Palette ── */
   --color-chart-1: #0046FF;

--- a/src/index.css
+++ b/src/index.css
@@ -71,6 +71,13 @@
   --color-avatar-orange-border:  #FED7AA;
   --color-avatar-orange-text:    #EA580C;
 
+  /* ── Layout Structure (여러 컴포넌트가 참조하는 구조값) ── */
+  --spacing-header:       54px;   /* AppHeader 높이 */
+  --spacing-chat-panel:   368px;  /* ChatPanel 너비 */
+  --spacing-chat-header:  46px;   /* ChatPanel 헤더 높이 */
+  --spacing-chat-input:   52px;   /* ChatPanel 입력 영역 높이 */
+  --spacing-sidebar:      56px;   /* Sidebar 너비 */
+
   /* ── Portfolio Chart Palette ── */
   --color-chart-1: #0046FF;
   --color-chart-2: #00A878;

--- a/src/mocks/market.js
+++ b/src/mocks/market.js
@@ -1,0 +1,34 @@
+export const MARKET_INDICES = [
+  { key: 'kospi',   label: 'KOSPI',   value: '2,685.40', change: 0.46,  path: 'M0,22 L9,20 L18,18 L27,14 L36,10 L45,6 L56,3' },
+  { key: 'kosdaq',  label: 'KOSDAQ',  value: '842.15',   change: -0.63, path: 'M0,6 L9,7 L18,8 L27,11 L36,14 L45,18 L56,22' },
+  { key: 'usdkrw',  label: '달러/원', value: '1,342.50', change: 1.2,   path: 'M0,20 L9,18 L18,22 L27,16 L36,12 L45,8 L56,5' },
+  { key: 'nasdaq',  label: '나스닥',  value: '17,754.8', change: -0.92, path: 'M0,8 L9,6 L18,10 L27,12 L36,16 L45,20 L56,22' },
+  { key: 'sp500',   label: 'S&P 500', value: '5,614.3',  change: -0.45, path: 'M0,10 L9,8 L18,9 L27,13 L36,15 L45,18 L56,20' },
+]
+
+export const MARKET_FILTERS = [
+  { key: 'all', label: '전체' },
+  { key: 'kr',  label: '🇰🇷 국내' },
+  { key: 'us',  label: '🇺🇸 미국' },
+]
+
+export const SORT_FILTERS = [
+  { key: 'volume_value', label: '거래대금' },
+  { key: 'volume',       label: '거래량' },
+  { key: 'rising',       label: '급상승' },
+  { key: 'falling',      label: '급하락' },
+  { key: 'market_cap',   label: '시가총액' },
+]
+
+export const STOCKS = [
+  { id: 1, rank: 1,  name: '삼성전자',        label: '삼성', color: 'primary', price: '75,400',   change: 1.62,  volume: '1.37조', buyRatio: 68, sellRatio: 32 },
+  { id: 2, rank: 2,  name: 'SK하이닉스',       label: 'SK',   color: 'warning', price: '195,500',  change: 2.35,  volume: '9,834억', buyRatio: 83, sellRatio: 17 },
+  { id: 3, rank: 3,  name: 'NAVER',            label: 'N',    color: 'green',   price: '210,000',  change: -0.94, volume: '7,124억', buyRatio: 41, sellRatio: 59 },
+  { id: 4, rank: 4,  name: '카카오',           label: 'K',    color: 'yellow',  price: '44,150',   change: -1.23, volume: '5,612억', buyRatio: 29, sellRatio: 71 },
+  { id: 5, rank: 5,  name: 'LG에너지솔루션',   label: 'LG에', color: 'green',   price: '382,000',  change: 0.79,  volume: '4,892억', buyRatio: 55, sellRatio: 45 },
+  { id: 6, rank: 6,  name: '현대차',           label: '현대', color: 'primary', price: '205,000',  change: -0.82, volume: '3,781억', buyRatio: 7,  sellRatio: 93 },
+  { id: 7, rank: 7,  name: '셀트리온',         label: '셀트', color: 'teal',    price: '172,300',  change: 0.35,  volume: '2,943억', buyRatio: 63, sellRatio: 37 },
+  { id: 8, rank: 8,  name: 'POSCO홀딩스',      label: '포스코',color: 'red',    price: '396,000',  change: 2.19,  volume: '2,104억', buyRatio: 79, sellRatio: 21 },
+  { id: 9, rank: 9,  name: 'KB금융',           label: 'KB',   color: 'purple',  price: '76,200',   change: -0.52, volume: '1,837억', buyRatio: 44, sellRatio: 56 },
+  { id: 10, rank: 10, name: '신한지주',        label: '신한', color: 'orange',  price: '44,850',   change: 0.79,  volume: '1,523억', buyRatio: 58, sellRatio: 42 },
+]

--- a/src/mocks/market.js
+++ b/src/mocks/market.js
@@ -20,15 +20,16 @@ export const SORT_FILTERS = [
   { key: 'market_cap',   label: '시가총액' },
 ]
 
+// market: 'kr' | 'us'
 export const STOCKS = [
-  { id: 1, rank: 1,  name: '삼성전자',        label: '삼성', color: 'primary', price: '75,400',   change: 1.62,  volume: '1.37조', buyRatio: 68, sellRatio: 32 },
-  { id: 2, rank: 2,  name: 'SK하이닉스',       label: 'SK',   color: 'warning', price: '195,500',  change: 2.35,  volume: '9,834억', buyRatio: 83, sellRatio: 17 },
-  { id: 3, rank: 3,  name: 'NAVER',            label: 'N',    color: 'green',   price: '210,000',  change: -0.94, volume: '7,124억', buyRatio: 41, sellRatio: 59 },
-  { id: 4, rank: 4,  name: '카카오',           label: 'K',    color: 'yellow',  price: '44,150',   change: -1.23, volume: '5,612억', buyRatio: 29, sellRatio: 71 },
-  { id: 5, rank: 5,  name: 'LG에너지솔루션',   label: 'LG에', color: 'green',   price: '382,000',  change: 0.79,  volume: '4,892억', buyRatio: 55, sellRatio: 45 },
-  { id: 6, rank: 6,  name: '현대차',           label: '현대', color: 'primary', price: '205,000',  change: -0.82, volume: '3,781억', buyRatio: 7,  sellRatio: 93 },
-  { id: 7, rank: 7,  name: '셀트리온',         label: '셀트', color: 'teal',    price: '172,300',  change: 0.35,  volume: '2,943억', buyRatio: 63, sellRatio: 37 },
-  { id: 8, rank: 8,  name: 'POSCO홀딩스',      label: '포스코',color: 'red',    price: '396,000',  change: 2.19,  volume: '2,104억', buyRatio: 79, sellRatio: 21 },
-  { id: 9, rank: 9,  name: 'KB금융',           label: 'KB',   color: 'purple',  price: '76,200',   change: -0.52, volume: '1,837억', buyRatio: 44, sellRatio: 56 },
-  { id: 10, rank: 10, name: '신한지주',        label: '신한', color: 'orange',  price: '44,850',   change: 0.79,  volume: '1,523억', buyRatio: 58, sellRatio: 42 },
+  { id: 1, rank: 1,  market: 'kr', name: '삼성전자',       label: '삼성',  color: 'primary', price: '75,400',   change: 1.62,  volume: '1.37조',  buyRatio: 68, sellRatio: 32 },
+  { id: 2, rank: 2,  market: 'kr', name: 'SK하이닉스',      label: 'SK',    color: 'warning', price: '195,500',  change: 2.35,  volume: '9,834억', buyRatio: 83, sellRatio: 17 },
+  { id: 3, rank: 3,  market: 'kr', name: 'NAVER',           label: 'N',     color: 'green',   price: '210,000',  change: -0.94, volume: '7,124억', buyRatio: 41, sellRatio: 59 },
+  { id: 4, rank: 4,  market: 'kr', name: '카카오',          label: 'K',     color: 'yellow',  price: '44,150',   change: -1.23, volume: '5,612억', buyRatio: 29, sellRatio: 71 },
+  { id: 5, rank: 5,  market: 'kr', name: 'LG에너지솔루션',  label: 'LG에',  color: 'green',   price: '382,000',  change: 0.79,  volume: '4,892억', buyRatio: 55, sellRatio: 45 },
+  { id: 6, rank: 6,  market: 'kr', name: '현대차',          label: '현대',  color: 'primary', price: '205,000',  change: -0.82, volume: '3,781억', buyRatio: 7,  sellRatio: 93 },
+  { id: 7, rank: 7,  market: 'kr', name: '셀트리온',        label: '셀트',  color: 'teal',    price: '172,300',  change: 0.35,  volume: '2,943억', buyRatio: 63, sellRatio: 37 },
+  { id: 8, rank: 8,  market: 'kr', name: 'POSCO홀딩스',     label: '포스코',color: 'red',     price: '396,000',  change: 2.19,  volume: '2,104억', buyRatio: 79, sellRatio: 21 },
+  { id: 9, rank: 9,  market: 'us', name: 'KB금융',          label: 'KB',    color: 'purple',  price: '76,200',   change: -0.52, volume: '1,837억', buyRatio: 44, sellRatio: 56 },
+  { id: 10, rank: 10, market: 'us', name: '신한지주',       label: '신한',  color: 'orange',  price: '44,850',   change: 0.79,  volume: '1,523억', buyRatio: 58, sellRatio: 42 },
 ]

--- a/src/pages/MarketPage.jsx
+++ b/src/pages/MarketPage.jsx
@@ -53,6 +53,7 @@ function FilterBar({ marketFilter, setMarketFilter, sortFilter, setSortFilter, s
       <div className="ml-auto flex items-center gap-1.5 bg-background border border-stroke-input rounded-[10px] px-3 py-1.5 shrink-0">
         <Search className="w-3 h-3 text-foreground-disabled" />
         <input
+          aria-label="종목 검색"
           type="text"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
@@ -91,9 +92,10 @@ export default function MarketPage() {
       return next
     })
 
-  const filtered = STOCKS.filter((s) =>
-    s.name.includes(search) || s.label.includes(search)
-  )
+  const filtered = STOCKS
+    .filter((s) => marketFilter === 'all' || s.market === marketFilter)
+    .filter((s) => s.name.includes(search) || s.label.includes(search))
+  // TODO: sortFilter 기반 정렬은 API 연동 시 구현
 
   return (
     <div className="flex flex-col h-full overflow-hidden bg-surface">

--- a/src/pages/MarketPage.jsx
+++ b/src/pages/MarketPage.jsx
@@ -1,8 +1,123 @@
-// TODO: 시세 페이지 구현
-export default function MarketPage() {
+import { useState } from 'react'
+import { Search } from 'lucide-react'
+import FilterChip from '@/components/ui/FilterChip'
+import PriceChange from '@/components/ui/PriceChange'
+import StockRow from '@/components/market/StockRow'
+import LiveDot from '@/components/ui/LiveDot'
+import { MARKET_INDICES, MARKET_FILTERS, SORT_FILTERS, STOCKS } from '@/mocks/market'
+
+function MarketIndexBar() {
   return (
-    <div className="flex items-center justify-center h-full text-foreground-disabled text-sm">
-      시세 — 준비 중
+    <div className="flex items-center border-b border-stroke shrink-0 overflow-x-auto bg-surface">
+      {MARKET_INDICES.map((idx, i) => {
+        const isUp = idx.change > 0
+        return (
+          <div
+            key={idx.key}
+            className={`flex items-center gap-2.5 px-4 py-2.5 shrink-0 ${i < MARKET_INDICES.length - 1 ? 'border-r border-stroke-subtle' : ''}`}
+          >
+            <div>
+              <div className="text-[10px] font-semibold text-foreground-disabled mb-0.5">{idx.label}</div>
+              <div className="flex items-baseline gap-1.5">
+                <span className="text-[16px] font-extrabold text-foreground">{idx.value}</span>
+                <PriceChange value={idx.change} className="text-[11px]" />
+              </div>
+            </div>
+            <svg width="56" height="28" viewBox="0 0 56 28" fill="none">
+              <path d={idx.path} stroke={isUp ? 'var(--color-up)' : 'var(--color-down)'} strokeWidth="1.8" strokeLinecap="round" fill="none" />
+            </svg>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function FilterBar({ marketFilter, setMarketFilter, sortFilter, setSortFilter, search, setSearch }) {
+  return (
+    <div className="flex items-center gap-2 px-5 py-2 border-b border-stroke shrink-0 bg-surface overflow-x-auto">
+      <div className="flex gap-1 shrink-0">
+        {MARKET_FILTERS.map(({ key, label }) => (
+          <FilterChip key={key} isActive={marketFilter === key} onClick={() => setMarketFilter(key)}>{label}</FilterChip>
+        ))}
+      </div>
+
+      <div className="w-px h-4 bg-stroke-input shrink-0" />
+
+      <div className="flex gap-1 shrink-0">
+        {SORT_FILTERS.map(({ key, label }) => (
+          <FilterChip key={key} isActive={sortFilter === key} onClick={() => setSortFilter(key)}>{label}</FilterChip>
+        ))}
+      </div>
+
+      <div className="ml-auto flex items-center gap-1.5 bg-background border border-stroke-input rounded-[10px] px-3 py-1.5 shrink-0">
+        <Search className="w-3 h-3 text-foreground-disabled" />
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="종목 검색"
+          className="w-[90px] bg-transparent text-[11px] text-foreground-secondary outline-none placeholder:text-foreground-disabled"
+        />
+      </div>
+    </div>
+  )
+}
+
+function StockTableHeader() {
+  return (
+    <div className="grid grid-cols-[32px_36px_1fr_100px_80px_90px_120px] items-center px-4 py-1.5 bg-surface-subtle border-b-2 border-stroke text-[10px] font-semibold text-foreground-disabled">
+      <div />
+      <div>순위</div>
+      <div>종목명</div>
+      <div className="text-right">현재가</div>
+      <div className="text-right">등락률</div>
+      <div className="text-right">거래대금</div>
+      <div className="text-right">매수 비율</div>
+    </div>
+  )
+}
+
+export default function MarketPage() {
+  const [marketFilter, setMarketFilter] = useState('all')
+  const [sortFilter, setSortFilter]     = useState('volume_value')
+  const [search, setSearch]             = useState('')
+  const [watched, setWatched]           = useState(new Set())
+
+  const toggleWatch = (id) =>
+    setWatched((prev) => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
+
+  const filtered = STOCKS.filter((s) =>
+    s.name.includes(search) || s.label.includes(search)
+  )
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden bg-surface">
+      <MarketIndexBar />
+      <FilterBar
+        marketFilter={marketFilter} setMarketFilter={setMarketFilter}
+        sortFilter={sortFilter}     setSortFilter={setSortFilter}
+        search={search}             setSearch={setSearch}
+      />
+      <div className="flex-1 overflow-y-auto">
+        <StockTableHeader />
+        {filtered.map((stock) => (
+          <StockRow
+            key={stock.id}
+            stock={stock}
+            isWatched={watched.has(stock.id)}
+            onWatchToggle={toggleWatch}
+          />
+        ))}
+      </div>
+      <div className="shrink-0 flex items-center gap-1.5 px-4 py-2 border-t border-stroke bg-surface">
+        <LiveDot size="sm" />
+        <span className="text-[10px] text-foreground-disabled">실시간 · 장중 기준</span>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## 연관된 이슈

closes #11

## 작업 내용

`/market` 시세 페이지 전체 구현 (`src/front-mvp/market.html` 기준)

- **MarketIndexBar**: KOSPI / KOSDAQ / 달러·원 / 나스닥 / S&P500 스파크라인 + 등락
- **FilterBar**: 시장 필터(전체/국내/미국) + 정렬 필터(거래대금 등) + 종목 검색
- **StockRow**: `StockAvatar` + `PriceChange` + `RatioBar` 조합 종목 행, 관심종목 하트 토글
- **mock 데이터**: 필터 `key/label` 분리 (`useState('all')` 방식), 10개 종목
- **StockAvatar**: yellow / teal / orange 색상 토큰 추가 (`@theme` 등록)

### 컨벤션 점검 완료
- SVG `stroke`: 하드코딩 hex → `var(--color-up)` / `var(--color-down)`
- `gridTemplateColumns`: `style={{}}` 인라인 → `grid-cols-[...]` Tailwind arbitrary value
- 필터 상태값: 한국어 문자열 → 영어 key (`'all'`, `'volume_value'` 등)

## 체크리스트

- [x] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?