### PR TITLE
feat(home): 홈 페이지 위젯 그리드 구현

### DIFF
--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -1,18 +1,13 @@
-import { Outlet, useLocation } from 'react-router-dom'
+import { Outlet } from 'react-router-dom'
 import AppHeader from './AppHeader'
-import Sidebar from './Sidebar'
 import ChatPanel from './ChatPanel'
 
 export default function AppShell() {
-  const { pathname } = useLocation()
-  const isHome = pathname === '/'
-
   return (
     <div className="flex flex-col h-screen overflow-hidden">
       <AppHeader />
       <div className="flex flex-1 overflow-hidden">
-        {isHome && <Sidebar />}
-        <main className="flex-1 overflow-y-auto bg-background">
+        <main className="flex-1 overflow-hidden bg-background">
           <Outlet />
         </main>
         <ChatPanel />

--- a/src/components/ui/LockedOverlay.jsx
+++ b/src/components/ui/LockedOverlay.jsx
@@ -1,0 +1,24 @@
+import { Lock } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
+
+export default function LockedOverlay({ message = '계좌 정보를 보려면' }) {
+  const navigate = useNavigate()
+
+  return (
+    <div className="absolute inset-0 rounded-2xl bg-white/85 backdrop-blur-sm flex flex-col items-center justify-center gap-2">
+      <div className="w-9 h-9 rounded-xl bg-surface-muted flex items-center justify-center">
+        <Lock className="w-[18px] h-[18px] text-foreground-disabled" />
+      </div>
+      <div className="text-center">
+        <div className="text-[12px] font-bold text-foreground-secondary">로그인 필요</div>
+        <div className="text-[10px] text-foreground-disabled mt-0.5">{message}</div>
+      </div>
+      <button
+        onClick={(e) => { e.stopPropagation(); navigate('/login') }}
+        className="px-4 py-1.5 bg-primary text-white text-[11px] font-semibold rounded-lg hover:bg-primary-hover transition-colors duration-[150ms]"
+      >
+        로그인하기
+      </button>
+    </div>
+  )
+}

--- a/src/components/ui/TabChip.jsx
+++ b/src/components/ui/TabChip.jsx
@@ -1,0 +1,21 @@
+/**
+ * 위젯 내 소형 탭 칩 (DESIGN.md §8 TabChip)
+ *
+ * @param {boolean} isActive
+ * @param {function} onClick
+ */
+export default function TabChip({ children, isActive = false, onClick }) {
+  return (
+    <button
+      onClick={onClick}
+      className={[
+        'px-[9px] py-[3px] text-[10px] font-semibold rounded-[6px] border-none cursor-pointer transition-colors duration-[150ms]',
+        isActive
+          ? 'bg-primary-light text-primary'
+          : 'bg-transparent text-foreground-disabled hover:bg-surface-muted hover:text-foreground-secondary',
+      ].join(' ')}
+    >
+      {children}
+    </button>
+  )
+}

--- a/src/components/widgets/AddWidgetSlot.jsx
+++ b/src/components/widgets/AddWidgetSlot.jsx
@@ -1,0 +1,14 @@
+import { Plus } from 'lucide-react'
+
+export default function AddWidgetSlot() {
+  return (
+    <div className="col-span-1 rounded-2xl border-2 border-dashed border-primary-border bg-primary-light/50 flex flex-col items-center justify-center gap-2 cursor-pointer transition-all duration-[200ms] hover:border-primary hover:bg-primary-light group">
+      <div className="w-9 h-9 rounded-full border-2 border-dashed border-stroke-input flex items-center justify-center transition-all duration-[200ms] group-hover:border-primary group-hover:bg-primary-light">
+        <Plus className="w-4 h-4 text-foreground-disabled group-hover:text-primary transition-colors duration-[200ms]" />
+      </div>
+      <span className="text-[11px] text-foreground-disabled group-hover:text-primary transition-colors duration-[200ms]">
+        위젯 추가
+      </span>
+    </div>
+  )
+}

--- a/src/components/widgets/AddWidgetSlot.jsx
+++ b/src/components/widgets/AddWidgetSlot.jsx
@@ -2,13 +2,16 @@ import { Plus } from 'lucide-react'
 
 export default function AddWidgetSlot() {
   return (
-    <div className="col-span-1 rounded-2xl border-2 border-dashed border-primary-border bg-primary-light/50 flex flex-col items-center justify-center gap-2 cursor-pointer transition-all duration-[200ms] hover:border-primary hover:bg-primary-light group">
+    <button
+      aria-label="위젯 추가"
+      className="col-span-1 rounded-2xl border-2 border-dashed border-primary-border bg-primary-light/50 flex flex-col items-center justify-center gap-2 cursor-pointer transition-all duration-[200ms] hover:border-primary hover:bg-primary-light group"
+    >
       <div className="w-9 h-9 rounded-full border-2 border-dashed border-stroke-input flex items-center justify-center transition-all duration-[200ms] group-hover:border-primary group-hover:bg-primary-light">
         <Plus className="w-4 h-4 text-foreground-disabled group-hover:text-primary transition-colors duration-[200ms]" />
       </div>
       <span className="text-[11px] text-foreground-disabled group-hover:text-primary transition-colors duration-[200ms]">
         위젯 추가
       </span>
-    </div>
+    </button>
   )
 }

--- a/src/components/widgets/BalanceWidget.jsx
+++ b/src/components/widgets/BalanceWidget.jsx
@@ -1,0 +1,45 @@
+import LiveDot from '@/components/ui/LiveDot'
+import LockedOverlay from '@/components/ui/LockedOverlay'
+import useAuthStore from '@/store/useAuthStore'
+import WidgetCard from './WidgetCard'
+import { BALANCE } from '@/mocks/home'
+
+export default function BalanceWidget() {
+  const { isAuthenticated } = useAuthStore()
+
+  return (
+    <WidgetCard className="relative">
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">계좌 잔고</span>
+        <LiveDot />
+      </div>
+      <div className="flex-1 flex flex-col justify-between">
+        <div>
+          <div className="text-[10px] text-foreground-disabled mb-0.5">총 평가자산</div>
+          <div className="text-[18px] font-bold leading-tight tracking-tight text-foreground">
+            {BALANCE.total}
+            <span className="text-[11px] font-medium text-foreground-tertiary ml-0.5">원</span>
+          </div>
+          <div className="text-[11px] font-semibold text-up mt-0.5">▲ {BALANCE.profit} ({BALANCE.profitRate})</div>
+        </div>
+        <div className="flex flex-col gap-1 pt-2 border-t border-stroke-subtle mt-2">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-1.5">
+              <span className="text-[13px]">🇰🇷</span>
+              <span className="text-[10px] text-foreground-tertiary">KRW</span>
+            </div>
+            <span className="text-[10px] font-semibold text-foreground-secondary">{BALANCE.krw}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-1.5">
+              <span className="text-[13px]">🇺🇸</span>
+              <span className="text-[10px] text-foreground-tertiary">USD</span>
+            </div>
+            <span className="text-[10px] font-semibold text-foreground-secondary">{BALANCE.usd}</span>
+          </div>
+        </div>
+      </div>
+      {!isAuthenticated && <LockedOverlay message="계좌 정보를 보려면" />}
+    </WidgetCard>
+  )
+}

--- a/src/components/widgets/ExchangeWidget.jsx
+++ b/src/components/widgets/ExchangeWidget.jsx
@@ -1,0 +1,44 @@
+import LiveDot from '@/components/ui/LiveDot'
+import LockedOverlay from '@/components/ui/LockedOverlay'
+import useAuthStore from '@/store/useAuthStore'
+import WidgetCard from './WidgetCard'
+import { EXCHANGE } from '@/mocks/home'
+
+export default function ExchangeWidget() {
+  const { isAuthenticated } = useAuthStore()
+
+  return (
+    <WidgetCard className="relative">
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
+        <LiveDot />
+      </div>
+      <div className="flex-1 flex flex-col justify-between">
+        {EXCHANGE.map((item) => {
+          const isUp = item.change > 0
+          return (
+            <div key={item.pair} className="flex items-center gap-2 py-1.5 px-2 rounded-xl bg-surface-subtle">
+              <span className="text-[16px]">{item.flag}</span>
+              <div className="flex-1">
+                <div className="text-[9px] text-foreground-disabled">{item.pair}</div>
+                <div className="flex items-baseline gap-1">
+                  <span className="text-[15px] font-bold text-foreground">{item.rate}</span>
+                  <span className={`text-[9px] ${isUp ? 'text-up' : 'text-down'}`}>
+                    {isUp ? '▲' : '▼'}{Math.abs(item.change)}
+                  </span>
+                </div>
+              </div>
+            </div>
+          )
+        })}
+        <button
+          onClick={(e) => e.stopPropagation()}
+          className="w-full py-1.5 rounded-xl bg-primary-light text-primary text-[10px] font-bold hover:bg-primary-dim transition-colors duration-[150ms]"
+        >
+          환전하기 →
+        </button>
+      </div>
+      {!isAuthenticated && <LockedOverlay message="환율 정보를 보려면" />}
+    </WidgetCard>
+  )
+}

--- a/src/components/widgets/IndexWidget.jsx
+++ b/src/components/widgets/IndexWidget.jsx
@@ -1,0 +1,45 @@
+import { useState } from 'react'
+import PriceChange from '@/components/ui/PriceChange'
+import TabChip from '@/components/ui/TabChip'
+import WidgetCard from './WidgetCard'
+import { HOME_INDICES } from '@/mocks/home'
+
+const TABS = ['국내', '미국', '아시아']
+
+export default function IndexWidget() {
+  const [activeTab, setActiveTab] = useState('국내')
+
+  return (
+    <WidgetCard colSpan={2}>
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">주요 지수</span>
+        <div className="flex gap-1">
+          {TABS.map((tab) => (
+            <TabChip
+              key={tab}
+              isActive={activeTab === tab}
+              onClick={(e) => { e.stopPropagation(); setActiveTab(tab) }}
+            >
+              {tab}
+            </TabChip>
+          ))}
+        </div>
+      </div>
+      <div className="flex-1 grid grid-cols-5 gap-1 items-center">
+        {HOME_INDICES.map((idx) => (
+          <div
+            key={idx.key}
+            className={[
+              'text-center py-2 rounded-xl border',
+              idx.change > 0 ? 'bg-up-bg border-up-border' : 'bg-down-bg border-down-border',
+            ].join(' ')}
+          >
+            <div className="text-[9px] text-foreground-disabled mb-0.5">{idx.label}</div>
+            <div className="text-[13px] font-bold text-foreground">{idx.value}</div>
+            <PriceChange value={idx.change} className="text-[10px]" />
+          </div>
+        ))}
+      </div>
+    </WidgetCard>
+  )
+}

--- a/src/components/widgets/MarketOverviewWidget.jsx
+++ b/src/components/widgets/MarketOverviewWidget.jsx
@@ -1,0 +1,25 @@
+import WidgetCard from './WidgetCard'
+import { MARKET_OVERVIEW } from '@/mocks/home'
+
+export default function MarketOverviewWidget() {
+  return (
+    <WidgetCard>
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">오늘의 시황</span>
+        <span className="text-[9px] text-foreground-disabled">{MARKET_OVERVIEW.time}</span>
+      </div>
+      <div className="flex-1 flex flex-col justify-between gap-1.5">
+        <div className="flex gap-2 p-2 rounded-xl bg-primary-light border border-primary-dim">
+          <div className="w-1 rounded-full bg-primary self-stretch shrink-0" />
+          <p className="text-[10px] text-foreground-secondary leading-relaxed">{MARKET_OVERVIEW.headline}</p>
+        </div>
+        {MARKET_OVERVIEW.bullets.map((bullet) => (
+          <div key={bullet} className="flex gap-2 items-start px-1">
+            <div className="w-[4px] h-[4px] rounded-full bg-foreground-disabled mt-1 shrink-0" />
+            <p className="text-[10px] text-foreground-disabled leading-relaxed">{bullet}</p>
+          </div>
+        ))}
+      </div>
+    </WidgetCard>
+  )
+}

--- a/src/components/widgets/PortfolioWidget.jsx
+++ b/src/components/widgets/PortfolioWidget.jsx
@@ -1,0 +1,47 @@
+import LockedOverlay from '@/components/ui/LockedOverlay'
+import useAuthStore from '@/store/useAuthStore'
+import WidgetCard from './WidgetCard'
+import { PORTFOLIO } from '@/mocks/home'
+
+export default function PortfolioWidget() {
+  const { isAuthenticated } = useAuthStore()
+
+  return (
+    <WidgetCard className="relative">
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">포트폴리오</span>
+        <span className="text-[10px] font-semibold text-primary">5종목</span>
+      </div>
+      <div className="flex items-center gap-2.5 flex-1">
+        {/* 도넛 파이 차트 */}
+        <div className="relative shrink-0">
+          <div
+            className="w-[52px] h-[52px] rounded-full"
+            style={{ background: 'conic-gradient(var(--color-chart-1) 0% 34%, var(--color-chart-2) 34% 54%, var(--color-chart-3) 54% 69%, var(--color-chart-4) 69% 81%, var(--color-chart-5) 81% 100%)' }}
+          />
+          <div className="absolute inset-0 flex items-center justify-center">
+            <div className="w-8 h-8 rounded-full bg-surface shadow-inner flex items-center justify-center">
+              <span className="text-[9px] font-bold text-up">{PORTFOLIO.returnRate}</span>
+            </div>
+          </div>
+        </div>
+        {/* 종목 비율 리스트 */}
+        <div className="flex-1 flex flex-col gap-[3px]">
+          {PORTFOLIO.items.map((item) => (
+            <div key={item.name} className="flex items-center justify-between">
+              <div className="flex items-center gap-1">
+                <div className="w-[6px] h-[6px] rounded-sm shrink-0" style={{ background: item.color }} />
+                <span className="text-[10px] text-foreground-tertiary">{item.name}</span>
+              </div>
+              <div className="flex items-center gap-1">
+                <div className="h-[3px] rounded-full opacity-80" style={{ width: item.barWidth, background: item.color }} />
+                <span className="text-[9px] font-medium text-foreground">{item.ratio}%</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      {!isAuthenticated && <LockedOverlay message="포트폴리오를 보려면" />}
+    </WidgetCard>
+  )
+}

--- a/src/components/widgets/RankingWidget.jsx
+++ b/src/components/widgets/RankingWidget.jsx
@@ -1,0 +1,52 @@
+import { useState } from 'react'
+import PriceChange from '@/components/ui/PriceChange'
+import StockAvatar from '@/components/ui/StockAvatar'
+import TabChip from '@/components/ui/TabChip'
+import WidgetCard from './WidgetCard'
+import { RANKING } from '@/mocks/home'
+
+const TABS = ['거래대금', '급상승', '거래량', '🇺🇸 미국']
+
+export default function RankingWidget() {
+  const [activeTab, setActiveTab] = useState('거래대금')
+
+  return (
+    <WidgetCard colSpan={2}>
+      <div className="flex items-center justify-between mb-1.5">
+        <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">실시간 순위</span>
+        <div className="flex gap-0.5">
+          {TABS.map((tab) => (
+            <TabChip
+              key={tab}
+              isActive={activeTab === tab}
+              onClick={(e) => { e.stopPropagation(); setActiveTab(tab) }}
+            >
+              {tab}
+            </TabChip>
+          ))}
+        </div>
+      </div>
+      <div className="flex-1 flex flex-col justify-between gap-0.5">
+        {RANKING.map((stock) => (
+          <div
+            key={stock.rank}
+            className="flex items-center gap-2.5 px-1.5 py-1.5 rounded-xl hover:bg-surface-subtle transition-colors cursor-pointer"
+          >
+            <span className={`text-[11px] font-bold w-4 text-center shrink-0 ${stock.rank === 1 ? 'text-primary' : 'text-foreground-disabled'}`}>
+              {stock.rank}
+            </span>
+            <StockAvatar name={stock.label} color={stock.color} size="sm" />
+            <div className="flex-1 min-w-0">
+              <div className="text-[11px] font-semibold text-foreground leading-none truncate">{stock.name}</div>
+              <div className="text-[9px] text-foreground-disabled mt-0.5">거래대금 {stock.volume}</div>
+            </div>
+            <div className="text-right shrink-0">
+              <div className="text-[11px] font-bold text-primary">{stock.price}</div>
+              <PriceChange value={stock.change} className="text-[9px]" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </WidgetCard>
+  )
+}

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -1,0 +1,54 @@
+import StockAvatar from '@/components/ui/StockAvatar'
+import PriceChange from '@/components/ui/PriceChange'
+import WidgetCard from './WidgetCard'
+
+export default function StockChartWidget({ stock }) {
+  const isUp = stock.change > 0
+  const strokeColor = isUp ? 'var(--color-up)' : 'var(--color-down)'
+  const fillId = `spark-fill-${stock.id}`
+
+  return (
+    <WidgetCard>
+      <div className="flex items-center gap-2 mb-1">
+        <StockAvatar name={stock.label} color={stock.color} size="sm" />
+        <div className="flex-1 min-w-0">
+          <div className="text-[12px] font-bold leading-none truncate text-foreground">{stock.name}</div>
+          <div className="text-[9px] text-foreground-disabled mt-0.5">{stock.code}</div>
+        </div>
+        <PriceChange value={stock.change} variant="badge" />
+      </div>
+      <div className="my-1">
+        <div className={`text-[18px] font-bold leading-tight tracking-tight ${isUp ? 'text-up' : 'text-down'}`}>
+          {stock.price}
+        </div>
+        <div className={`text-[10px] ${isUp ? 'text-up' : 'text-down'}`}>
+          {isUp ? '▲' : '▼'} {stock.changeAmt}원 ({isUp ? '+' : ''}{stock.change}%)
+        </div>
+      </div>
+      <div className="flex justify-between text-[9px] py-1.5 border-t border-stroke-subtle mb-1">
+        <div className="text-center">
+          <div className="text-foreground-disabled">시가</div>
+          <div className="font-medium text-foreground-secondary">{stock.open}</div>
+        </div>
+        <div className="text-center">
+          <div className="text-foreground-disabled">고가</div>
+          <div className="font-medium text-up">{stock.high}</div>
+        </div>
+        <div className="text-center">
+          <div className="text-foreground-disabled">저가</div>
+          <div className="font-medium text-down">{stock.low}</div>
+        </div>
+      </div>
+      <svg className="w-full" height="22" viewBox="0 0 120 22" preserveAspectRatio="none">
+        <defs>
+          <linearGradient id={fillId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={strokeColor} stopOpacity=".15" />
+            <stop offset="100%" stopColor={strokeColor} stopOpacity="0" />
+          </linearGradient>
+        </defs>
+        <path d={stock.sparkPath} fill="none" stroke={strokeColor} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+        <path d={stock.fillPath} fill={`url(#${fillId})`} />
+      </svg>
+    </WidgetCard>
+  )
+}

--- a/src/components/widgets/WatchlistWidget.jsx
+++ b/src/components/widgets/WatchlistWidget.jsx
@@ -1,0 +1,35 @@
+import PriceChange from '@/components/ui/PriceChange'
+import StockAvatar from '@/components/ui/StockAvatar'
+import WidgetCard from './WidgetCard'
+import { WATCHLIST } from '@/mocks/home'
+
+export default function WatchlistWidget() {
+  return (
+    <WidgetCard>
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">관심 종목</span>
+        <button
+          onClick={(e) => e.stopPropagation()}
+          className="text-[10px] text-primary font-semibold hover:underline"
+        >
+          + 추가
+        </button>
+      </div>
+      <div className="flex-1 flex flex-col justify-between gap-0.5">
+        {WATCHLIST.map((stock, i) => (
+          <div key={stock.name}>
+            <div className="flex items-center gap-2 py-1 hover:bg-surface-subtle rounded-xl px-1 transition-colors cursor-pointer">
+              <StockAvatar name={stock.label} color={stock.color} size="sm" />
+              <div className="flex-1 min-w-0">
+                <div className="text-[11px] font-medium text-foreground leading-none">{stock.name}</div>
+                <div className="text-[9px] text-foreground-disabled">{stock.price}</div>
+              </div>
+              <PriceChange value={stock.change} className="text-[10px]" />
+            </div>
+            {i < WATCHLIST.length - 1 && <div className="h-px bg-stroke-subtle mx-1" />}
+          </div>
+        ))}
+      </div>
+    </WidgetCard>
+  )
+}

--- a/src/components/widgets/WidgetCard.jsx
+++ b/src/components/widgets/WidgetCard.jsx
@@ -1,0 +1,16 @@
+export default function WidgetCard({ children, colSpan = 1, className = '' }) {
+  return (
+    <div
+      className={[
+        'bg-surface border border-stroke rounded-2xl p-[14px_16px]',
+        'flex flex-col overflow-hidden cursor-pointer',
+        'transition-[border-color,box-shadow,transform] duration-[200ms]',
+        'hover:border-widget-border-hover hover:shadow-widget-hover hover:-translate-y-px',
+        colSpan === 2 ? 'col-span-2' : 'col-span-1',
+        className,
+      ].join(' ')}
+    >
+      {children}
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -48,9 +48,10 @@
   --color-surface-muted:    #F3F4F6;  /* bg-muted   → bg-surface-muted     */
 
   /* ── Border (DESIGN.md: border / border-subtle / border-input) ── */
-  --color-stroke:       #EAECF0;  /* border       → border-stroke       */
-  --color-stroke-subtle:#F3F4F6;  /* border-subtle → border-stroke-subtle */
-  --color-stroke-input: #E5E7EB;  /* border-input  → border-stroke-input  */
+  --color-stroke:              #EAECF0;  /* border       → border-stroke       */
+  --color-stroke-subtle:       #F3F4F6;  /* border-subtle → border-stroke-subtle */
+  --color-stroke-input:        #E5E7EB;  /* border-input  → border-stroke-input  */
+  --color-widget-border-hover: #BFD0FF;  /* 위젯 카드 hover 테두리 */
 
   /* ── Stock Avatar 테마 (종목 아이콘 배경/테두리) ── */
   --color-avatar-warning-bg:     #FFF3E0;

--- a/src/mocks/home.js
+++ b/src/mocks/home.js
@@ -1,0 +1,79 @@
+export const BALANCE = {
+  total: '84,320,000',
+  profit: '+2,140,000',
+  profitRate: '+2.61%',
+  krw: '72,100,000',
+  usd: '$8,924',
+}
+
+export const HOME_INDICES = [
+  { key: 'kospi',  label: 'KOSPI',   value: '2,685', change: 0.46 },
+  { key: 'kosdaq', label: 'KOSDAQ',  value: '842',   change: -0.63 },
+  { key: 'nasdaq', label: 'NASDAQ',  value: '16,274',change: -0.92 },
+  { key: 'sp500',  label: 'S&P 500', value: '5,234', change: -0.55 },
+  { key: 'dow',    label: 'DOW',     value: '38,921',change: 0.11 },
+]
+
+export const PORTFOLIO = {
+  returnRate: '+5.2%',
+  items: [
+    { name: '삼성전자', ratio: 34, color: 'var(--color-chart-1)', barWidth: 28 },
+    { name: 'SK하이닉스', ratio: 20, color: 'var(--color-chart-2)', barWidth: 16 },
+    { name: 'NAVER',    ratio: 15, color: 'var(--color-chart-3)', barWidth: 12 },
+    { name: '기타',     ratio: 31, color: 'var(--color-chart-5)', barWidth: 25 },
+  ],
+}
+
+export const HOME_STOCKS = [
+  {
+    id: 'samsung',
+    name: '삼성전자',
+    label: '삼성',
+    code: '005930 · KOSPI',
+    color: 'primary',
+    price: '75,400',
+    change: 1.62,
+    changeAmt: '1,200',
+    open: '74,200', high: '76,100', low: '73,900',
+    sparkPath: 'M0,18 L12,16 L24,14 L36,16 L48,10 L60,12 L72,7 L84,5 L96,3 L108,1.5 L120,1',
+    fillPath:  'M0,18 L12,16 L24,14 L36,16 L48,10 L60,12 L72,7 L84,5 L96,3 L108,1.5 L120,1 L120,22 L0,22Z',
+  },
+  {
+    id: 'skhynix',
+    name: 'SK하이닉스',
+    label: 'SK',
+    code: '000660 · KOSPI',
+    color: 'warning',
+    price: '195,500',
+    change: 2.35,
+    changeAmt: '4,500',
+    open: '191,500', high: '197,000', low: '190,500',
+    sparkPath: 'M0,20 L12,18 L24,20 L36,14 L48,16 L60,10 L72,12 L84,7 L96,5 L108,3 L120,1',
+    fillPath:  'M0,20 L12,18 L24,20 L36,14 L48,16 L60,10 L72,12 L84,7 L96,5 L108,3 L120,1 L120,22 L0,22Z',
+  },
+]
+
+export const RANKING = [
+  { rank: 1,  name: '삼성전자',      label: '삼성', color: 'primary', price: '75,400',  change: 1.62,  volume: '5.2조' },
+  { rank: 2,  name: 'SK하이닉스',   label: 'SK',    color: 'warning', price: '195,500', change: 2.35,  volume: '3.8조' },
+  { rank: 3,  name: 'NAVER',         label: 'N',     color: 'green',   price: '210,000', change: -0.94, volume: '1.4조' },
+  { rank: 4,  name: '카카오',        label: 'K',     color: 'yellow',  price: '44,150',  change: -1.23, volume: '0.9조' },
+  { rank: 5,  name: 'LG에너지솔루션',label: 'LG에',  color: 'green',   price: '382,000', change: 0.79,  volume: '0.7조' },
+]
+
+export const WATCHLIST = [
+  { name: '현대차',   label: 'H',   color: 'primary', price: '₩205,000', change: -0.82 },
+  { name: 'LG에너지', label: 'LG',  color: 'green',   price: '₩382,000', change: 1.20 },
+  { name: '셀트리온', label: '셀트', color: 'teal',    price: '₩172,300', change: 0.34 },
+]
+
+export const MARKET_OVERVIEW = {
+  time: '14:32',
+  headline: '美 CPI 하회… 나스닥 1% 상승, 반도체 강세',
+  bullets: ['外人 순매수 4,200억 · 반도체↑', '원달러 1,378원 소폭 하락 마감'],
+}
+
+export const EXCHANGE = [
+  { flag: '🇺🇸', pair: 'USD / KRW', rate: '1,378.50', change: -2.30 },
+  { flag: '🇯🇵', pair: 'JPY / KRW', rate: '9.24',     change: 0.05 },
+]

--- a/src/mocks/home.js
+++ b/src/mocks/home.js
@@ -17,10 +17,10 @@ export const HOME_INDICES = [
 export const PORTFOLIO = {
   returnRate: '+5.2%',
   items: [
-    { name: '삼성전자', ratio: 34, color: 'var(--color-chart-1)', barWidth: 28 },
-    { name: 'SK하이닉스', ratio: 20, color: 'var(--color-chart-2)', barWidth: 16 },
-    { name: 'NAVER',    ratio: 15, color: 'var(--color-chart-3)', barWidth: 12 },
-    { name: '기타',     ratio: 31, color: 'var(--color-chart-5)', barWidth: 25 },
+    { name: '삼성전자', ratio: 34, color: 'var(--color-chart-1)', barWidth: '28px' },
+    { name: 'SK하이닉스', ratio: 20, color: 'var(--color-chart-2)', barWidth: '16px' },
+    { name: 'NAVER',    ratio: 15, color: 'var(--color-chart-3)', barWidth: '12px' },
+    { name: '기타',     ratio: 31, color: 'var(--color-chart-5)', barWidth: '25px' },
   ],
 }
 

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,8 +1,47 @@
-// TODO: 홈 페이지 구현
+import LiveDot from '@/components/ui/LiveDot'
+import BalanceWidget from '@/components/widgets/BalanceWidget'
+import IndexWidget from '@/components/widgets/IndexWidget'
+import PortfolioWidget from '@/components/widgets/PortfolioWidget'
+import StockChartWidget from '@/components/widgets/StockChartWidget'
+import RankingWidget from '@/components/widgets/RankingWidget'
+import WatchlistWidget from '@/components/widgets/WatchlistWidget'
+import MarketOverviewWidget from '@/components/widgets/MarketOverviewWidget'
+import ExchangeWidget from '@/components/widgets/ExchangeWidget'
+import AddWidgetSlot from '@/components/widgets/AddWidgetSlot'
+import { HOME_STOCKS } from '@/mocks/home'
+
 export default function HomePage() {
   return (
-    <div className="flex items-center justify-center h-full text-foreground-disabled text-sm">
-      홈 — 준비 중
+    <div className="flex flex-col h-full overflow-hidden p-3 gap-2.5">
+      {/* 서브바 */}
+      <div className="flex items-center justify-between shrink-0 px-1">
+        <div className="flex items-center gap-2">
+          <span className="text-[13px] font-bold text-foreground">나의 대시보드</span>
+          <div className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-background border border-stroke">
+            <LiveDot size="sm" />
+            <span className="text-[10px] text-foreground-disabled">실시간 반영</span>
+          </div>
+        </div>
+      </div>
+
+      {/* 위젯 그리드: 4열 × 3행 */}
+      <div className="grid grid-cols-4 grid-rows-3 gap-[10px] flex-1 min-h-0">
+        {/* Row 1 */}
+        <BalanceWidget />
+        <IndexWidget />
+        <PortfolioWidget />
+
+        {/* Row 2 */}
+        <StockChartWidget stock={HOME_STOCKS[0]} />
+        <RankingWidget />
+        <WatchlistWidget />
+
+        {/* Row 3 */}
+        <MarketOverviewWidget />
+        <ExchangeWidget />
+        <StockChartWidget stock={HOME_STOCKS[1]} />
+        <AddWidgetSlot />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## 관련 이슈
Closes #19

## 작업 내용
- 4열 × 3행 위젯 그리드 레이아웃 구현 (gap-[10px], flex-1 min-h-0)
- 9개 위젯 신규 구현: BalanceWidget, IndexWidget, PortfolioWidget, StockChartWidget, RankingWidget, WatchlistWidget, MarketOverviewWidget, ExchangeWidget, AddWidgetSlot
- WidgetCard: hover 효과(border, shadow, -translate-y-px) 기본 카드 컴포넌트
- TabChip: 위젯 내 소형 탭 칩 컴포넌트 (DESIGN.md §8)
- LockedOverlay: 비로그인 상태 잠금 오버레이 (BalanceWidget, PortfolioWidget, ExchangeWidget 적용)
- AppShell 사이드바 제거 (AppHeader NavTabs로 네비게이션 일원화)
- home 목업 데이터 추가 (src/mocks/home.js)

## 컴포넌트 공유 현황
- PriceChange: IndexWidget, StockChartWidget, RankingWidget, WatchlistWidget, MarketPage 공유
- StockAvatar: StockChartWidget, RankingWidget, WatchlistWidget, StockRow 공유
- LiveDot: BalanceWidget, ExchangeWidget, HomePage, ChatPanel, MarketPage 공유
- TabChip: IndexWidget, RankingWidget 공유
- LockedOverlay: BalanceWidget, PortfolioWidget, ExchangeWidget 공유