### PR TITLE
feat(user): 회원가입 UI 개선 및 레이아웃 최적화, 동의서 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,16 +10,18 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "lucide-react": "^0.577.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-hook-form": "^7.71.2",
     "react-router-dom": "^7.13.1",
+    "zod": "^4.3.6",
     "zustand": "^5.0.12"
   },
   "devDependencies": {
-    "@tailwindcss/vite": "^4.2.1",
-    "tailwindcss": "^4.2.1",
     "@eslint/js": "^9.39.4",
+    "@tailwindcss/vite": "^4.2.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.0",
@@ -27,6 +29,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "tailwindcss": "^4.2.1",
     "vite": "^8.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@radix-ui/react-primitive": "^2.0.1",
+    "@radix-ui/react-accordion": "^1.2.2",
+    "@radix-ui/react-dialog": "^1.1.2",
+    "@radix-ui/react-dropdown-menu": "^2.1.2",
     "lucide-react": "^0.577.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,18 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.71.2(react@19.2.4))
+      '@radix-ui/react-accordion':
+        specifier: ^1.2.2
+        version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.2
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.2
+        version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive':
+        specifier: ^2.0.1
+        version: 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.4)
@@ -183,6 +195,21 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
   '@hookform/resolvers@5.2.2':
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
     peerDependencies:
@@ -229,6 +256,333 @@ packages:
 
   '@oxc-project/types@0.115.0':
     resolution: {integrity: sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==}
+
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-accordion@1.2.12':
+    resolution: {integrity: sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-arrow@1.1.7':
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collapsible@1.1.12':
+    resolution: {integrity: sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.7':
+    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.1':
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dropdown-menu@2.1.16':
+    resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.16':
+    resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.4':
+    resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.11':
+    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.4':
+    resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.9':
     resolution: {integrity: sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==}
@@ -478,6 +832,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -544,6 +902,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   electron-to-chromium@1.5.313:
     resolution: {integrity: sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==}
@@ -654,6 +1015,10 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -977,6 +1342,26 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-router-dom@7.13.1:
     resolution: {integrity: sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==}
     engines: {node: '>=20.0.0'}
@@ -992,6 +1377,16 @@ packages:
       react-dom: '>=18'
     peerDependenciesMeta:
       react-dom:
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
         optional: true
 
   react@19.2.4:
@@ -1063,6 +1458,26 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   vite@8.0.0:
     resolution: {integrity: sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==}
@@ -1314,6 +1729,23 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@floating-ui/utils@0.2.11': {}
+
   '@hookform/resolvers@5.2.2(react-hook-form@7.71.2(react@19.2.4))':
     dependencies:
       '@standard-schema/utils': 0.3.0
@@ -1359,6 +1791,317 @@ snapshots:
   '@oxc-project/runtime@0.115.0': {}
 
   '@oxc-project/types@0.115.0': {}
+
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-accordion@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-collapsible@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-direction@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/rect@1.1.1': {}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.9':
     optional: true
@@ -1522,6 +2265,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   balanced-match@1.0.2: {}
 
   baseline-browser-mapping@2.10.8: {}
@@ -1575,6 +2322,8 @@ snapshots:
   deep-is@0.1.4: {}
 
   detect-libc@2.1.2: {}
+
+  detect-node-es@1.1.0: {}
 
   electron-to-chromium@1.5.313: {}
 
@@ -1700,6 +2449,8 @@ snapshots:
     optional: true
 
   gensync@1.0.0-beta.2: {}
+
+  get-nonce@1.0.1: {}
 
   glob-parent@6.0.2:
     dependencies:
@@ -1939,6 +2690,25 @@ snapshots:
     dependencies:
       react: 19.2.4
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.4)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.4)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   react-router-dom@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -1952,6 +2722,14 @@ snapshots:
       set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.4(react@19.2.4)
+
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   react@19.2.4: {}
 
@@ -2007,8 +2785,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   type-check@0.4.0:
     dependencies:
@@ -2023,6 +2800,21 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   vite@8.0.0(jiti@2.6.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      '@tailwindcss/vite':
-        specifier: ^4.2.1
-        version: 4.2.1(vite@8.0.0(jiti@2.6.1))
+      '@hookform/resolvers':
+        specifier: ^5.2.2
+        version: 5.2.2(react-hook-form@7.71.2(react@19.2.4))
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.4)
@@ -20,12 +20,15 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      react-hook-form:
+        specifier: ^7.71.2
+        version: 7.71.2(react@19.2.4)
       react-router-dom:
         specifier: ^7.13.1
         version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      tailwindcss:
-        specifier: ^4.2.1
-        version: 4.2.1
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(react@19.2.4)
@@ -33,6 +36,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.4
         version: 9.39.4
+      '@tailwindcss/vite':
+        specifier: ^4.2.1
+        version: 4.2.1(vite@8.0.0(jiti@2.6.1))
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -54,6 +60,9 @@ importers:
       globals:
         specifier: ^17.4.0
         version: 17.4.0
+      tailwindcss:
+        specifier: ^4.2.1
+        version: 4.2.1
       vite:
         specifier: ^8.0.0
         version: 8.0.0(jiti@2.6.1)
@@ -173,6 +182,11 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@hookform/resolvers@5.2.2':
+    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -316,6 +330,9 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-rc.9':
     resolution: {integrity: sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@tailwindcss/node@4.2.1':
     resolution: {integrity: sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==}
@@ -954,6 +971,12 @@ packages:
     peerDependencies:
       react: ^19.2.4
 
+  react-hook-form@7.71.2:
+    resolution: {integrity: sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-router-dom@7.13.1:
     resolution: {integrity: sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==}
     engines: {node: '>=20.0.0'}
@@ -1291,6 +1314,11 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@hookform/resolvers@5.2.2(react-hook-form@7.71.2(react@19.2.4))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.71.2(react@19.2.4)
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -1382,6 +1410,8 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
   '@rolldown/pluginutils@1.0.0-rc.9': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@tailwindcss/node@4.2.1':
     dependencies:
@@ -1904,6 +1934,10 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-hook-form@7.71.2(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   react-router-dom@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,0 +1,32 @@
+const BASE = '/api/auth'
+
+async function post(path, body) {
+  const res = await fetch(`${BASE}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  const data = await res.json()
+  if (!res.ok) throw data
+  return data
+}
+
+async function get(path, params) {
+  const query = params ? '?' + new URLSearchParams(params).toString() : ''
+  const res = await fetch(`${BASE}${path}${query}`)
+  const data = await res.json()
+  if (!res.ok) throw data
+  return data
+}
+
+export const authApi = {
+  signup:               (body)   => post('/signup', body),
+  login:                (body)   => post('/login', body),
+  sendVerifyEmail:      (body)   => post('/email/verify/send', body),
+  confirmVerifyEmail:   (body)   => post('/email/verify/confirm', body),
+  getEmailVerifyStatus: (email)  => get('/email/verify/status', { email }),
+  refreshToken:         (body)   => post('/token/refresh', body),
+  requestPasswordReset: (body)   => post('/password/reset/request', body),
+  confirmPasswordReset: (body)   => post('/password/reset/confirm', body),
+  logout:               (body)   => post('/logout', body),
+}

--- a/src/components/signup/AccountIntroStep.jsx
+++ b/src/components/signup/AccountIntroStep.jsx
@@ -4,10 +4,8 @@ export default function AccountIntroStep({ onNext }) {
   return (
     <div className="w-full min-h-screen relative overflow-hidden px-8 py-11 flex flex-col justify-center">
       {/* 배경 장식 요소들 */}
-      <div className="absolute -top-40 -right-40 w-80 h-80 rounded-full blur-3xl pointer-events-none"
-           style={{background: 'rgba(0, 70, 255, 0.15)'}} />
-      <div className="absolute -bottom-40 -left-40 w-96 h-96 rounded-full blur-3xl pointer-events-none"
-           style={{background: 'rgba(0, 70, 255, 0.1)'}} />
+      <div className="absolute -top-40 -right-40 w-80 h-80 rounded-full blur-3xl pointer-events-none bg-primary/15" />
+      <div className="absolute -bottom-40 -left-40 w-96 h-96 rounded-full blur-3xl pointer-events-none bg-primary/10" />
 
       {/* 메인 콘텐츠 */}
       <div className="relative z-10">

--- a/src/components/signup/AccountIntroStep.jsx
+++ b/src/components/signup/AccountIntroStep.jsx
@@ -1,0 +1,33 @@
+import { ArrowRight, Landmark } from 'lucide-react'
+
+export default function AccountIntroStep({ onNext }) {
+  return (
+    <div>
+      <div className="rounded-[20px] border border-primary-border bg-[linear-gradient(180deg,#F8FAFF_0%,#EEF2FF_100%)] p-5 shadow-[0_10px_30px_rgba(0,70,255,.08)]">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <div className="text-[11px] font-semibold text-primary tracking-[.04em] uppercase mb-2">대표 계좌</div>
+            <div className="text-[24px] font-black tracking-tight text-foreground mb-2">증권종합</div>
+            <p className="text-[13px] text-foreground-secondary leading-[1.8]">
+              국내 주식과 금융상품 거래를 위한 기본 계좌입니다.
+              <br />
+              기본 정보를 입력한 뒤 계좌 개설 전 확인 절차를 진행합니다.
+            </p>
+          </div>
+          <div className="w-14 h-14 rounded-2xl bg-white border border-primary-border flex items-center justify-center shrink-0">
+            <Landmark className="w-7 h-7 text-primary" strokeWidth={2.2} />
+          </div>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={onNext}
+        className="w-full mt-7 py-[13px] bg-primary text-white border-none rounded-xl text-sm font-bold shadow-primary-btn hover:bg-primary-hover transition-colors duration-[150ms] flex items-center justify-center gap-2"
+      >
+        계좌 개설하기
+        <ArrowRight className="w-4 h-4" />
+      </button>
+    </div>
+  )
+}

--- a/src/components/signup/AccountIntroStep.jsx
+++ b/src/components/signup/AccountIntroStep.jsx
@@ -1,33 +1,87 @@
-import { ArrowRight, Landmark } from 'lucide-react'
+import { ArrowRight, Smartphone, FileText, CreditCard } from 'lucide-react'
 
 export default function AccountIntroStep({ onNext }) {
   return (
-    <div>
-      <div className="rounded-[20px] border border-primary-border bg-[linear-gradient(180deg,#F8FAFF_0%,#EEF2FF_100%)] p-5 shadow-[0_10px_30px_rgba(0,70,255,.08)]">
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <div className="text-[11px] font-semibold text-primary tracking-[.04em] uppercase mb-2">대표 계좌</div>
-            <div className="text-[24px] font-black tracking-tight text-foreground mb-2">증권종합</div>
-            <p className="text-[13px] text-foreground-secondary leading-[1.8]">
-              국내 주식과 금융상품 거래를 위한 기본 계좌입니다.
-              <br />
-              기본 정보를 입력한 뒤 계좌 개설 전 확인 절차를 진행합니다.
-            </p>
-          </div>
-          <div className="w-14 h-14 rounded-2xl bg-white border border-primary-border flex items-center justify-center shrink-0">
-            <Landmark className="w-7 h-7 text-primary" strokeWidth={2.2} />
+    <div className="w-full min-h-screen relative overflow-hidden px-8 py-11 flex flex-col justify-center">
+      {/* 배경 장식 요소들 */}
+      <div className="absolute -top-40 -right-40 w-80 h-80 rounded-full blur-3xl pointer-events-none"
+           style={{background: 'rgba(0, 70, 255, 0.15)'}} />
+      <div className="absolute -bottom-40 -left-40 w-96 h-96 rounded-full blur-3xl pointer-events-none"
+           style={{background: 'rgba(0, 70, 255, 0.1)'}} />
+
+      {/* 메인 콘텐츠 */}
+      <div className="relative z-10">
+        {/* Hero 섹션 */}
+        <div className="mb-10">
+          <h1 className="text-5xl font-black text-foreground mb-6 tracking-tight leading-tight">
+            증권종합
+          </h1>
+
+          <p className="text-xl text-foreground-secondary max-w-2xl mb-8 leading-relaxed">
+            국내 주식과 금융상품 거래를 위한 기본 계좌입니다.
+            <br />
+            안전한 거래 환경과 최고의 서비스를 제공합니다.
+          </p>
+        </div>
+
+        {/* 필요한 준비물 섹션 */}
+        <div className="mb-12">
+          <h2 className="text-2xl font-bold text-foreground mb-10">
+            세 가지 준비물이 필요해요
+          </h2>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {[
+              { icon: Smartphone, label: '휴대폰', desc: '본인 명의 휴대폰' },
+              { icon: FileText, label: '신분증', desc: '유효한 신분증' },
+              { icon: CreditCard, label: '금융계좌', desc: '본인 계좌' },
+            ].map((item, idx) => {
+              const Icon = item.icon
+              return (
+                <div
+                  key={idx}
+                  className="relative p-8 rounded-3xl bg-surface border border-stroke-subtle hover:border-widget-border-hover transition-all duration-300 overflow-hidden group"
+                >
+                  {/* 배경 그라데이션 */}
+                  <div className="absolute inset-0 bg-gradient-to-br from-primary/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+
+                  {/* 콘텐츠 */}
+                  <div className="relative z-10">
+                    <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-primary/20 to-primary/10 flex items-center justify-center mb-6">
+                      <Icon className="w-8 h-8 text-primary" strokeWidth={1.5} />
+                    </div>
+                    <h3 className="text-xl font-bold text-foreground mb-2">
+                      {item.label}
+                    </h3>
+                    <p className="text-sm text-foreground-secondary">
+                      {item.desc}
+                    </p>
+                  </div>
+                </div>
+              )
+            })}
           </div>
         </div>
-      </div>
 
-      <button
-        type="button"
-        onClick={onNext}
-        className="w-full mt-7 py-[13px] bg-primary text-white border-none rounded-xl text-sm font-bold shadow-primary-btn hover:bg-primary-hover transition-colors duration-[150ms] flex items-center justify-center gap-2"
-      >
-        계좌 개설하기
-        <ArrowRight className="w-4 h-4" />
-      </button>
+
+        {/* 최종 CTA */}
+        <div className="mt-8 text-center">
+          <button
+            type="button"
+            onClick={onNext}
+            className="px-12 py-5 bg-primary hover:bg-primary-hover text-white font-bold rounded-2xl
+                       transition-all duration-200 flex items-center justify-center gap-2
+                       shadow-primary-btn hover:shadow-brand-glow text-lg mx-auto"
+          >
+            지금 계좌 개설하기
+            <ArrowRight className="w-6 h-6" />
+          </button>
+
+          <p className="text-sm text-foreground-secondary mt-6">
+            이미 계좌가 있으신가요? <a href="#" className="text-primary hover:underline font-semibold">로그인</a>
+          </p>
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/components/signup/AccountStep.jsx
+++ b/src/components/signup/AccountStep.jsx
@@ -1,0 +1,24 @@
+import { Activity } from 'lucide-react'
+
+export default function AccountStep({ onFinish }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-center">
+      <div className="w-16 h-16 rounded-2xl bg-primary-light flex items-center justify-center mb-5">
+        <Activity className="w-8 h-8 text-primary" />
+      </div>
+      <h2 className="text-xl font-extrabold text-foreground tracking-tight mb-2">계좌 개설 완료!</h2>
+      <p className="text-[13px] text-foreground-disabled mb-8 leading-[1.8]">
+        증권종합 계좌 개설 절차가 완료되었습니다.
+        <br />
+        로그인하여 SOL Lite 모의투자 서비스를 시작해 주세요.
+      </p>
+      <button
+        type="button"
+        onClick={onFinish}
+        className="w-full py-[13px] bg-primary text-white border-none rounded-xl text-sm font-bold shadow-primary-btn hover:bg-primary-hover transition-colors duration-[150ms]"
+      >
+        로그인하고 시작하기
+      </button>
+    </div>
+  )
+}

--- a/src/components/signup/BasicInfoStep.jsx
+++ b/src/components/signup/BasicInfoStep.jsx
@@ -1,0 +1,179 @@
+import { Controller } from 'react-hook-form'
+import { CheckCircle, Mail } from 'lucide-react'
+import { formatPhoneNumber } from '@/components/signup/phoneNumber'
+import { Input, PasswordInput } from '@/components/ui/Input'
+import { getPasswordChecks } from '@/components/signup/passwordValidation'
+
+const PASSWORD_RULES = [
+  { key: 'length', label: '최소 8자 이상' },
+  { key: 'letter', label: '영문 포함' },
+  { key: 'number', label: '숫자 포함' },
+  { key: 'special', label: '특수문자 포함' },
+]
+
+function PasswordRules({ checks }) {
+  return (
+    <div className="mt-[7px] bg-surface-subtle rounded-[10px] px-3 py-2.5 grid grid-cols-2 gap-x-3 gap-y-[5px]">
+      {PASSWORD_RULES.map(({ key, label }) => (
+        <div key={key} className="flex items-center gap-[5px] text-[11px]">
+          <div className={['w-1 h-1 rounded-full shrink-0', checks[key] ? 'bg-live' : 'bg-stroke-input'].join(' ')} />
+          <span className={checks[key] ? 'text-live' : 'text-foreground-disabled'}>{label}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default function BasicInfoStep({
+  control,
+  password,
+  isSending,
+  sendDone,
+  emailVerified,
+  verifyHighlight,
+  error,
+  fieldErrors,
+  onEmailInputChange,
+  onBack,
+  onSendVerifyEmail,
+  onNext,
+}) {
+  const passwordChecks = getPasswordChecks(password)
+
+  return (
+    <>
+      <h2 className="text-xl font-extrabold text-foreground tracking-tight mb-1">기본 정보 입력</h2>
+      <p className="text-[13px] text-foreground-disabled mb-7">증권종합 계좌 개설에 필요한 기본 정보를 입력해 주세요.</p>
+
+      <div className="flex flex-col gap-[18px]">
+        <div>
+          <label className="block text-[11px] font-semibold text-foreground-secondary mb-1.5">
+            이메일 <span className="text-up">*</span>
+          </label>
+          <div className="flex gap-2">
+            <Controller
+              name="email"
+              control={control}
+              render={({ field }) => (
+                <input
+                  {...field}
+                  type="email"
+                  placeholder="example@domain.com"
+                  onChange={(e) => {
+                    field.onChange(e)
+                    onEmailInputChange(e)
+                  }}
+                  className="flex-1 px-3.5 py-[11px] border-[1.5px] border-stroke-input rounded-[10px] text-sm text-foreground bg-surface outline-none transition-[border-color,box-shadow] duration-[200ms] focus:border-primary focus:shadow-focus-ring placeholder:text-foreground-disabled"
+                />
+              )}
+            />
+            <button
+              type="button"
+              onClick={onSendVerifyEmail}
+              disabled={isSending || emailVerified}
+              className="px-4 bg-surface-muted border-[1.5px] border-stroke-input rounded-[10px] text-xs font-semibold text-foreground-secondary whitespace-nowrap hover:bg-stroke-subtle transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              {isSending ? '발송 중...' : emailVerified ? '인증 완료' : sendDone ? '재발송' : '인증 발송'}
+            </button>
+          </div>
+          {fieldErrors.email && <p className="mt-1.5 text-[11px] text-up">{fieldErrors.email}</p>}
+
+          {sendDone && !emailVerified && (
+            <div
+              className={[
+                'mt-2 flex items-start gap-2.5 rounded-[10px] px-3 py-2.5 border transition-colors duration-[200ms]',
+                verifyHighlight ? 'bg-primary-light border-primary' : 'bg-surface-subtle border-stroke-input',
+              ].join(' ')}
+            >
+              <Mail className={['w-3.5 h-3.5 mt-px shrink-0', verifyHighlight ? 'text-primary' : 'text-foreground-disabled'].join(' ')} />
+              <div>
+                <p className={['text-[11px] font-semibold', verifyHighlight ? 'text-primary' : 'text-foreground-secondary'].join(' ')}>
+                  인증 메일이 발송되었습니다
+                </p>
+                <p className="text-[11px] text-foreground-disabled mt-0.5">
+                  메일함에서 인증 링크를 클릭해 주세요. (30분 유효)
+                </p>
+              </div>
+            </div>
+          )}
+
+          {emailVerified && (
+            <div className="mt-2 flex items-center gap-2 bg-surface-subtle rounded-[10px] px-3 py-2.5 border border-stroke-input">
+              <CheckCircle className="w-3.5 h-3.5 text-live shrink-0" />
+              <span className="text-[11px] font-semibold text-live">이메일 인증이 완료되었습니다.</span>
+            </div>
+          )}
+        </div>
+
+        <Controller
+          name="name"
+          control={control}
+          render={({ field }) => (
+            <Input label="이름" required type="text" placeholder="이름을 입력하세요" {...field} />
+          )}
+        />
+        {fieldErrors.name && <p className="-mt-3 text-[11px] text-up">{fieldErrors.name}</p>}
+
+        <Controller
+          name="phone"
+          control={control}
+          render={({ field }) => (
+            <Input
+              label="휴대폰 번호"
+              type="tel"
+              placeholder="010-0000-0000"
+              {...field}
+              onChange={(e) => field.onChange(formatPhoneNumber(e.target.value))}
+            />
+          )}
+        />
+        {fieldErrors.phone && <p className="-mt-3 text-[11px] text-up">{fieldErrors.phone}</p>}
+
+        <div>
+          <Controller
+            name="password"
+            control={control}
+            render={({ field }) => (
+              <PasswordInput label="비밀번호" required placeholder="비밀번호를 입력하세요" {...field} />
+            )}
+          />
+          <PasswordRules checks={passwordChecks} />
+          {fieldErrors.password && <p className="mt-1.5 text-[11px] text-up">{fieldErrors.password}</p>}
+        </div>
+
+        <Controller
+          name="passwordConfirm"
+          control={control}
+          render={({ field }) => (
+            <PasswordInput
+              label="비밀번호 확인"
+              required
+              placeholder="비밀번호를 다시 입력하세요"
+              {...field}
+            />
+          )}
+        />
+        {fieldErrors.passwordConfirm && <p className="-mt-3 text-[11px] text-up">{fieldErrors.passwordConfirm}</p>}
+
+        {error && <p className="text-[11px] text-up">{error}</p>}
+
+        <div className="flex gap-3 mt-1">
+          <button
+            type="button"
+            onClick={onBack}
+            className="flex-1 py-[13px] rounded-xl border border-stroke-input bg-surface text-sm font-semibold text-foreground-secondary hover:bg-surface-subtle transition-colors"
+          >
+            이전
+          </button>
+          <button
+            type="button"
+            onClick={onNext}
+            className="flex-[1.3] py-[13px] bg-primary text-white border-none rounded-xl text-sm font-bold shadow-primary-btn hover:bg-primary-hover transition-colors duration-[150ms]"
+          >
+            다음 단계 →
+          </button>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/components/signup/BasicInfoStep.jsx
+++ b/src/components/signup/BasicInfoStep.jsx
@@ -103,6 +103,16 @@ export default function BasicInfoStep({
               <span className="text-[11px] font-semibold text-live">이메일 인증이 완료되었습니다.</span>
             </div>
           )}
+
+          {fieldErrors.email?.includes('이미 등록된') && (
+            <div className="mt-2 flex flex-col gap-2 rounded-[10px] px-3 py-2.5 border border-up/30 bg-up/5">
+              <p className="text-[11px] font-semibold text-up">{fieldErrors.email}</p>
+              <p className="text-[11px] text-foreground-secondary">
+                이미 가입된 계정이 있으신가요?{' '}
+                <a href="/login" className="text-primary font-semibold hover:underline">로그인</a>
+              </p>
+            </div>
+          )}
         </div>
 
         <Controller

--- a/src/components/signup/BrandPanel.jsx
+++ b/src/components/signup/BrandPanel.jsx
@@ -9,8 +9,7 @@ const FEATURES = [
 export default function BrandPanel() {
   return (
     <div
-      className="w-[44%] shrink-0 flex flex-col py-12 px-11 relative overflow-hidden"
-      style={{ background: 'linear-gradient(145deg, #0035CC 0%, #0046FF 50%, #2563EB 100%)' }}
+      className="w-[44%] shrink-0 flex flex-col py-12 px-11 relative overflow-hidden bg-gradient-to-br from-[#0035CC] via-primary to-[#2563EB]"
     >
       <div className="absolute -top-20 -right-20 w-80 h-80 rounded-full bg-white/[.06]" />
       <div className="absolute -bottom-[60px] -left-[60px] w-60 h-60 rounded-full bg-white/[.04]" />

--- a/src/components/signup/BrandPanel.jsx
+++ b/src/components/signup/BrandPanel.jsx
@@ -1,0 +1,54 @@
+import { Activity, MessageCircle, LayoutGrid, BarChart2 } from 'lucide-react'
+
+const FEATURES = [
+  { icon: MessageCircle, label: 'SOL AI 채팅 어시스턴트' },
+  { icon: LayoutGrid, label: '자유롭게 구성하는 위젯 대시보드' },
+  { icon: BarChart2, label: '국내·해외 실시간 시세 및 주문' },
+]
+
+export default function BrandPanel() {
+  return (
+    <div
+      className="w-[44%] shrink-0 flex flex-col py-12 px-11 relative overflow-hidden"
+      style={{ background: 'linear-gradient(145deg, #0035CC 0%, #0046FF 50%, #2563EB 100%)' }}
+    >
+      <div className="absolute -top-20 -right-20 w-80 h-80 rounded-full bg-white/[.06]" />
+      <div className="absolute -bottom-[60px] -left-[60px] w-60 h-60 rounded-full bg-white/[.04]" />
+
+      <div className="flex items-center gap-2.5 relative z-10">
+        <div className="w-9 h-9 rounded-[11px] bg-white/20 flex items-center justify-center">
+          <Activity className="w-[18px] h-[18px] text-white" strokeWidth={2.5} />
+        </div>
+        <span className="text-xl font-extrabold text-white tracking-tight">
+          SOL <span className="opacity-85">Lite</span>
+        </span>
+      </div>
+
+      <div className="my-auto relative z-10">
+        <div className="text-[11px] font-semibold text-white/60 tracking-[.08em] uppercase mb-3.5">
+          새로운 증권 경험
+        </div>
+        <h1 className="text-[30px] font-black text-white leading-[1.3] tracking-tight mb-3.5">
+          채팅과 위젯으로<br />증권을 더<br />편리하게
+        </h1>
+        <p className="text-[13px] text-white/70 leading-[1.8]">
+          AI 채팅 어시스턴트에게 물어보고,<br />내가 원하는 대로 대시보드를 구성하세요.
+        </p>
+        <div className="mt-7 flex flex-col gap-2.5">
+          {FEATURES.map((feature) => (
+            <div key={feature.label} className="flex items-center gap-2.5">
+              <div className="w-7 h-7 rounded-lg bg-white/15 flex items-center justify-center shrink-0">
+                <feature.icon className="w-[13px] h-[13px] text-white" />
+              </div>
+              <span className="text-[13px] text-white/85 font-medium">{feature.label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="text-[10px] text-white/40 relative z-10">
+        SOL Lite는 실제 투자와 무관한 모의투자 서비스입니다
+      </div>
+    </div>
+  )
+}

--- a/src/components/signup/ConsentStep.jsx
+++ b/src/components/signup/ConsentStep.jsx
@@ -1,0 +1,393 @@
+import { useState } from 'react'
+import { Check, ChevronDown, ChevronUp } from 'lucide-react'
+
+const CONSENT_DOCUMENTS = [
+  {
+    key: 'finance',
+    title: '개인(신용)정보 처리 동의서 [금융거래설정용]',
+    groups: [
+      {
+        key: 'financeCollection',
+        label: '개인신용정보 수집•이용에 동의합니다.',
+        itemKeys: ['financeCollectionDetails', 'financeCollectionItems'],
+        items: [
+          {
+            key: 'financeCollectionDetails',
+            title: '수집•이용에 관한 사항',
+            lines: [
+              '수집 • 이용 목적',
+              '• (금융)계약의 체결 • 유지 • 이행 • 관리 • 개선',
+              '• 법령상 의무이행(실명확인, 특정금융거래보고, 불공정거래예방, 적합성확인)',
+              '• 금융사고 방지(본인확인, 이상금융거래탐지)',
+              '• 통계 및 분석, 리스크 관리, 고객서비스 품질 향상',
+              '• 분쟁 • 민원처리 사고 조사',
+              '',
+              '보유 및 이용기간',
+              '• (금융)거래 종료일로부터 5년(단, 금융사고조사, 분쟁해결, 민원처리, 자본시장법(10년 이상 보관) 법령상 의무이행을 위한 경우에는 분리하여 별도 보관)',
+              '• 위 보유 기간에서의 (금융)거래 종료일이란 고객이 보유하고 있는 모든 계좌의 적극적 폐쇄 및 모든 상품의 계약 해지가 이루어지는 시점을 말합니다.',
+              '',
+              '거부 권리 및 불이익',
+              '• 귀하는 아래 개인신용정보의 수집•이용에 대해 거부하실 수 있습니다. 다만, "수집•이용에 관한 동의"는 금융거래 설정을 위한 필수적 사항이므로 동의를 거부하실 경우 관련 상품 및 서비스의 체결, 이행, (금융)거래관계의 설정 및 유지가 불가능할 수 있습니다.',
+            ],
+          },
+          {
+            key: 'financeCollectionItems',
+            title: '수집•이용 항목',
+            lines: [
+              '개인(신용)정보(69개)',
+              '• 일반개인정보(50개) : 성명, 생년월일 등',
+              '• 신용거래정보(9개) : 상품종류, 금융 거래정보 등',
+              '• 신용도판단정보(4개) : 연체, 명의도용 정보 등',
+              '• 신용능력정보(3개) : 소득, 재산정보 등',
+              '• 공공정보(3개) : 개인신용정보평점, 기초수급자여부 등',
+            ],
+          },
+        ],
+      },
+      {
+        key: 'financeIdentifier',
+        label: '고유식별정보 수집•이용에 동의합니다.',
+        itemKeys: ['financeIdentifierItems'],
+        items: [
+          {
+            key: 'financeIdentifierItems',
+            title: '수집•이용 항목',
+            lines: [
+              '고유식별정보(5개)',
+              '• 주민등록번호, 외국인등록번호, 여권번호, 운전면허번호, 대리인 주민등록번호',
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    key: 'safety',
+    title: '개인(신용)정보 처리 동의서 [비대면 계좌개설 안심차단 등록 여부 조회용]',
+    intro: '귀하는 상기 개인(신용)정보 수집•이용·제공•조회에 대한 동의를 거부할 권리가 있습니다. 다만, 위 사항에 동의하셔야만 비대면 계좌개설 안심차단 등록 여부 조회 및 비대면 계좌개설 진행(안심차단을 신청하지 않은 것으로 확인된 경우)이 가능합니다.',
+    groups: [
+      {
+        key: 'safetyUse',
+        label: '고유식별정보 수집•이용에 동의합니다.',
+        heading: '수집•이용에 관한 사항 [공통필수]',
+        itemKeys: ['safetyUseDetails', 'safetyUseItems'],
+        items: [
+          {
+            key: 'safetyUseDetails',
+            title: '수집•이용에 관한 사항',
+            lines: [
+              '수집 • 이용 목적',
+              '• 비대면 계좌개설 시 안심차단 등록 여부 조회',
+              '',
+              '보유 및 이용기간',
+              '• 거래종료일로부터 3개월까지 보유 • 이용됩니다.',
+              '• 거래종료일이란, 비대면 계좌개설 안심차단 등록 여부 조회를 완료한 시점을 의미합니다.',
+              '• 거래종료일 후에는 금융사고 조사, 분쟁 해결, 민원처리, 법령상 의무이행 목적으로만 보유•이용됩니다. 단, 관련 법령에 따른 의무를 이행해야 하는 경우 해당 법령상의 보존 기간을 따릅니다.',
+            ],
+          },
+          {
+            key: 'safetyUseItems',
+            title: '수집•이용 항목',
+            lines: [
+              '[개인식별번호]',
+              '• 고유식별정보(주민등록번호, 외국인등록번호)',
+            ],
+          },
+        ],
+      },
+      {
+        key: 'safetyProvide',
+        label: '고유식별정보 제공에 동의합니다.',
+        heading: '제공에 관한 사항',
+        itemKeys: ['safetyProvideDetails', 'safetyProvideItems'],
+        items: [
+          {
+            key: 'safetyProvideDetails',
+            title: '제공에 관한 사항',
+            lines: [
+              '제공받는 자',
+              '• 종합신용정보집중기관 : 한국신용정보원',
+              '',
+              '제공받는 자의 이용목적',
+              '• 조회기관의 요청에 따라 비대면 계좌개설 안심차단 등록 여부를 조회기관에 제공',
+              '',
+              '보유 및 이용기간',
+              '• 제공받는 자의 이용 목적을 달성할 때까지 보유 • 이용됩니다. 이 경우 관련 법령상 보존기간을 따릅니다.',
+            ],
+          },
+          {
+            key: 'safetyProvideItems',
+            title: '제공할 개인(신용)정보의 항목',
+            lines: [
+              '[개인식별번호]',
+              '• 고유식별정보(주민등록번호, 외국인등록번호)',
+            ],
+          },
+        ],
+      },
+      {
+        key: 'safetyQueryPersonal',
+        label: '개인(신용)정보를 조회하는 것에 동의합니다.',
+        heading: '조회에 관한 사항',
+        itemKeys: ['safetyQueryPersonalDetails', 'safetyQueryPersonalItems'],
+        items: [
+          {
+            key: 'safetyQueryPersonalDetails',
+            title: '조회에 관한 사항',
+            lines: [
+              '조회 대상 기관',
+              '• 종합신용정보집중기관 : 한국신용정보원',
+              '',
+              '조회 목적',
+              '• 비대면 계좌개설 안심차단 등록 여부 확인',
+              '',
+              '보유 및 이용기간',
+              '• 거래종료일까지 조회 동의의 효력이 지속됩니다.',
+              '• 거래종료일이란, 비대면 계좌개설 안심차단 등록 여부 조회를 완료한 시점을 의미합니다. 단, 관련 법령에 따른 의무를 이행해야 하는 경우 해당 법령상의 효력 기간을 따릅니다.',
+            ],
+          },
+          {
+            key: 'safetyQueryPersonalItems',
+            title: '조회할 개인(신용)정보의 항목',
+            lines: [
+              '[개인식별번호]',
+              '• 고유식별정보(주민등록번호, 외국인등록번호)',
+              '[일반개인정보(성명)]',
+              '[공공정보 등]',
+              '• 금융거래 안심차단 신청내역 정보, 사망자 정보 등',
+            ],
+          },
+        ],
+      },
+      {
+        key: 'safetyQueryIdentifier',
+        label: '고유식별정보를 조회하는 것에 동의합니다.',
+        heading: '조회에 관한 사항',
+        itemKeys: ['safetyQueryIdentifierDetails', 'safetyQueryIdentifierItems'],
+        items: [
+          {
+            key: 'safetyQueryIdentifierDetails',
+            title: '조회에 관한 사항',
+            lines: [
+              '조회 대상 기관',
+              '• 종합신용정보집중기관 : 한국신용정보원',
+              '',
+              '조회 목적',
+              '• 비대면 계좌개설 안심차단 등록 여부 확인',
+              '',
+              '보유 및 이용기간',
+              '• 거래종료일까지 조회 동의의 효력이 지속됩니다.',
+              '• 거래종료일이란, 비대면 계좌개설 안심차단 등록 여부 조회를 완료한 시점을 의미합니다. 단, 관련 법령에 따른 의무를 이행해야 하는 경우 해당 법령상의 효력 기간을 따릅니다.',
+            ],
+          },
+          {
+            key: 'safetyQueryIdentifierItems',
+            title: '조회할 개인(신용)정보의 항목',
+            lines: [
+              '[개인식별번호]',
+              '• 고유식별정보(주민등록번호, 외국인등록번호)',
+              '[일반개인정보(성명)]',
+              '[공공정보]',
+              '• 금융거래 안심차단 신청내역 정보, 사망자 정보 등',
+            ],
+          },
+        ],
+      },
+    ],
+  },
+]
+
+export const FINANCE_KEYS = CONSENT_DOCUMENTS.find((doc) => doc.key === 'finance').groups.flatMap((g) => g.itemKeys)
+export const SAFETY_KEYS  = CONSENT_DOCUMENTS.find((doc) => doc.key === 'safety').groups.flatMap((g) => g.itemKeys)
+export const CONSENT_ALL_KEYS = [...FINANCE_KEYS, ...SAFETY_KEYS]
+
+export const CONSENT_INITIAL_STATE = Object.fromEntries(
+  CONSENT_ALL_KEYS.map((key) => [key, false])
+)
+
+function Checkbox({ checked, onChange }) {
+  return (
+    <button
+      type="button"
+      onClick={(e) => { e.stopPropagation(); onChange() }}
+      className={[
+        'w-4 h-4 rounded-[3px] flex items-center justify-center shrink-0 transition-colors',
+        checked ? 'bg-primary' : 'border-[1.5px] border-stroke-input bg-surface',
+      ].join(' ')}
+    >
+      {checked && <Check className="w-[9px] h-[9px] text-white" strokeWidth={3.5} />}
+    </button>
+  )
+}
+
+function ItemRow({ itemKey, checked, onToggle, title, lines, expanded, onToggleExpand }) {
+  return (
+    <div className="border-t border-stroke-subtle">
+      <div className="flex items-center gap-3 py-3">
+        <Checkbox checked={checked} onChange={onToggle} />
+        <button
+          type="button"
+          onClick={onToggleExpand}
+          className="flex-1 flex items-center justify-between gap-2 text-left"
+        >
+          <span className="text-[13px] text-foreground-secondary">{title}</span>
+          {expanded
+            ? <ChevronUp className="w-3.5 h-3.5 text-foreground-disabled shrink-0" />
+            : <ChevronDown className="w-3.5 h-3.5 text-foreground-disabled shrink-0" />}
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="pb-3 pl-7 space-y-1">
+          {lines.map((line, i) =>
+            line === ''
+              ? <div key={i} className="h-2" />
+              : <p key={i} className="text-[12px] text-foreground-secondary leading-[1.8]">{line}</p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function GroupRow({ group, agreements, onAgreementsChange, expandedItems, onExpandItems }) {
+  const groupChecked = group.itemKeys.every((key) => agreements[key])
+
+  function toggleGroup() {
+    const next = !groupChecked
+    const updated = { ...agreements }
+    group.itemKeys.forEach((key) => { updated[key] = next })
+    onAgreementsChange(updated)
+    if (next) onExpandItems(group.itemKeys)
+  }
+
+  return (
+    <div className="border-t border-stroke">
+      {group.heading && (
+        <p className="text-[11px] font-semibold text-foreground-disabled pt-4 pb-1">{group.heading}</p>
+      )}
+      <label className="flex items-center gap-3 py-3.5 cursor-pointer select-none">
+        <Checkbox checked={groupChecked} onChange={toggleGroup} />
+        <span className="text-[14px] font-bold text-foreground">{group.label}</span>
+      </label>
+
+      <div className="pl-7">
+        {group.items.map((item) => (
+          <ItemRow
+            key={item.key}
+            itemKey={item.key}
+            checked={!!agreements[item.key]}
+            onToggle={() => {
+              const next = !agreements[item.key]
+              onAgreementsChange({ ...agreements, [item.key]: next })
+              if (next) onExpandItems([item.key])
+            }}
+            title={item.title}
+            lines={item.lines}
+            expanded={!!expandedItems[item.key]}
+            onToggleExpand={() => onExpandItems([item.key], 'toggle')}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function DocumentSection({ doc, agreements, onAgreementsChange, expandedItems, onExpandItems }) {
+  return (
+    <div>
+      <p className="text-[13px] font-bold text-foreground-secondary mb-1">{doc.title}</p>
+      {doc.intro && (
+        <p className="text-[11px] text-foreground-disabled leading-[1.75] mb-2">{doc.intro}</p>
+      )}
+      {doc.groups.map((group) => (
+        <GroupRow
+          key={group.key}
+          group={group}
+          agreements={agreements}
+          onAgreementsChange={onAgreementsChange}
+          expandedItems={expandedItems}
+          onExpandItems={onExpandItems}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default function ConsentStep({ agreements, onAgreementsChange, onBack, onSubmit, isLoading, error }) {
+  const [expandedItems, setExpandedItems] = useState({})
+  const allChecked = CONSENT_ALL_KEYS.every((key) => agreements[key])
+
+  function handleExpandItems(keys, mode = 'open') {
+    setExpandedItems((prev) => {
+      const next = { ...prev }
+      keys.forEach((key) => {
+        next[key] = mode === 'toggle' ? !prev[key] : true
+      })
+      return next
+    })
+  }
+
+  function toggleAll() {
+    const next = !allChecked
+    const updated = { ...agreements }
+    CONSENT_ALL_KEYS.forEach((key) => { updated[key] = next })
+    onAgreementsChange(updated)
+    if (next) {
+      const allExpanded = Object.fromEntries(CONSENT_ALL_KEYS.map((key) => [key, true]))
+      setExpandedItems(allExpanded)
+    }
+  }
+
+  return (
+    <div>
+      <div className="mb-7">
+        <h2 className="text-xl font-extrabold text-foreground tracking-tight mb-1">개인(신용)정보 처리 동의서</h2>
+        <p className="text-[13px] text-foreground-disabled leading-[1.8]">
+          상위 동의 체크 시 하위 항목이 함께 선택됩니다.
+        </p>
+      </div>
+
+      <div className="rounded-2xl border border-stroke bg-surface px-5 py-2 space-y-6">
+        {CONSENT_DOCUMENTS.map((doc) => (
+          <DocumentSection
+            key={doc.key}
+            doc={doc}
+            agreements={agreements}
+            onAgreementsChange={onAgreementsChange}
+            expandedItems={expandedItems}
+            onExpandItems={handleExpandItems}
+          />
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={toggleAll}
+        className="w-full mt-4 py-[12px] rounded-xl bg-primary text-white text-sm font-bold shadow-primary-btn hover:bg-primary-hover transition-colors"
+      >
+        모두 체크하기
+      </button>
+
+      {error && <p className="mt-4 text-[11px] text-up">{error}</p>}
+
+      <div className="mt-7 flex gap-3">
+        <button
+          type="button"
+          onClick={onBack}
+          className="flex-1 py-[13px] rounded-xl border border-stroke-input bg-surface text-sm font-semibold text-foreground-secondary hover:bg-surface-subtle transition-colors"
+        >
+          이전
+        </button>
+        <button
+          type="button"
+          onClick={onSubmit}
+          disabled={!allChecked || isLoading}
+          className="flex-[1.3] py-[13px] rounded-xl bg-primary text-white text-sm font-bold shadow-primary-btn hover:bg-primary-hover transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          {isLoading ? '처리 중...' : '동의하고 계좌 만들기'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/signup/ConsentStep.jsx
+++ b/src/components/signup/ConsentStep.jsx
@@ -295,8 +295,8 @@ function GroupRow({ group, agreements, onAgreementsChange, expandedItems, onExpa
 
 function DocumentSection({ doc, agreements, onAgreementsChange, expandedItems, onExpandItems }) {
   return (
-    <div>
-      <p className="text-[13px] font-bold text-foreground-secondary mb-1">{doc.title}</p>
+    <div className="pt-6 border-t border-stroke-subtle">
+      <p className="text-[13px] font-bold text-foreground mb-3">{doc.title}</p>
       {doc.intro && (
         <p className="text-[11px] text-foreground-disabled leading-[1.75] mb-2">{doc.intro}</p>
       )}

--- a/src/components/signup/PreOpenCheckStep.jsx
+++ b/src/components/signup/PreOpenCheckStep.jsx
@@ -1,0 +1,256 @@
+import { useState } from 'react'
+import { Check, X } from 'lucide-react'
+
+const PRE_OPEN_NOTICES = [
+  {
+    key: 'limited',
+    title: '1. 한도제한 계좌로 개설됩니다.',
+    description: '해제 조건을 만족하거나, 금융거래 목적에 맞는 서류를 제출하면 직접 해제 신청할 수 있어요. (개설 후 1개월 안에 금융거래 목적을 확인할 수 있는 거래 정보가 있으면 자동으로 해제돼요.)',
+    note: '※ 1일 출금한도 : 온라인/ATM 100만원, 영업점 300만원',
+    buttonLabel: '자세히 보기',
+  },
+  {
+    key: 'deposit',
+    title: '2. 예금자보호에 대한 설명을 확인하세요.',
+    description: '본인이 가입하는 금융상품의 예금자 보호여부(보호 또는 비보호) 및 보호한도에 대하여 설명 듣고 이해하였습니다.',
+    buttonLabel: '자세히 보기',
+  },
+]
+
+const PURPOSE_PROOF_ROWS = [
+  {
+    purpose: '금융투자상품거래',
+    proofs: [
+      '주식•금융상품 거래내역서 또는 잔고확인서(거래회사인감날인 필수, 발행 후 3개월 이내)',
+      '※ CMA, RP 등 현금성 자산 제외',
+      '※ 기존 당사거래 고객은 일정 기준 이상의 주식•금융상품 거래내역이 있는 경우 영업점 및 디지털PB센터를 통해 유선신청 가능',
+    ],
+  },
+  {
+    purpose: '급여수령',
+    proofs: [
+      '근로소득원천징수영수증, 건강보험자격득실확인서(직장가입자용), 소득금액증명원, 근로계약서, 재직증명서, 합격증, 퇴직연금 가입 확인서, 최근 3개월 이내 급여명세서, 명함+사원증 등',
+      '아르바이트비 수령 시 고용주의 사업자등록증 사본 + 근로계약서(급여명세표) 등',
+    ],
+  },
+  {
+    purpose: '기타',
+    proofs: [
+      '거래목적을 확인할 수 있는 객관적 증빙자료',
+      '영업점에서 신청 가능',
+    ],
+  },
+]
+
+const LIMIT_ROWS = [
+  { channel: '창구', limit: '300만원' },
+  { channel: 'ATM', limit: '100만원' },
+  { channel: '전자금융거래 (온라인)', limit: '100만원' },
+]
+
+function DetailModal({ title, onClose, children }) {
+  return (
+    <div className="fixed inset-0 z-40 bg-black/40 flex items-center justify-center px-6 py-8">
+      <div
+        className="w-full max-w-[860px] max-h-[82vh] bg-surface rounded-2xl shadow-modal overflow-hidden"
+        style={{ animation: 'modal-in .2s ease both' }}
+      >
+        <div className="flex items-center justify-between px-6 py-5 border-b border-stroke">
+          <h3 className="text-[18px] font-extrabold tracking-tight text-foreground">{title}</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-9 h-9 rounded-full bg-surface-subtle border border-stroke flex items-center justify-center text-foreground-secondary hover:bg-surface-muted transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+        <div className="overflow-y-auto max-h-[calc(82vh-74px)] px-6 py-5">
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function LimitedAccountDetailModal({ onClose }) {
+  return (
+    <DetailModal title="한도제한 계좌 자세히보기" onClose={onClose}>
+      <div className="space-y-6">
+        <section>
+          <h4 className="text-[15px] font-bold text-foreground mb-2">금융거래 한도제한 계좌란?</h4>
+          <p className="text-[13px] text-foreground-secondary leading-[1.85]">
+            보이스피싱 피해 예방 및 전기통신금융사기 방지를 위해 계좌개설 시 금융거래 목적이 확인이 필요하며, 목적에 따른 증빙서류가 확인되지 않으면 출금한도가 제한되는 계좌로 개설됩니다.
+            <br />
+            (ISA, IRP, 연금저축계좌는 제외)
+          </p>
+        </section>
+
+        <section>
+          <h4 className="text-[15px] font-bold text-foreground mb-3">금융거래 목적에 따른 증빙 서류</h4>
+          <div className="rounded-2xl border border-stroke overflow-hidden">
+            <div className="grid grid-cols-[180px_1fr] bg-surface-subtle border-b border-stroke">
+              <div className="px-4 py-3 text-[12px] font-semibold text-foreground-secondary">금융거래 목적</div>
+              <div className="px-4 py-3 text-[12px] font-semibold text-foreground-secondary">증빙서류</div>
+            </div>
+            {PURPOSE_PROOF_ROWS.map((row) => (
+              <div key={row.purpose} className="grid grid-cols-[180px_1fr] border-b border-stroke last:border-b-0">
+                <div className="px-4 py-4 text-[13px] font-semibold text-foreground bg-surface-subtle/70">{row.purpose}</div>
+                <div className="px-4 py-4">
+                  <ul className="space-y-2">
+                    {row.proofs.map((proof) => (
+                      <li key={proof} className="text-[12px] text-foreground-secondary leading-[1.75]">{proof}</li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="mt-3 rounded-xl bg-surface-subtle border border-stroke-subtle px-4 py-3">
+            <ul className="space-y-2">
+              <li className="text-[12px] text-foreground-secondary leading-[1.7]">
+                ※ 상기자료 이외에도 거래목적을 증빙할 수 있는 다른 증빙자료를 준비하실 수 있으며, 필요 시 당사는 상기 증빙자료 외의 추가자료를 요청할 수 있습니다.
+              </li>
+              <li className="text-[12px] text-foreground-secondary leading-[1.7]">
+                ※ 미성년자는 본인 또는 법정대리인의 증빙서류 외에 미성년자 기준의 가족관계증명서와 기본증명서(상세)도 추가 제출해야 합니다.
+              </li>
+            </ul>
+          </div>
+        </section>
+
+        <section>
+          <h4 className="text-[15px] font-bold text-foreground mb-3">출금/이체 한도</h4>
+          <div className="rounded-2xl border border-stroke overflow-hidden">
+            <div className="grid grid-cols-[1fr_180px] bg-surface-subtle border-b border-stroke">
+              <div className="px-4 py-3 text-[12px] font-semibold text-foreground-secondary">거래채널</div>
+              <div className="px-4 py-3 text-[12px] font-semibold text-foreground-secondary">1일 출금 한도</div>
+            </div>
+            {LIMIT_ROWS.map((row) => (
+              <div key={row.channel} className="grid grid-cols-[1fr_180px] border-b border-stroke last:border-b-0">
+                <div className="px-4 py-3 text-[13px] text-foreground">{row.channel}</div>
+                <div className="px-4 py-3 text-[13px] font-semibold text-foreground">{row.limit}</div>
+              </div>
+            ))}
+          </div>
+          <p className="mt-3 text-[12px] text-foreground-secondary leading-[1.7]">
+            ※ 복수의 한도제한 계좌가 있는 경우 일 출금/이체 한도는 합산하여 적용됩니다.
+          </p>
+        </section>
+
+        <section>
+          <h4 className="text-[15px] font-bold text-foreground mb-2">해제 안내</h4>
+          <ul className="space-y-2">
+            <li className="text-[12px] text-foreground-secondary leading-[1.75]">• 금융거래 목적에 따른 증빙서류 제출</li>
+            <li className="text-[12px] text-foreground-secondary leading-[1.75]">• 해제 조건에 충족한 경우 증빙서류 제출 없이 해제 신청 가능</li>
+            <li className="text-[12px] text-foreground-secondary leading-[1.75]">※ 개설 후 1개월 안에 금융거래목적을 확인할 수 있는 거래 정보가 있으면 자동해제 됩니다.</li>
+            <li className="text-[12px] text-foreground-secondary leading-[1.75]">※ 자동해제 조건은 상시 변경될 수 있으며, 상세 조건은 안내되지 않습니다.</li>
+            <li className="text-[12px] text-foreground-secondary leading-[1.75]">
+              ※ SOL-FX계좌: 개설 후 1개월 내 동일명의 당사 타 계좌의 한도해제 이력이나 잔고•거래실적이 있으면 자동해제 됩니다. 다만 개설 후 1개월 내 자동해제가 되지 않으면, 동일명의 당사 타계좌의 잔고•거래실적을 제출해주셔야 SOL-FX계좌의 한도제한 해제가 가능합니다. (당사 타 계좌 잔고 및 거래내역 증빙일 경우 영업점, 디지털PB센터 유선 신청 가능)
+            </li>
+          </ul>
+        </section>
+      </div>
+    </DetailModal>
+  )
+}
+
+function DepositProtectionDetailModal({ onClose }) {
+  return (
+    <DetailModal title="예금자보호 설명/확인" onClose={onClose}>
+      <div className="space-y-6">
+        <section>
+          <h4 className="text-[15px] font-bold text-foreground mb-2">예금자보호제도란?</h4>
+          <p className="text-[13px] text-foreground-secondary leading-[1.85]">
+            본 금융회사가 예금등 채권의 지급정지 후 파산하게 되는 경우, 예금보험공사가 예금자 1인당 보호금융상품의 원금과 소정의 이자를 합하여 최고 1억원까지 보호합니다.
+          </p>
+        </section>
+        <section>
+          <h4 className="text-[15px] font-bold text-foreground mb-2">보호금융상품</h4>
+          <p className="text-[13px] text-foreground-secondary leading-[1.85]">
+            이 예탁금 중 증권매수 미사용 현금 잔액은 예금자보호법에 따라 원금과 소정의 이자를 합하여 1인당 "1억원까지"(본 금융회사의 여타 보호상품과 합산) 보호됩니다.
+          </p>
+        </section>
+        <section>
+          <h4 className="text-[15px] font-bold text-foreground mb-2">비보호상품</h4>
+          <p className="text-[13px] text-foreground-secondary leading-[1.85]">
+            이 금융상품은 예금자보호법에 따라 보호되지 않습니다.
+          </p>
+        </section>
+        <section>
+          <h4 className="text-[15px] font-bold text-foreground mb-2">IRP(개인형 퇴직연금)</h4>
+          <p className="text-[13px] text-foreground-secondary leading-[1.85]">
+            이 퇴직연금은 예금자보호법에 따라 예금보호 대상 금융상품으로 운용되는 적립금에 대하여 다른 보호상품과는 별도로 1인당 "1억원까지"(운용되는 금융상품 판매회사별 보호상품 합산) 보호됩니다.
+          </p>
+        </section>
+        <section>
+          <h4 className="text-[15px] font-bold text-foreground mb-2">중개형 ISA</h4>
+          <p className="text-[13px] text-foreground-secondary leading-[1.85]">
+            이 금융상품(중개형 ISA)은 예금자보호법에 따라 보호되지 않습니다. 다만, 중개형 ISA의 예탁금 중 증권매수 미사용 현금 잔액은 예금자보호법에 따라 원금과 소정의 이자를 합하여 1인당 "1억원까지" (본 금융회사의 여타 보호상품과 합산) 보호됩니다.
+          </p>
+        </section>
+        <section>
+          <h4 className="text-[15px] font-bold text-foreground mb-2">외화전용계좌(SOL-FX)</h4>
+          <p className="text-[13px] text-foreground-secondary leading-[1.85]">
+            이 예탁금은 예금자보호법에 따라 원금과 소정의 이자를 합하여 1인당 "1억원까지"(본 금융회사의 여타 보호상품과 합산) 보호됩니다.
+          </p>
+        </section>
+      </div>
+    </DetailModal>
+  )
+}
+
+export default function PreOpenCheckStep({ onBack, onNext }) {
+  const [openModal, setOpenModal] = useState(null)
+
+  return (
+    <>
+      <div>
+        <div className="mb-7">
+          <h2 className="text-xl font-extrabold text-foreground tracking-tight mb-1">계좌 개설 전에 꼭 확인하세요</h2>
+          <p className="text-[13px] text-foreground-disabled leading-[1.8]">
+            사전 안내를 확인한 뒤 다음 단계에서 동의서를 검토합니다.
+          </p>
+        </div>
+
+        <div className="rounded-2xl border border-stroke bg-surface overflow-hidden">
+          <div className="px-5 py-5 space-y-8">
+            {PRE_OPEN_NOTICES.map((item) => (
+              <div key={item.key}>
+                <p className="text-[16px] font-bold text-foreground leading-[1.55]">{item.title}</p>
+                <p className="text-[13px] text-foreground-secondary mt-2 leading-[1.8]">{item.description}</p>
+                {item.note && <p className="text-[11px] text-foreground-tertiary mt-2 leading-[1.7]">{item.note}</p>}
+                <button
+                  type="button"
+                  onClick={() => setOpenModal(item.key)}
+                  className="mt-4 inline-flex items-center text-[12px] font-semibold text-primary hover:text-primary-hover transition-colors"
+                >
+                  {item.buttonLabel}
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-7 flex gap-3">
+          <button
+            type="button"
+            onClick={onBack}
+            className="flex-1 py-[13px] rounded-xl border border-stroke-input bg-surface text-sm font-semibold text-foreground-secondary hover:bg-surface-subtle transition-colors"
+          >
+            이전
+          </button>
+          <button
+            type="button"
+            onClick={onNext}
+            className="flex-[1.3] py-[13px] rounded-xl bg-primary text-white text-sm font-bold shadow-primary-btn hover:bg-primary-hover transition-colors"
+          >
+            확인하고 계속하기
+          </button>
+        </div>
+      </div>
+
+      {openModal === 'limited' && <LimitedAccountDetailModal onClose={() => setOpenModal(null)} />}
+      {openModal === 'deposit' && <DepositProtectionDetailModal onClose={() => setOpenModal(null)} />}
+    </>
+  )
+}

--- a/src/components/signup/PreOpenCheckStep.jsx
+++ b/src/components/signup/PreOpenCheckStep.jsx
@@ -52,14 +52,14 @@ function DetailModal({ title, onClose, children }) {
   return (
     <div className="fixed inset-0 z-40 bg-black/40 flex items-center justify-center px-6 py-8">
       <div
-        className="w-full max-w-[860px] max-h-[82vh] bg-surface rounded-2xl shadow-modal overflow-hidden"
-        style={{ animation: 'modal-in .2s ease both' }}
+        className="w-full max-w-[860px] max-h-[82vh] bg-surface rounded-2xl shadow-modal overflow-hidden animate-modal-in"
       >
         <div className="flex items-center justify-between px-6 py-5 border-b border-stroke">
           <h3 className="text-[18px] font-extrabold tracking-tight text-foreground">{title}</h3>
           <button
             type="button"
             onClick={onClose}
+            aria-label="닫기"
             className="w-9 h-9 rounded-full bg-surface-subtle border border-stroke flex items-center justify-center text-foreground-secondary hover:bg-surface-muted transition-colors"
           >
             <X className="w-4 h-4" />

--- a/src/components/signup/StepIndicator.jsx
+++ b/src/components/signup/StepIndicator.jsx
@@ -1,0 +1,40 @@
+import { Check } from 'lucide-react'
+
+export default function StepIndicator({ current, steps }) {
+  return (
+    <div className="flex items-center mb-8">
+      {steps.map((label, i) => {
+        const done = i < current
+        const active = i === current
+
+        return (
+          <div key={label} className="flex items-center flex-1 last:flex-none">
+            <div className="flex flex-col items-center gap-[5px] shrink-0">
+              <div
+                className={[
+                  'w-[26px] h-[26px] rounded-full flex items-center justify-center text-[11px] font-bold',
+                  active ? 'bg-primary text-white shadow-[0_0_12px_rgba(0,70,255,.3)]'
+                    : done ? 'bg-primary text-white'
+                      : 'bg-surface-muted text-foreground-disabled border-[1.5px] border-stroke-input',
+                ].join(' ')}
+              >
+                {done ? <Check className="w-3 h-3" strokeWidth={3} /> : i + 1}
+              </div>
+              <span
+                className={[
+                  'text-[10px] font-semibold',
+                  active || done ? 'text-primary' : 'text-foreground-disabled',
+                ].join(' ')}
+              >
+                {label}
+              </span>
+            </div>
+            {i < steps.length - 1 && (
+              <div className={['flex-1 h-0.5 mx-2.5 mb-3.5', done ? 'bg-primary' : 'bg-stroke-input'].join(' ')} />
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/signup/StepIndicator.jsx
+++ b/src/components/signup/StepIndicator.jsx
@@ -13,7 +13,7 @@ export default function StepIndicator({ current, steps }) {
               <div
                 className={[
                   'w-[26px] h-[26px] rounded-full flex items-center justify-center text-[11px] font-bold',
-                  active ? 'bg-primary text-white shadow-[0_0_12px_rgba(0,70,255,.3)]'
+                  active ? 'bg-primary text-white shadow-brand-glow'
                     : done ? 'bg-primary text-white'
                       : 'bg-surface-muted text-foreground-disabled border-[1.5px] border-stroke-input',
                 ].join(' ')}

--- a/src/components/signup/passwordValidation.js
+++ b/src/components/signup/passwordValidation.js
@@ -1,0 +1,8 @@
+export function getPasswordChecks(password) {
+  return {
+    length: password.length >= 8,
+    letter: /[A-Za-z]/.test(password),
+    number: /[0-9]/.test(password),
+    special: /[^A-Za-z0-9]/.test(password),
+  }
+}

--- a/src/components/signup/phoneNumber.js
+++ b/src/components/signup/phoneNumber.js
@@ -1,0 +1,7 @@
+export function formatPhoneNumber(value) {
+  const digits = value.replace(/\D/g, '').slice(0, 11)
+
+  if (digits.length <= 3) return digits
+  if (digits.length <= 7) return `${digits.slice(0, 3)}-${digits.slice(3)}`
+  return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`
+}

--- a/src/components/signup/signupSchema.js
+++ b/src/components/signup/signupSchema.js
@@ -1,0 +1,28 @@
+import { z } from 'zod'
+
+export const signupBasicInfoSchema = z.object({
+  email: z.email('올바른 이메일 형식을 입력해 주세요.'),
+  name: z.string().trim().min(1, '이름을 입력해 주세요.'),
+  phone: z.union([
+    z.literal(''),
+    z.string().regex(/^\d{2,3}-\d{3,4}-\d{4}$/, '휴대폰 번호를 끝까지 입력해 주세요.'),
+  ]),
+  password: z
+    .string()
+    .min(8, '비밀번호는 최소 8자 이상이어야 합니다.')
+    .refine((value) => /[A-Za-z]/.test(value), '비밀번호에 영문을 포함해 주세요.')
+    .refine((value) => /[0-9]/.test(value), '비밀번호에 숫자를 포함해 주세요.')
+    .refine((value) => /[^A-Za-z0-9]/.test(value), '비밀번호에 특수문자를 포함해 주세요.'),
+  passwordConfirm: z.string().min(1, '비밀번호 확인을 입력해 주세요.'),
+}).refine((data) => data.password === data.passwordConfirm, {
+  path: ['passwordConfirm'],
+  message: '비밀번호가 일치하지 않습니다.',
+})
+
+export const signupBasicInfoDefaultValues = {
+  email: '',
+  name: '',
+  phone: '',
+  password: '',
+  passwordConfirm: '',
+}

--- a/src/components/ui/Input.jsx
+++ b/src/components/ui/Input.jsx
@@ -1,0 +1,67 @@
+import { forwardRef, useState } from 'react'
+import { Eye, EyeOff } from 'lucide-react'
+
+export const Input = forwardRef(function Input({ label, required, className = '', ...props }, ref) {
+  return (
+    <div>
+      {label && (
+        <label className="block text-[11px] font-semibold text-foreground-secondary mb-1.5">
+          {label}
+          {required && <span className="text-up ml-0.5">*</span>}
+        </label>
+      )}
+      <input
+        ref={ref}
+        className={[
+          'w-full px-3.5 py-[11px]',
+          'border-[1.5px] border-stroke-input rounded-[10px]',
+          'text-sm text-foreground bg-surface',
+          'outline-none transition-[border-color,box-shadow] duration-[200ms]',
+          'focus:border-primary focus:shadow-focus-ring',
+          'placeholder:text-foreground-disabled',
+          className,
+        ].join(' ')}
+        {...props}
+      />
+    </div>
+  )
+})
+
+export const PasswordInput = forwardRef(function PasswordInput({ label, required, className = '', ...props }, ref) {
+  const [show, setShow] = useState(false)
+
+  return (
+    <div>
+      {label && (
+        <label className="block text-[11px] font-semibold text-foreground-secondary mb-1.5">
+          {label}
+          {required && <span className="text-up ml-0.5">*</span>}
+        </label>
+      )}
+      <div className="relative">
+        <input
+          ref={ref}
+          type={show ? 'text' : 'password'}
+          className={[
+            'w-full px-3.5 py-[11px] pr-[42px]',
+            'border-[1.5px] border-stroke-input rounded-[10px]',
+            'text-sm text-foreground bg-surface',
+            'outline-none transition-[border-color,box-shadow] duration-[200ms]',
+            'focus:border-primary focus:shadow-focus-ring',
+            'placeholder:text-foreground-disabled',
+            className,
+          ].join(' ')}
+          {...props}
+        />
+        <button
+          type="button"
+          onClick={() => setShow((v) => !v)}
+          aria-label={show ? '비밀번호 숨기기' : '비밀번호 보기'}
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-foreground-disabled hover:text-foreground-tertiary transition-colors"
+        >
+          {show ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+        </button>
+      </div>
+    </div>
+  )
+})

--- a/src/hooks/useEmailVerification.js
+++ b/src/hooks/useEmailVerification.js
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState } from 'react'
+import { authApi } from '@/api/auth'
+
+const POLL_INTERVAL = 3000
+
+export default function useEmailVerification(email, { onError } = {}) {
+  const [isSending, setIsSending] = useState(false)
+  const [sendDone, setSendDone] = useState(false)
+  const [emailVerified, setEmailVerified] = useState(false)
+  const pollingRef = useRef(null)
+
+  useEffect(() => {
+    if (!sendDone || emailVerified) return undefined
+
+    pollingRef.current = setInterval(async () => {
+      try {
+        const res = await authApi.getEmailVerifyStatus(email)
+        if (res?.verified) {
+          setEmailVerified(true)
+          clearInterval(pollingRef.current)
+        }
+      } catch {
+        // Polling errors are ignored to keep retrying.
+      }
+    }, POLL_INTERVAL)
+
+    return () => clearInterval(pollingRef.current)
+  }, [email, sendDone, emailVerified])
+
+  function resetVerification() {
+    setSendDone(false)
+    setEmailVerified(false)
+    clearInterval(pollingRef.current)
+  }
+
+  async function sendVerifyEmail() {
+    if (!email) {
+      onError?.('이메일을 먼저 입력해 주세요.')
+      return { ok: false, error: { message: '이메일을 먼저 입력해 주세요.' } }
+    }
+
+    onError?.('')
+    setIsSending(true)
+
+    try {
+      await authApi.sendVerifyEmail({ email })
+      setSendDone(true)
+      setEmailVerified(false)
+      return { ok: true }
+    } catch (err) {
+      return {
+        ok: false,
+        error: err ?? { message: '인증 메일 발송에 실패했습니다.' },
+      }
+    } finally {
+      setIsSending(false)
+    }
+  }
+
+  return {
+    isSending,
+    sendDone,
+    emailVerified,
+    resetVerification,
+    sendVerifyEmail,
+  }
+}

--- a/src/pages/auth/EmailVerifyPage.jsx
+++ b/src/pages/auth/EmailVerifyPage.jsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react'
+import { useSearchParams, useNavigate } from 'react-router-dom'
+import { Activity, CheckCircle, XCircle, Loader } from 'lucide-react'
+import { authApi } from '@/api/auth'
+
+export default function EmailVerifyPage() {
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const token = searchParams.get('token')
+
+  const [status, setStatus] = useState('loading') // 'loading' | 'success' | 'error'
+  const [message, setMessage] = useState('')
+
+  useEffect(() => {
+    if (!token) {
+      setStatus('error')
+      setMessage('유효하지 않은 인증 링크입니다.')
+      return
+    }
+
+    authApi.confirmVerifyEmail({ token })
+      .then(() => setStatus('success'))
+      .catch((err) => {
+        setStatus('error')
+        setMessage(err?.message ?? '인증 링크가 만료되었거나 유효하지 않습니다.')
+      })
+  }, [token])
+
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-5">
+      <div
+        className="w-full max-w-[400px] bg-surface rounded-xl shadow-modal p-8 text-center"
+        style={{ animation: 'modal-in .2s ease both' }}
+      >
+        {/* 로고 */}
+        <div className="flex items-center justify-center gap-2 mb-8">
+          <div className="w-7 h-7 rounded-[9px] bg-primary flex items-center justify-center">
+            <Activity className="w-3.5 h-3.5 text-white" strokeWidth={2.5} />
+          </div>
+          <span className="text-[15px] font-bold tracking-tight text-foreground-secondary">SOL Lite</span>
+        </div>
+
+        {status === 'loading' && (
+          <>
+            <Loader className="w-12 h-12 text-primary mx-auto mb-5 animate-spin" />
+            <h2 className="text-xl font-extrabold text-foreground tracking-tight mb-2">인증 처리 중</h2>
+            <p className="text-[13px] text-foreground-disabled">잠시만 기다려 주세요...</p>
+          </>
+        )}
+
+        {status === 'success' && (
+          <>
+            <CheckCircle className="w-12 h-12 text-live mx-auto mb-5" />
+            <h2 className="text-xl font-extrabold text-foreground tracking-tight mb-2">이메일 인증 완료</h2>
+            <p className="text-[13px] text-foreground-disabled leading-[1.8] mb-8">
+              이메일 인증이 완료되었습니다.<br />로그인하여 서비스를 이용하세요.
+            </p>
+            <button
+              onClick={() => navigate('/login')}
+              className="w-full py-[13px] bg-primary text-white rounded-xl text-sm font-bold shadow-primary-btn hover:bg-primary-hover transition-colors duration-[150ms]"
+            >
+              로그인하러 가기
+            </button>
+          </>
+        )}
+
+        {status === 'error' && (
+          <>
+            <XCircle className="w-12 h-12 text-up mx-auto mb-5" />
+            <h2 className="text-xl font-extrabold text-foreground tracking-tight mb-2">인증 실패</h2>
+            <p className="text-[13px] text-foreground-disabled leading-[1.8] mb-8">{message}</p>
+            <button
+              onClick={() => navigate('/login')}
+              className="w-full py-[13px] bg-surface-muted border border-stroke text-foreground-secondary rounded-xl text-sm font-semibold hover:bg-stroke-subtle transition-colors"
+            >
+              로그인 페이지로
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/auth/LoginPage.jsx
+++ b/src/pages/auth/LoginPage.jsx
@@ -1,0 +1,151 @@
+import { useState } from 'react'
+import { Activity, X, Check } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
+import { Input, PasswordInput } from '@/components/ui/Input'
+import { authApi } from '@/api/auth'
+import useAuthStore from '@/store/useAuthStore'
+
+export default function LoginPage() {
+  const navigate  = useNavigate()
+  const setAuth   = useAuthStore((s) => s.setAuth)
+
+  const [email, setEmail]       = useState('')
+  const [password, setPassword] = useState('')
+  const [autoLogin, setAutoLogin] = useState(true)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError]         = useState('')
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    setError('')
+    setIsLoading(true)
+    try {
+      const res = await authApi.login({ email, password, autoLogin })
+      setAuth({
+        accessToken:  res.accessToken,
+        refreshToken: res.refreshToken,
+        user:         res.user,
+        autoLogin,
+      })
+      navigate('/')
+    } catch (err) {
+      setError(err?.message ?? '이메일 또는 비밀번호를 확인해 주세요.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-10 flex items-center justify-center p-5">
+      {/* 뒷배경 */}
+      <div className="fixed inset-0 bg-background">
+        <div className="h-header bg-surface border-b border-stroke flex items-center px-6 gap-3 opacity-40">
+          <div className="w-7 h-7 rounded-[9px] bg-primary" />
+          <div className="w-20 h-3.5 bg-stroke-input rounded" />
+          <div className="flex gap-1 ml-2">
+            {[true, false, false, false].map((active, i) => (
+              <div key={i} className={['w-11 h-7 rounded-lg', active ? 'bg-primary-light' : 'bg-surface-muted'].join(' ')} />
+            ))}
+          </div>
+        </div>
+        <div className="p-5 grid grid-cols-4 gap-[10px] opacity-35">
+          <div className="h-40 bg-surface rounded-2xl" />
+          <div className="h-40 bg-surface rounded-2xl col-span-2" />
+          <div className="h-40 bg-surface rounded-2xl" />
+          <div className="h-40 bg-surface rounded-2xl" />
+          <div className="h-40 bg-surface rounded-2xl col-span-2" />
+          <div className="h-40 bg-surface rounded-2xl" />
+        </div>
+      </div>
+
+      {/* 딤 오버레이 */}
+      <div className="fixed inset-0 bg-black/50 backdrop-blur-[6px] z-10" />
+
+      {/* 모달 */}
+      <div
+        className="relative z-20 w-full max-w-[400px] bg-surface rounded-[6px] shadow-modal overflow-hidden"
+        style={{ animation: 'modal-in .2s ease both' }}
+      >
+        {/* 모달 헤더 */}
+        <div className="flex items-center justify-between px-6 pt-[22px]">
+          <div className="flex items-center gap-2.5">
+            <div className="w-[26px] h-[26px] rounded-[5px] bg-primary flex items-center justify-center">
+              <Activity className="w-[13px] h-[13px] text-white" strokeWidth={2.5} />
+            </div>
+            <span className="text-[15px] font-bold tracking-tight text-foreground-secondary">SOL Lite</span>
+          </div>
+          <button
+            onClick={() => navigate('/')}
+            aria-label="닫기"
+            className="text-foreground-disabled hover:text-foreground-tertiary p-1 transition-colors"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="px-6 pt-4">
+          <h2 className="text-xl font-extrabold text-foreground tracking-tight">로그인</h2>
+        </div>
+
+        {/* 폼 */}
+        <form onSubmit={handleSubmit} className="px-6 pt-[18px] pb-[26px] flex flex-col gap-3.5">
+          <Input
+            label="이메일"
+            type="email"
+            placeholder="example@domain.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+
+          {/* 비밀번호 */}
+          <div>
+            <div className="flex justify-between items-center mb-1.5">
+              <label className="text-[11px] font-semibold text-foreground-secondary">비밀번호</label>
+              <a href="#" className="text-[11px] text-primary font-medium">비밀번호 찾기</a>
+            </div>
+            <PasswordInput
+              placeholder="비밀번호를 입력하세요"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </div>
+
+          {/* 자동 로그인 */}
+          <label className="flex items-center gap-[7px] cursor-pointer select-none">
+            <button
+              type="button"
+              onClick={() => setAutoLogin((v) => !v)}
+              className={[
+                'w-4 h-4 rounded-[2px] flex items-center justify-center shrink-0 transition-colors',
+                autoLogin ? 'bg-primary' : 'border-[1.5px] border-stroke-input bg-surface',
+              ].join(' ')}
+            >
+              {autoLogin && <Check className="w-[9px] h-[9px] text-white" strokeWidth={3.5} />}
+            </button>
+            <span className="text-xs text-foreground-secondary">자동 로그인</span>
+          </label>
+
+          {error && <p className="text-[11px] text-up">{error}</p>}
+
+          {/* 로그인 버튼 */}
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="w-full py-[13px] bg-primary text-white border-none rounded-[4px] text-sm font-bold hover:bg-primary-hover transition-colors duration-[150ms] disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {isLoading ? '로그인 중...' : '로그인'}
+          </button>
+
+          {/* 회원가입 링크 */}
+          <p className="text-center text-xs text-foreground-disabled mt-0.5">
+            계정이 없으신가요?
+            <button type="button" onClick={() => navigate('/signup')}
+              className="text-primary font-semibold ml-1">
+              회원가입
+            </button>
+          </p>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/auth/PasswordResetPage.jsx
+++ b/src/pages/auth/PasswordResetPage.jsx
@@ -1,0 +1,195 @@
+import { useState } from 'react'
+import { useSearchParams, useNavigate } from 'react-router-dom'
+import { Activity, CheckCircle, XCircle } from 'lucide-react'
+import { PasswordInput } from '@/components/ui/Input'
+import { authApi } from '@/api/auth'
+
+const PW_RULES = [
+  { key: 'length',  label: '최소 8자 이상',  check: (pw) => pw.length >= 8 },
+  { key: 'letter',  label: '영문 포함',       check: (pw) => /[A-Za-z]/.test(pw) },
+  { key: 'number',  label: '숫자 포함',       check: (pw) => /[0-9]/.test(pw) },
+  { key: 'special', label: '특수문자 포함',   check: (pw) => /[^A-Za-z0-9]/.test(pw) },
+]
+
+function PasswordRules({ password }) {
+  return (
+    <div className="mt-[7px] bg-surface-subtle rounded-[10px] px-3 py-2.5 grid grid-cols-2 gap-x-3 gap-y-[5px]">
+      {PW_RULES.map(({ key, label, check }) => {
+        const ok = check(password)
+        return (
+          <div key={key} className="flex items-center gap-[5px] text-[11px]">
+            <div className={['w-1 h-1 rounded-full shrink-0', ok ? 'bg-live' : 'bg-stroke-input'].join(' ')} />
+            <span className={ok ? 'text-live' : 'text-foreground-disabled'}>{label}</span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export default function PasswordResetPage() {
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const token = searchParams.get('token')
+
+  const [newPassword, setNewPassword]           = useState('')
+  const [newPasswordConfirm, setNewPasswordConfirm] = useState('')
+  const [isLoading, setIsLoading]               = useState(false)
+  const [status, setStatus]                     = useState('form') // 'form' | 'success' | 'error'
+  const [error, setError]                       = useState('')
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    setError('')
+
+    if (newPassword !== newPasswordConfirm) {
+      setError('비밀번호가 일치하지 않습니다.')
+      return
+    }
+    const allOk = PW_RULES.every(({ check }) => check(newPassword))
+    if (!allOk) {
+      setError('비밀번호 조건을 모두 충족해야 합니다.')
+      return
+    }
+
+    setIsLoading(true)
+    try {
+      await authApi.confirmPasswordReset({ token, newPassword, newPasswordConfirm })
+      setStatus('success')
+    } catch (err) {
+      if (err?.message?.includes('만료') || err?.message?.includes('유효')) {
+        setStatus('error')
+      } else {
+        setError(err?.message ?? '비밀번호 재설정에 실패했습니다. 다시 시도해 주세요.')
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  // 토큰 없음
+  if (!token) {
+    return (
+      <ResultCard>
+        <XCircle className="w-12 h-12 text-up mx-auto mb-5" />
+        <h2 className="text-xl font-extrabold text-foreground tracking-tight mb-2">유효하지 않은 링크</h2>
+        <p className="text-[13px] text-foreground-disabled leading-[1.8] mb-8">
+          비밀번호 재설정 링크가 올바르지 않습니다.
+        </p>
+        <button onClick={() => navigate('/login')}
+          className="w-full py-[13px] bg-surface-muted border border-stroke text-foreground-secondary rounded-xl text-sm font-semibold hover:bg-stroke-subtle transition-colors">
+          로그인 페이지로
+        </button>
+      </ResultCard>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-5">
+      <div
+        className="w-full max-w-[400px] bg-surface rounded-xl shadow-modal overflow-hidden"
+        style={{ animation: 'modal-in .2s ease both' }}
+      >
+        {/* 헤더 */}
+        <div className="flex items-center gap-2.5 px-6 pt-[22px]">
+          <div className="w-[26px] h-[26px] rounded-[5px] bg-primary flex items-center justify-center">
+            <Activity className="w-[13px] h-[13px] text-white" strokeWidth={2.5} />
+          </div>
+          <span className="text-[15px] font-bold tracking-tight text-foreground-secondary">SOL Lite</span>
+        </div>
+
+        {status === 'form' && (
+          <form onSubmit={handleSubmit} className="px-6 pt-5 pb-[26px] flex flex-col gap-3.5">
+            <div>
+              <h2 className="text-xl font-extrabold text-foreground tracking-tight">비밀번호 재설정</h2>
+              <p className="text-[13px] text-foreground-disabled mt-1">새로 사용할 비밀번호를 입력해 주세요.</p>
+            </div>
+
+            <div className="flex flex-col gap-[18px] mt-1">
+              <div>
+                <PasswordInput
+                  label="새 비밀번호"
+                  required
+                  placeholder="새 비밀번호를 입력하세요"
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                />
+                <PasswordRules password={newPassword} />
+              </div>
+
+              <PasswordInput
+                label="새 비밀번호 확인"
+                required
+                placeholder="비밀번호를 다시 입력하세요"
+                value={newPasswordConfirm}
+                onChange={(e) => setNewPasswordConfirm(e.target.value)}
+              />
+            </div>
+
+            {error && <p className="text-[11px] text-up">{error}</p>}
+
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="w-full py-[13px] bg-primary text-white rounded-[4px] text-sm font-bold hover:bg-primary-hover transition-colors duration-[150ms] disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              {isLoading ? '처리 중...' : '비밀번호 변경'}
+            </button>
+          </form>
+        )}
+
+        {status === 'success' && (
+          <div className="px-6 py-8 text-center">
+            <CheckCircle className="w-12 h-12 text-live mx-auto mb-5" />
+            <h2 className="text-xl font-extrabold text-foreground tracking-tight mb-2">변경 완료</h2>
+            <p className="text-[13px] text-foreground-disabled leading-[1.8] mb-8">
+              비밀번호가 변경되었습니다.<br />새 비밀번호로 로그인해 주세요.
+            </p>
+            <button
+              onClick={() => navigate('/login')}
+              className="w-full py-[13px] bg-primary text-white rounded-xl text-sm font-bold shadow-primary-btn hover:bg-primary-hover transition-colors duration-[150ms]"
+            >
+              로그인하러 가기
+            </button>
+          </div>
+        )}
+
+        {status === 'error' && (
+          <div className="px-6 py-8 text-center">
+            <XCircle className="w-12 h-12 text-up mx-auto mb-5" />
+            <h2 className="text-xl font-extrabold text-foreground tracking-tight mb-2">링크 만료</h2>
+            <p className="text-[13px] text-foreground-disabled leading-[1.8] mb-8">
+              비밀번호 재설정 링크가 만료되었습니다.<br />다시 요청해 주세요.
+            </p>
+            <button
+              onClick={() => navigate('/login')}
+              className="w-full py-[13px] bg-surface-muted border border-stroke text-foreground-secondary rounded-xl text-sm font-semibold hover:bg-stroke-subtle transition-colors"
+            >
+              로그인 페이지로
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// 토큰 없는 경우 래퍼
+function ResultCard({ children }) {
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-5">
+      <div
+        className="w-full max-w-[400px] bg-surface rounded-xl shadow-modal p-8 text-center"
+        style={{ animation: 'modal-in .2s ease both' }}
+      >
+        <div className="flex items-center justify-center gap-2 mb-8">
+          <div className="w-7 h-7 rounded-[9px] bg-primary flex items-center justify-center">
+            <Activity className="w-3.5 h-3.5 text-white" strokeWidth={2.5} />
+          </div>
+          <span className="text-[15px] font-bold tracking-tight text-foreground-secondary">SOL Lite</span>
+        </div>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/auth/SignupPage.jsx
+++ b/src/pages/auth/SignupPage.jsx
@@ -140,14 +140,13 @@ export default function SignupPage() {
       <BrandPanel />
 
       <div className="flex-1 bg-surface flex flex-col overflow-y-auto">
-        <div className="max-w-[560px] w-full mx-auto px-8 py-11">
-          <StepIndicator current={STEP_TO_INDICATOR[step]} steps={INDICATOR_STEPS} />
+        {step === 0 ? (
+          <AccountIntroStep onNext={() => setStep(1)} />
+        ) : (
+          <div className="max-w-[560px] w-full mx-auto px-8 py-11">
+            <StepIndicator current={STEP_TO_INDICATOR[step]} steps={INDICATOR_STEPS} />
 
-          {step === 0 && (
-            <AccountIntroStep onNext={() => setStep(1)} />
-          )}
-
-          {step === 1 && (
+            {step === 1 && (
             <BasicInfoStep
               password={password}
               control={control}
@@ -202,6 +201,7 @@ export default function SignupPage() {
             </p>
           )}
         </div>
+        )}
       </div>
     </div>
   )

--- a/src/pages/auth/SignupPage.jsx
+++ b/src/pages/auth/SignupPage.jsx
@@ -1,0 +1,208 @@
+import { useState } from 'react'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router-dom'
+import AccountStep from '@/components/signup/AccountStep'
+import AccountIntroStep from '@/components/signup/AccountIntroStep'
+import BasicInfoStep from '@/components/signup/BasicInfoStep'
+import BrandPanel from '@/components/signup/BrandPanel'
+import PreOpenCheckStep from '@/components/signup/PreOpenCheckStep'
+import ConsentStep, { CONSENT_INITIAL_STATE, FINANCE_KEYS, SAFETY_KEYS } from '@/components/signup/ConsentStep'
+import StepIndicator from '@/components/signup/StepIndicator'
+import { signupBasicInfoDefaultValues, signupBasicInfoSchema } from '@/components/signup/signupSchema'
+import { authApi } from '@/api/auth'
+import useEmailVerification from '@/hooks/useEmailVerification'
+
+const INDICATOR_STEPS = ['계좌개설', '기본정보', '계좌설정']
+const STEP_TO_INDICATOR = [0, 1, 1, 1, 2]
+
+export default function SignupPage() {
+  const navigate = useNavigate()
+  const [step, setStep] = useState(0)
+  const basicInfoForm = useForm({
+    resolver: zodResolver(signupBasicInfoSchema),
+    mode: 'onChange',
+    defaultValues: signupBasicInfoDefaultValues,
+  })
+  const {
+    control,
+    clearErrors,
+    handleSubmit,
+    setError: setFieldError,
+    trigger,
+    watch,
+    formState: { errors },
+  } = basicInfoForm
+  const email = watch('email')
+  const name = watch('name')
+  const phone = watch('phone')
+  const password = watch('password')
+  const passwordConfirm = watch('passwordConfirm')
+
+  const [agreements, setAgreements] = useState(CONSENT_INITIAL_STATE)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError]         = useState('')
+  const [emailCheckError, setEmailCheckError] = useState('')
+  const [verifyHighlight, setVerifyHighlight] = useState(false)
+  const { isSending, sendDone, emailVerified, resetVerification, sendVerifyEmail } = useEmailVerification(email, {
+    onError: setError,
+  })
+
+  function handleEmailChange() {
+    clearErrors('email')
+    setError('')
+    setEmailCheckError('')
+    if (sendDone) {
+      resetVerification()
+    }
+  }
+
+  async function handleSendVerifyEmail() {
+    const isEmailValid = await trigger('email')
+    if (!isEmailValid) return
+
+    clearErrors('email')
+    setError('')
+    setEmailCheckError('')
+
+    const result = await sendVerifyEmail()
+    if (result.ok) return
+
+    if (result.error?.code === 'DUPLICATE_EMAIL') {
+      const message = result.error.message ?? '이미 등록된 이메일입니다'
+      setEmailCheckError(message)
+      setFieldError('email', {
+        type: 'server',
+        message,
+      })
+      return
+    }
+
+    setError(result.error?.message ?? '인증 메일 발송에 실패했습니다.')
+  }
+
+  function handleBasicInfoStep() {
+    handleSubmit(() => {
+      setError('')
+      setVerifyHighlight(false)
+
+      if (emailCheckError) {
+        setFieldError('email', {
+          type: 'server',
+          message: emailCheckError,
+        })
+        return
+      }
+
+      if (!emailVerified) {
+        setVerifyHighlight(true)
+        if (!sendDone) {
+          setError('이메일 인증 발송을 먼저 해주세요.')
+        } else {
+          setError('메일함에서 인증 링크를 클릭한 후 다시 시도해 주세요.')
+        }
+        return
+      }
+
+      setStep(2)
+    }, () => {
+      setError('')
+      setVerifyHighlight(false)
+    })()
+  }
+
+  async function handleSignup() {
+    setError('')
+    setIsLoading(true)
+    try {
+      const serviceTermsAgreed = FINANCE_KEYS.every((key) => agreements[key])
+      const privacyTermsAgreed = SAFETY_KEYS.every((key) => agreements[key])
+
+      await authApi.signup({
+        email,
+        password,
+        passwordConfirm,
+        name,
+        phone: phone || null,
+        serviceTermsAgreed,
+        privacyTermsAgreed,
+      })
+      setStep(4)
+    } catch (err) {
+      setError(err?.message ?? '회원가입에 실패했습니다. 다시 시도해 주세요.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="flex h-screen overflow-hidden">
+      <BrandPanel />
+
+      <div className="flex-1 bg-surface flex flex-col overflow-y-auto">
+        <div className="max-w-[560px] w-full mx-auto px-8 py-11">
+          <StepIndicator current={STEP_TO_INDICATOR[step]} steps={INDICATOR_STEPS} />
+
+          {step === 0 && (
+            <AccountIntroStep onNext={() => setStep(1)} />
+          )}
+
+          {step === 1 && (
+            <BasicInfoStep
+              password={password}
+              control={control}
+              isSending={isSending}
+              sendDone={sendDone}
+              emailVerified={emailVerified}
+              verifyHighlight={verifyHighlight}
+              error={error}
+              fieldErrors={{
+                email: errors.email?.message,
+                name: errors.name?.message,
+                phone: errors.phone?.message,
+                password: errors.password?.message,
+                passwordConfirm: errors.passwordConfirm?.message,
+              }}
+              onEmailInputChange={handleEmailChange}
+              onBack={() => setStep(0)}
+              onSendVerifyEmail={handleSendVerifyEmail}
+              onNext={handleBasicInfoStep}
+            />
+          )}
+
+          {step === 2 && (
+            <PreOpenCheckStep
+              onBack={() => setStep(1)}
+              onNext={() => setStep(3)}
+            />
+          )}
+
+          {step === 3 && (
+            <ConsentStep
+              agreements={agreements}
+              onAgreementsChange={setAgreements}
+              onBack={() => setStep(2)}
+              onSubmit={handleSignup}
+              isLoading={isLoading}
+              error={error}
+            />
+          )}
+
+          {step === 4 && (
+            <AccountStep onFinish={() => navigate('/login')} />
+          )}
+
+          {step < 4 && (
+            <p className="text-center text-xs text-foreground-disabled mt-5">
+              이미 계정이 있으신가요?
+              <button type="button" onClick={() => navigate('/login')}
+                className="text-primary font-semibold ml-1">
+                로그인
+              </button>
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -4,6 +4,10 @@ import HomePage from '@/pages/HomePage'
 import MarketPage from '@/pages/MarketPage'
 import InvestPage from '@/pages/InvestPage'
 import AssetPage from '@/pages/AssetPage'
+import LoginPage from '@/pages/auth/LoginPage'
+import SignupPage from '@/pages/auth/SignupPage'
+import EmailVerifyPage from '@/pages/auth/EmailVerifyPage'
+import PasswordResetPage from '@/pages/auth/PasswordResetPage'
 
 export const router = createBrowserRouter([
   {
@@ -16,4 +20,8 @@ export const router = createBrowserRouter([
       { path: 'asset',      element: <AssetPage /> },
     ],
   },
+  { path: '/login',          element: <LoginPage /> },
+  { path: '/signup',         element: <SignupPage /> },
+  { path: '/email/verify',   element: <EmailVerifyPage /> },
+  { path: '/password/reset', element: <PasswordResetPage /> },
 ])

--- a/src/store/useAuthStore.js
+++ b/src/store/useAuthStore.js
@@ -1,10 +1,37 @@
 import { create } from 'zustand'
 
-const useAuthStore = create((set) => ({
+const useAuthStore = create((set, get) => ({
   isAuthenticated: false,
-  user: null,
-  login: (user) => set({ isAuthenticated: true, user }),
-  logout: () => set({ isAuthenticated: false, user: null }),
+  user: null,           // { userId, email, name }
+  accessToken: null,
+  refreshToken: null,
+
+  // 로그인 성공 시 호출
+  setAuth: ({ accessToken, refreshToken, user, autoLogin }) => {
+    const storage = autoLogin ? localStorage : sessionStorage
+    storage.setItem('accessToken', accessToken)
+    storage.setItem('refreshToken', refreshToken)
+    set({ isAuthenticated: true, user, accessToken, refreshToken })
+  },
+
+  // 앱 초기화 시 저장된 토큰 복원
+  restoreAuth: () => {
+    const accessToken =
+      localStorage.getItem('accessToken') ?? sessionStorage.getItem('accessToken')
+    const refreshToken =
+      localStorage.getItem('refreshToken') ?? sessionStorage.getItem('refreshToken')
+    if (accessToken) {
+      set({ isAuthenticated: true, accessToken, refreshToken })
+    }
+  },
+
+  logout: () => {
+    localStorage.removeItem('accessToken')
+    localStorage.removeItem('refreshToken')
+    sessionStorage.removeItem('accessToken')
+    sessionStorage.removeItem('refreshToken')
+    set({ isAuthenticated: false, user: null, accessToken: null, refreshToken: null })
+  },
 }))
 
 export default useAuthStore

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,4 +13,12 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## 연관된 이슈

> 

## 작업 내용

회원가입 페이지의 UI를 전문적인 랜딩페이지 스타일로 리디자인하고 레이아웃을 최적화했습니다.

### 주요 변경사항

**AccountIntroStep**
- 큰 타이포그래피(text-5xl)와 배경 장식 효과 추가
- 세 가지 준비물 카드 섹션으로 구성
- 최종 CTA 버튼으로 통일 (중복된 버튼 제거)

**SignupPage**
- Step 0(AccountIntroStep)은 full-width로 표시
- Step 1~4(폼 단계)는 560px 제약 유지
- StepIndicator는 Step 1부터 표시하여 intro 단계와 구분

**ConsentStep**
- 두 document 섹션 사이에 border와 spacing 추가
- 독립적인 섹션으로 시각적 구분 명확화
- 개인(신용)정보 처리 동의서 섹션 분리

### 스크린샷 (선택)

## 체크리스트

- [x] 코드가 정상적으로 빌드되는지 확인했나요?
- [x] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항(선택)

> 