### PR TITLE
feat(layout): EditPanel 위젯 사이즈 선택 및 미리보기 UI 구현

### DIFF
--- a/.claude/agents/frontend.md
+++ b/.claude/agents/frontend.md
@@ -54,6 +54,30 @@ chore(config): tailwind 디자인 토큰 등록
 style(market): StockRow hover 스타일 수정
 ```
 
+## GitHub 이슈 컨벤션
+
+### 제목 형식
+```
+[Type] 한글 설명
+```
+
+### Type
+- `[Feat]` : 새로운 기능
+- `[Fix]` : 버그 수정
+- `[Refactor]` : 리팩토링
+- `[Style]` : UI/스타일 수정
+- `[Chore]` : 빌드, 설정, 패키지 등 유지보수
+- `[Docs]` : 문서
+
+### 예시
+```
+[Feat] EditPanel 위젯 사이즈 선택 UI 구현
+[Fix] 관심종목 위젯 overflow 수정
+[Refactor] className 조합 방식 cn() 유틸로 통일
+```
+
+---
+
 ## 커밋 단위
 - 하나의 컴포넌트 또는 하나의 기능 단위로 커밋
 - 공통 UI 원자 컴포넌트는 여러 개를 묶어서 커밋 가능

--- a/package.json
+++ b/package.json
@@ -10,16 +10,17 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "clsx": "^2.1.1",
     "lucide-react": "^0.577.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.13.1",
+    "tailwind-merge": "^3.5.0",
     "zustand": "^5.0.12"
   },
   "devDependencies": {
-    "@tailwindcss/vite": "^4.2.1",
-    "tailwindcss": "^4.2.1",
     "@eslint/js": "^9.39.4",
+    "@tailwindcss/vite": "^4.2.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.0",
@@ -27,6 +28,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "tailwindcss": "^4.2.1",
     "vite": "^8.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      '@tailwindcss/vite':
-        specifier: ^4.2.1
-        version: 4.2.1(vite@8.0.0(jiti@2.6.1))
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.4)
@@ -23,9 +23,9 @@ importers:
       react-router-dom:
         specifier: ^7.13.1
         version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      tailwindcss:
-        specifier: ^4.2.1
-        version: 4.2.1
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.5.0
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(react@19.2.4)
@@ -33,6 +33,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.4
         version: 9.39.4
+      '@tailwindcss/vite':
+        specifier: ^4.2.1
+        version: 4.2.1(vite@8.0.0(jiti@2.6.1))
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -54,6 +57,9 @@ importers:
       globals:
         specifier: ^17.4.0
         version: 17.4.0
+      tailwindcss:
+        specifier: ^4.2.1
+        version: 4.2.1
       vite:
         specifier: ^8.0.0
         version: 8.0.0(jiti@2.6.1)
@@ -487,6 +493,10 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1014,6 +1024,9 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
+
   tailwindcss@4.2.1:
     resolution: {integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==}
 
@@ -1518,6 +1531,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  clsx@2.1.1: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -1963,6 +1978,8 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.1: {}
 

--- a/src/components/layout/AppHeader.jsx
+++ b/src/components/layout/AppHeader.jsx
@@ -1,7 +1,8 @@
-import { Activity } from 'lucide-react'
+import { Activity, LayoutGrid } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import NavTabs from './NavTabs'
 import useAuthStore from '@/store/useAuthStore'
+import useEditModeStore from '@/store/useEditModeStore'
 
 function Logo() {
   return (
@@ -58,12 +59,52 @@ function UserArea() {
   )
 }
 
+function EditModeActions() {
+  const { exitEditMode, saveLayout } = useEditModeStore()
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl bg-primary-light border border-primary-border">
+        <LayoutGrid className="w-3.5 h-3.5 text-primary" strokeWidth={2} />
+        <span className="text-[12px] font-semibold text-primary">위젯 편집</span>
+      </div>
+      <button
+        onClick={exitEditMode}
+        className="px-3 py-1.5 rounded-xl border border-stroke-input text-[12px] text-foreground-tertiary font-medium hover:bg-surface-muted transition-colors duration-[150ms]"
+      >
+        취소
+      </button>
+      <button
+        onClick={saveLayout}
+        className="px-3 py-1.5 rounded-xl bg-primary text-white text-[12px] font-semibold hover:bg-primary-hover transition-colors duration-[150ms] shadow-primary-btn"
+      >
+        완료 · 저장
+      </button>
+    </div>
+  )
+}
+
+function WidgetEditButton() {
+  const { enterEditMode } = useEditModeStore()
+  return (
+    <button
+      onClick={enterEditMode}
+      className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl border border-stroke text-foreground-secondary text-[12px] font-medium hover:border-primary hover:text-primary hover:bg-primary-light transition-all duration-[150ms]"
+    >
+      <LayoutGrid className="w-3.5 h-3.5" strokeWidth={2} />
+      위젯 편집
+    </button>
+  )
+}
+
 export default function AppHeader() {
+  const { isEditMode } = useEditModeStore()
+
   return (
     <header className="h-header flex items-center px-4 gap-3 bg-surface border-b border-stroke shrink-0 z-50">
       <Logo />
       <NavTabs />
       <div className="flex-1" />
+      {isEditMode ? <EditModeActions /> : <WidgetEditButton />}
       <UserArea />
     </header>
   )

--- a/src/components/layout/ChatPanel.jsx
+++ b/src/components/layout/ChatPanel.jsx
@@ -2,6 +2,8 @@ import { MessageSquare, Send, Lock } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import LiveDot from '@/components/ui/LiveDot'
 import useAuthStore from '@/store/useAuthStore'
+import useEditModeStore from '@/store/useEditModeStore'
+import EditPanel from './EditPanel'
 
 function LoginPrompt() {
   const navigate = useNavigate()
@@ -71,6 +73,9 @@ function ChatMessages() {
 
 export default function ChatPanel() {
   const { isAuthenticated } = useAuthStore()
+  const { isEditMode } = useEditModeStore()
+
+  if (isEditMode) return <EditPanel />
 
   return (
     <aside className="w-chat-panel flex flex-col bg-surface border-l border-stroke shrink-0">

--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -242,7 +242,7 @@ function PreviewContent({ type }) {
             <span className="text-[9px] text-foreground-disabled">종목별 비중</span>
             <span className="text-[10px] font-bold text-up">+5.2%</span>
           </div>
-          <div className="flex flex-col gap-0.9">
+          <div className="flex flex-col gap-1">
             {[
               { name: '삼성전자',       pct: 34, color: 'bg-chart-1' },
               { name: 'SK하이닉스',     pct: 20, color: 'bg-chart-2' },

--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -242,12 +242,11 @@ function PreviewContent({ type }) {
             <span className="text-[9px] text-foreground-disabled">종목별 비중</span>
             <span className="text-[10px] font-bold text-up">+5.2%</span>
           </div>
-          <div className="flex flex-col gap-1">
+          <div className="flex flex-col gap-2">
             {[
-              { name: '삼성전자',       pct: 34, color: 'bg-chart-1' },
-              { name: 'SK하이닉스',     pct: 20, color: 'bg-chart-2' },
-              { name: 'LG에너지솔루션', pct: 18, color: 'bg-chart-3' },
-              { name: '기타',           pct: 28, color: 'bg-chart-4' },
+              { name: '삼성전자',   pct: 34, color: 'bg-chart-1' },
+              { name: 'SK하이닉스', pct: 20, color: 'bg-chart-2' },
+              { name: '기타',       pct: 46, color: 'bg-chart-4' },
             ].map(({ name, pct, color }) => (
               <div key={name}>
                 <div className="flex justify-between mb-0.5">

--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -1,0 +1,856 @@
+import { ChevronLeft, Plus } from 'lucide-react'
+import { cn } from '@/lib/cn'
+
+/* ── 비율 계산 ──────────────────────────────────────────────
+   패널 폭 = 2열 기준.
+   너비: colSpan=1 → w-1/2,  colSpan=2 → w-full
+   비율: 실제 대시보드 셀 비율 그대로
+     1×1 → aspect-square
+     2×1 → aspect-[2/1]
+     1×2 → aspect-[1/2] (현재 실제 사용하지는 x)
+     2×2 → aspect-square
+─────────────────────────────────────────────────────────── */
+function widthClass(colSpan) {
+  return colSpan === 2 ? 'w-full' : 'w-1/2'
+}
+
+function aspectClass(colSpan, rowSpan) {
+  if (colSpan === 1 && rowSpan === 2) return 'aspect-[1/2]'
+  if (colSpan === 2 && rowSpan === 1) return 'aspect-[2/1]'
+  if (colSpan === 2 && rowSpan === 2) return 'aspect-square'
+  return 'aspect-square' // 1×1
+}
+
+function SizeBadge({ colSpan, rowSpan }) {
+  return (
+    <span className="text-[8px] font-semibold text-foreground-disabled bg-surface-muted px-1.5 py-0.5 rounded shrink-0">
+      {colSpan}×{rowSpan}
+    </span>
+  )
+}
+
+/* ── 위젯별 미리보기 콘텐츠 ─────────────────────────────── */
+function PreviewContent({ type }) {
+  switch (type) {
+
+    /* 계좌 잔고 — 소형 1×1 */
+    case 'balance-sm':
+      return (
+        <div className="flex flex-col justify-between h-full">
+          <span className="text-[9px] text-foreground-disabled">총 평가자산</span>
+          <div>
+            <div className="text-[14px] font-extrabold text-foreground leading-none">84,320,000</div>
+            <div className="text-[10px] text-up font-semibold mt-1">▲ +2.61%</div>
+          </div>
+        </div>
+      )
+
+    /* 계좌 잔고 — 와이드 2×1 */
+    case 'balance-lg':
+      return (
+        <div className="flex items-center justify-between h-full gap-3">
+          <div className="flex flex-col justify-center gap-1">
+            <span className="text-[9px] text-foreground-disabled">총 평가자산</span>
+            <div className="text-[15px] font-extrabold text-foreground leading-none">84,320,000원</div>
+            <div className="text-[10px] text-up font-semibold">▲ +2,152,000원 (+2.61%)</div>
+          </div>
+          <div className="flex flex-col gap-2 shrink-0">
+            <div className="text-right">
+              <div className="text-[9px] text-foreground-disabled">투자원금</div>
+              <div className="text-[11px] font-semibold text-foreground">82,168,000</div>
+            </div>
+            <div className="text-right">
+              <div className="text-[9px] text-foreground-disabled">평가손익</div>
+              <div className="text-[11px] font-semibold text-up">+2,152,000</div>
+            </div>
+          </div>
+        </div>
+      )
+
+    /* 주가/차트 — 카드형 1×1 */
+    case 'stock-sm':
+      return (
+        <div className="flex flex-col justify-between h-full">
+          <div className="flex items-center justify-between">
+            <span className="text-[10px] font-bold text-foreground">삼성전자</span>
+            <span className="text-[8px] text-foreground-disabled">005930</span>
+          </div>
+          <div>
+            <div className="text-[14px] font-extrabold text-foreground leading-none">75,400</div>
+            <div className="text-[10px] text-up font-medium mt-0.5">▲ 1,200 (+1.62%)</div>
+          </div>
+        </div>
+      )
+
+    /* 주가/차트 — 차트형 1×1 */
+    case 'stock-tall':
+      return (
+        <div className="flex flex-col h-full gap-1.5">
+          <div className="flex items-center justify-between shrink-0">
+            <span className="text-[10px] font-bold text-foreground">삼성전자</span>
+            <span className="text-[8px] text-foreground-disabled">1D</span>
+          </div>
+          <div className="flex-1 min-h-0 bg-background rounded-lg flex items-end px-1.5 pb-1.5 pt-2 gap-px">
+            {[42, 58, 50, 72, 60, 68, 55, 80, 70, 85, 75, 90].map((h, i) => (
+              <div key={i} className="flex-1 bg-up/50 rounded-sm" style={{ height: `${h}%` }} />
+            ))}
+          </div>
+          <div className="shrink-0">
+            <div className="text-[13px] font-extrabold text-foreground leading-none">75,400</div>
+            <div className="text-[10px] text-up mt-0.5">▲ +1.62%</div>
+          </div>
+        </div>
+      )
+
+    /* 실시간 순위 — 목록형 2×1 */
+    case 'ranking-wide':
+      return (
+        <div className="flex flex-col h-full gap-1.5">
+          <div className="flex gap-1.5 shrink-0">
+            {['거래대금', '상승률', '거래량'].map((tab, i) => (
+              <span key={tab} className={`text-[9px] font-semibold px-1.5 py-0.5 rounded-full ${i === 0 ? 'bg-primary-light text-primary' : 'text-foreground-disabled'}`}>{tab}</span>
+            ))}
+          </div>
+          <div className="flex flex-col gap-1.5">
+            {[
+              ['1', '삼성전자',       '+1.62%', true ],
+              ['2', 'SK하이닉스',     '+2.35%', true ],
+              ['3', 'LG에너지솔루션', '-0.87%', false],
+              ['4', 'POSCO홀딩스',    '+0.54%', true ],
+              ['5', '현대차',         '-1.20%', false],
+            ].map(([rank, name, chg, up]) => (
+              <div key={rank} className="flex items-center justify-between">
+                <div className="flex items-center gap-1.5">
+                  <span className="text-[9px] text-foreground-disabled w-3">{rank}</span>
+                  <span className="text-[10px] font-medium text-foreground">{name}</span>
+                </div>
+                <span className={`text-[10px] font-semibold ${up ? 'text-up' : 'text-down'}`}>{chg}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+
+    /* 실시간 순위 — 확장형 2×2 */
+    case 'ranking-lg':
+      return (
+        <div className="flex flex-col h-full gap-1.5">
+          <div className="flex gap-1.5 shrink-0">
+            {['거래대금', '상승률', '거래량'].map((tab, i) => (
+              <span key={tab} className={`text-[9px] font-semibold px-1.5 py-0.5 rounded-full ${i === 0 ? 'bg-primary-light text-primary' : 'text-foreground-disabled'}`}>{tab}</span>
+            ))}
+          </div>
+          <div className="flex flex-col gap-1.5">
+            {[
+              ['1',  '삼성전자',       '+1.62%', true ],
+              ['2',  'SK하이닉스',     '+2.35%', true ],
+              ['3',  'LG에너지솔루션', '-0.87%', false],
+              ['4',  'POSCO홀딩스',    '+0.54%', true ],
+              ['5',  '현대차',         '-1.20%', false],
+              ['6',  '카카오',         '+0.38%', true ],
+              ['7',  'NAVER',          '-0.92%', false],
+              ['8',  'KB금융',         '+1.15%', true ],
+              ['9',  '셀트리온',       '+2.40%', true ],
+              ['10', '기아',           '+0.76%', true ],
+            ].map(([rank, name, chg, up]) => (
+              <div key={rank} className="flex items-center justify-between">
+                <div className="flex items-center gap-1.5">
+                  <span className="text-[9px] text-foreground-disabled w-4">{rank}</span>
+                  <span className="text-[10px] font-medium text-foreground">{name}</span>
+                </div>
+                <span className={`text-[10px] font-semibold ${up ? 'text-up' : 'text-down'}`}>{chg}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+
+    /* 주요 지수 — 단일 1×1 */
+    case 'index-sm':
+      return (
+        <div className="flex flex-col justify-between h-full">
+          <span className="text-[9px] font-semibold text-foreground-disabled">KOSPI</span>
+          <div className="flex-1 my-1.5 min-h-0 bg-background rounded flex items-end px-1 pb-1 pt-1 gap-px">
+            {[50,55,48,60,52,58,54,62,56,65].map((h, i) => (
+              <div key={i} className="flex-1 bg-up/50 rounded-sm" style={{ height: `${h}%` }} />
+            ))}
+          </div>
+          <div>
+            <div className="text-[14px] font-extrabold text-foreground leading-none">2,685.42</div>
+            <div className="text-[10px] text-up font-medium mt-0.5">▲ +12.3 (+0.46%)</div>
+          </div>
+        </div>
+      )
+
+    /* 주요 지수 — 복합 2×1 */
+    case 'index-wide':
+      return (
+        <div className="flex h-full divide-x divide-stroke">
+          {[
+            { name: 'KOSPI',  val: '2,685.42', chg: '+0.46%', up: true,  bars: [50,55,48,60,52,58,54,62] },
+            { name: 'KOSDAQ', val: '868.15',   chg: '-0.21%', up: false, bars: [60,55,58,52,56,50,54,48] },
+            { name: 'NASDAQ', val: '16,274',   chg: '+0.83%', up: true,  bars: [45,52,48,58,54,62,58,68] },
+          ].map(({ name, val, chg, up, bars }) => (
+            <div key={name} className="flex-1 flex flex-col justify-between items-center px-1 py-1">
+              <div className="text-center">
+                <span className="text-[9px] font-semibold text-foreground-disabled">{name}</span>
+                <div className="text-[11px] font-extrabold text-foreground leading-none">{val}</div>
+                <span className={`text-[9px] font-medium ${up ? 'text-up' : 'text-down'}`}>{chg}</span>
+              </div>
+              <div className="flex items-end gap-px h-6 w-full">
+                {bars.map((h, i) => (
+                  <div key={i} className={`flex-1 rounded-sm ${up ? 'bg-up/50' : 'bg-down/50'}`} style={{ height: `${h}%` }} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )
+
+    /* 포트폴리오 — 파이차트 1×1 */
+    case 'portfolio-sm':
+      return (
+        <div className="flex flex-col h-full gap-2">
+          <span className="text-[9px] text-foreground-disabled">종목별 비중</span>
+          <div className="flex items-center gap-2.5 flex-1 min-h-0">
+            <div
+              className="w-14 h-14 rounded-full shrink-0"
+              style={{ background: 'conic-gradient(var(--color-chart-1) 0% 34%, var(--color-chart-2) 34% 54%, var(--color-chart-3) 54% 72%, var(--color-chart-4) 72% 100%)' }}
+            />
+            <div className="flex flex-col gap-1">
+              {[
+                { name: '삼성', color: 'bg-chart-1' },
+                { name: 'SK하이', color: 'bg-chart-2' },
+                { name: 'LG에너', color: 'bg-chart-3' },
+                { name: '기타', color: 'bg-chart-4' },
+              ].map(({ name, color }) => (
+                <div key={name} className="flex items-center gap-1">
+                  <div className={`w-1.5 h-1.5 rounded-full shrink-0 ${color}`} />
+                  <span className="text-[8px] text-foreground-secondary">{name}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )
+
+    /* 포트폴리오 — 상세 2×1 */
+    case 'portfolio-wide':
+      return (
+        <div className="flex flex-col h-full gap-1.5">
+          <div className="flex items-center justify-between shrink-0">
+            <span className="text-[9px] text-foreground-disabled">종목별 비중</span>
+            <span className="text-[10px] font-bold text-up">+5.2%</span>
+          </div>
+          <div className="flex flex-col gap-1.5">
+            {[
+              { name: '삼성전자',       pct: 34, color: 'bg-chart-1' },
+              { name: 'SK하이닉스',     pct: 20, color: 'bg-chart-2' },
+              { name: 'LG에너지솔루션', pct: 18, color: 'bg-chart-3' },
+              { name: '기타',           pct: 28, color: 'bg-chart-4' },
+            ].map(({ name, pct, color }) => (
+              <div key={name}>
+                <div className="flex justify-between mb-0.5">
+                  <span className="text-[9px] text-foreground-secondary">{name}</span>
+                  <span className="text-[9px] font-semibold text-foreground">{pct}%</span>
+                </div>
+                <div className="h-1.5 bg-surface-muted rounded-full overflow-hidden">
+                  <div className={`h-full rounded-full ${color}`} style={{ width: `${pct}%` }} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+
+    /* 환율 — 단일 1×1 */
+    case 'exchange-sm':
+      return (
+        <div className="flex flex-col justify-between h-full">
+          <div className="flex items-center justify-between">
+            <span className="text-[9px] text-foreground-disabled">환율</span>
+            <span className="text-[8px] text-foreground-disabled">09:30 기준</span>
+          </div>
+          <div>
+            <div className="text-[10px] font-semibold text-foreground-secondary">USD / KRW</div>
+            <div className="text-[14px] font-extrabold text-foreground leading-none">1,378.50</div>
+            <div className="text-[10px] text-down mt-0.5">▼ -2.30 (-0.17%)</div>
+          </div>
+        </div>
+      )
+
+    /* 환율 — 복합 2×1 */
+    case 'exchange-wide':
+      return (
+        <div className="flex flex-col h-full gap-0.5">
+          <span className="text-[7px] text-foreground-disabled text-right shrink-0">09:30 기준</span>
+          <div className="flex flex-1 divide-x divide-stroke">
+            {[
+              { pair: 'USD/KRW', rate: '1,378.50', chg: '-0.17%', up: false, bars: [60,58,62,55,58,52,56,50] },
+              { pair: 'JPY/KRW', rate: '9.18',     chg: '+0.11%', up: true,  bars: [45,48,50,52,49,54,52,56] },
+              { pair: 'EUR/KRW', rate: '1,502.30', chg: '-0.05%', up: false, bars: [55,53,57,52,54,50,52,49] },
+            ].map(({ pair, rate, chg, up, bars }) => (
+              <div key={pair} className="flex-1 flex flex-col justify-between items-center px-1">
+                <div className="text-center">
+                  <span className="text-[9px] text-foreground-disabled">{pair}</span>
+                  <div className="text-[11px] font-extrabold text-foreground leading-none">{rate}</div>
+                  <span className={`text-[9px] ${up ? 'text-up' : 'text-down'}`}>{chg}</span>
+                </div>
+                <div className="flex items-end gap-px h-5 w-full">
+                  {bars.map((h, i) => (
+                    <div key={i} className={`flex-1 rounded-sm ${up ? 'bg-up/40' : 'bg-down/40'}`} style={{ height: `${h}%` }} />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+
+    /* 오늘의 시황 — 헤드라인 1×1 */
+    case 'market-sm':
+      return (
+        <div className="flex flex-col h-full gap-2">
+          <span className="text-[9px] font-semibold text-foreground-disabled">시황</span>
+          <p className="text-[10px] text-foreground-secondary leading-snug">
+            美 CPI 예상치 하회…<br />나스닥 1% 이상 상승.<br />반도체 섹터 강세.
+          </p>
+        </div>
+      )
+
+    /* 오늘의 시황 — 상세 2×1 */
+    case 'market-wide':
+      return (
+        <div className="flex flex-col h-full gap-1.5">
+          <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">오늘의 시황</span>
+          <div className="flex flex-col gap-1.5">
+            {[
+              '美 CPI 예상치 하회… 나스닥 1% 상승',
+              'SK하이닉스 목표가 상향 조정',
+              '원/달러 환율 1,378원 하락 마감',
+              '코스피 외국인 순매수 이틀 연속',
+            ].map((headline, i) => (
+              <div key={i} className="flex items-start gap-1">
+                <span className="text-[8px] text-foreground-disabled mt-px shrink-0">{i + 1}</span>
+                <p className="text-[9px] text-foreground-secondary leading-snug">{headline}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+
+    /* 관심종목 — 컴팩트 1×1 */
+    case 'watchlist-sm':
+      return (
+        <div className="flex flex-col h-full gap-1">
+          <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">관심종목</span>
+          <div className="flex flex-col gap-1.5">
+            {[
+              { name: '삼성전자',   chg: '+1.62%', up: true  },
+              { name: '현대차',     chg: '-0.43%', up: false },
+              { name: 'LG에너지',   chg: '+0.91%', up: true  },
+              { name: 'SK하이닉스', chg: '-0.82%', up: false },
+              { name: 'NAVER',      chg: '-0.51%', up: false },
+            ].map(({ name, chg, up }) => (
+              <div key={name} className="flex items-center justify-between">
+                <span className="text-[10px] font-medium text-foreground">{name}</span>
+                <span className={`text-[9px] font-semibold ${up ? 'text-up' : 'text-down'}`}>{chg}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+
+    /* 관심종목 — 목록형 2×1 */
+    case 'watchlist-wide':
+      return (
+        <div className="flex flex-col h-full gap-1">
+          <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">관심종목</span>
+          <div className="flex flex-col gap-1.5">
+            {[
+              { name: '삼성전자',       price: '75,400',  chg: '+1.62%', up: true  },
+              { name: '현대차',         price: '221,500', chg: '-0.43%', up: false },
+              { name: 'LG에너지솔루션', price: '412,000', chg: '+0.91%', up: true  },
+              { name: 'POSCO홀딩스',    price: '378,500', chg: '+0.53%', up: true  },
+              { name: 'SK하이닉스',     price: '182,000', chg: '-0.82%', up: false },
+            ].map(({ name, price, chg, up }) => (
+              <div key={name} className="flex items-center justify-between gap-2">
+                <span className="text-[10px] font-medium text-foreground truncate">{name}</span>
+                <div className="flex items-center gap-1.5 shrink-0">
+                  <span className="text-[10px] font-semibold text-foreground">{price}</span>
+                  <span className={cn('text-[9px] font-medium', up ? 'text-up' : 'text-down')}>{chg}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+
+    /* 거래내역 — 주간 2×1 */
+    case 'trade-wide': {
+      const wDays = ['일', '월', '화', '수', '목', '금', '토']
+      const weekCells = [
+        { d: 16, trades: null },
+        { d: 17, trades: [{ s: '현대차', buy: true  }] },
+        { d: 18, trades: [{ s: '삼성',   buy: true  }, { s: 'NAVER',  buy: false }] },
+        { d: 19, trades: [{ s: 'LG에너', buy: true  }] },
+        { d: 20, trades: [{ s: 'SK하이', buy: false }] },
+        { d: 21, trades: [{ s: '삼성',   buy: true  }, { s: 'SK',     buy: false }] },
+        { d: 22, trades: null },
+      ]
+      return (
+        <div className="flex flex-col h-full gap-1">
+          <div className="flex items-center justify-between shrink-0">
+            <span className="text-[9px] font-bold text-foreground">2026년 3월</span>
+            <span className="text-[8px] text-foreground-disabled">3.16 ~ 3.22</span>
+          </div>
+          <div className="grid grid-cols-7 gap-0.5 shrink-0">
+            {wDays.map((d) => (
+              <div key={d} className="text-center text-[7px] font-semibold text-foreground-disabled">{d}</div>
+            ))}
+          </div>
+          <div className="grid grid-cols-7 gap-0.5 flex-1">
+            {weekCells.map(({ d, trades }, i) => (
+              <div
+                key={i}
+                className={cn('flex flex-col items-start justify-start rounded p-1', trades ? 'bg-primary/10' : 'bg-background/50')}
+              >
+                <span className={cn('text-[8px] leading-none mb-1', trades ? 'text-primary font-bold' : 'text-foreground')}>{d}</span>
+                {trades && trades.map((tr, j) => (
+                  <div key={j} className="flex items-center gap-0.5 w-full mb-0.5">
+                    <div className={cn('w-0.5 rounded-full shrink-0 self-stretch', tr.buy ? 'bg-up' : 'bg-down')} />
+                    <span className="text-[7px] leading-snug truncate text-foreground">{tr.s}</span>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+    }
+
+    /* 거래내역 — 목록형 1×1 */
+    case 'trade-list':
+      return (
+        <div className="flex flex-col h-full gap-1">
+          <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">거래내역</span>
+          <div className="flex flex-col gap-1.5">
+            {[
+              { name: '삼성전자',   type: '매수', qty: '10주' },
+              { name: 'SK하이닉스', type: '매도', qty: '5주'  },
+              { name: 'LG에너지',   type: '매수', qty: '3주'  },
+              { name: 'NAVER',      type: '매도', qty: '2주'  },
+              { name: '현대차',     type: '매수', qty: '7주'  },
+            ].map(({ name, type, qty }, i) => (
+              <div key={i} className="flex items-center justify-between">
+                <span className="text-[10px] text-foreground">{name}</span>
+                <div className="flex items-center gap-1">
+                  <span className={`text-[8px] font-semibold px-1 py-px rounded ${type === '매수' ? 'text-up bg-up/10' : 'text-down bg-down/10'}`}>{type}</span>
+                  <span className="text-[9px] text-foreground-disabled">{qty}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+
+    /* 거래내역 — 캘린더 2×2 */
+    case 'trade-cal': {
+      const days = ['일', '월', '화', '수', '목', '금', '토']
+      const cells = [null, null, null, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, null]
+      const tradeMap = {
+        3:  [{ s: '삼성', t: true }, { s: 'SK하이', t: false }],
+        7:  [{ s: '현대차', t: true }],
+        12: [{ s: 'LG에너', t: true }, { s: 'NAVER', t: false }],
+        18: [{ s: '삼성', t: true }, { s: 'SK', t: false }],
+        25: [{ s: '포스코', t: false }],
+      }
+      return (
+        <div className="flex flex-col h-full gap-1">
+          <div className="flex items-center justify-between shrink-0">
+            <span className="text-[9px] font-bold text-foreground">2026년 3월</span>
+            <span className="text-[8px] text-foreground-disabled">거래내역</span>
+          </div>
+          <div className="grid grid-cols-7 gap-0.5 shrink-0">
+            {days.map((d) => (
+              <div key={d} className="text-center text-[7px] font-semibold text-foreground-disabled">{d}</div>
+            ))}
+          </div>
+          <div className="grid grid-cols-7 gap-0.5 flex-1">
+            {cells.map((d, i) => {
+              const trades = d ? tradeMap[d] : null
+              return (
+                <div
+                  key={i}
+                  className="flex flex-col items-start justify-start rounded p-0.5"
+                >
+                  <span className={`text-[8px] leading-none mb-px ${d ? 'text-foreground' : ''}`}>
+                    {d ?? ''}
+                  </span>
+                  {trades && trades.slice(0, 2).map((tr, j) => (
+                    <div key={j} className="flex items-center gap-px w-full">
+                      <div className={`w-0.5 rounded-full shrink-0 self-stretch ${tr.t ? 'bg-up' : 'bg-down'}`} />
+                      <span className="text-[6.5px] leading-snug truncate text-foreground">{tr.s}</span>
+                    </div>
+                  ))}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )
+    }
+
+    /* 증권사 리포트 — 단일 1×1 */
+    case 'report-sm':
+      return (
+        <div className="flex flex-col justify-between h-full">
+          <span className="text-[8px] font-semibold text-foreground-disabled">리포트</span>
+          <div>
+            <div className="text-[9px] font-bold text-foreground leading-snug">삼성전자<br />목표가 상향</div>
+            <div className="text-[8px] text-foreground-disabled mt-1">키움증권 · 3.18</div>
+          </div>
+        </div>
+      )
+
+    /* 증권사 리포트 — 목록형 2×1 */
+    case 'report-wide':
+      return (
+        <div className="flex flex-col h-full gap-1">
+          <span className="text-[8px] font-semibold text-foreground-disabled shrink-0">증권사 리포트</span>
+          <div className="flex flex-col gap-2">
+            {[
+              { title: '삼성전자 목표가 상향',      firm: '키움증권',   date: '3.18' },
+              { title: 'SK하이닉스 HBM 수요 긍정적', firm: '삼성증권',   date: '3.17' },
+              { title: 'LG에너지 실적 전망 하향',   firm: 'NH투자증권', date: '3.16' },
+              { title: '현대차 글로벌 판매 호조',   firm: '한투증권',   date: '3.15' },
+            ].map(({ title, firm, date }, i) => (
+              <div key={i}>
+                <p className="text-[9px] text-foreground leading-snug">{title}</p>
+                <span className="text-[7px] text-foreground-disabled">{firm} · {date}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+
+    /* 계좌 잔고 — 대형 2×2 */
+    case 'balance-2x2':
+      return (
+        <div className="flex flex-col h-full gap-2">
+          <div>
+            <span className="text-[9px] text-foreground-disabled">총 평가자산</span>
+            <div className="text-[16px] font-extrabold text-foreground leading-none mt-0.5">84,320,000원</div>
+            <div className="text-[10px] text-up font-semibold mt-0.5">▲ +2,152,000원 (+2.61%)</div>
+          </div>
+          <div className="grid grid-cols-2 gap-1.5 shrink-0">
+            {[
+              { label: '투자원금', val: '82,168,000', color: 'text-foreground' },
+              { label: '평가손익', val: '+2,152,000', color: 'text-up' },
+              { label: '당일손익', val: '+342,000',   color: 'text-up' },
+              { label: '수익률',   val: '+2.61%',     color: 'text-up' },
+            ].map(({ label, val, color }) => (
+              <div key={label} className="bg-background rounded-lg px-2 py-1.5">
+                <div className="text-[9px] text-foreground-disabled">{label}</div>
+                <div className={`text-[11px] font-bold ${color}`}>{val}</div>
+              </div>
+            ))}
+          </div>
+          <div className="flex-1 min-h-0 bg-background rounded-lg flex items-end px-1.5 pb-1 pt-1.5 gap-px">
+            {[30, 45, 38, 60, 52, 65, 55, 70, 62, 78, 68, 85].map((h, i) => (
+              <div key={i} className="flex-1 bg-up/50 rounded-sm" style={{ height: `${h}%` }} />
+            ))}
+          </div>
+        </div>
+      )
+
+    /* 주가/차트 — 대형 차트 2×2 */
+    case 'stock-2x2':
+      return (
+        <div className="flex flex-col h-full gap-1.5">
+          <div className="flex items-start justify-between shrink-0">
+            <div>
+              <div className="text-[11px] font-bold text-foreground">삼성전자</div>
+              <div className="text-[9px] text-foreground-disabled">005930 · KOSPI</div>
+            </div>
+            <div className="text-right">
+              <div className="text-[14px] font-extrabold text-foreground leading-none">75,400</div>
+              <div className="text-[10px] text-up">▲ +1,200 (+1.62%)</div>
+            </div>
+          </div>
+          <div className="flex-1 min-h-0 bg-background rounded-lg flex items-end px-2 pb-2 pt-2 gap-px">
+            {[38, 52, 44, 58, 48, 62, 50, 68, 56, 72, 60, 78, 65, 82, 70, 88, 75, 90, 78, 85].map((h, i) => (
+              <div key={i} className="flex-1 bg-up/50 rounded-sm" style={{ height: `${h}%` }} />
+            ))}
+          </div>
+          <div className="flex justify-between shrink-0">
+            {[
+              { label: '시가',  val: '74,200' },
+              { label: '고가',  val: '76,100' },
+              { label: '저가',  val: '73,800' },
+              { label: '거래량', val: '12.4M' },
+            ].map(({ label, val }) => (
+              <div key={label} className="text-center">
+                <div className="text-[8px] text-foreground-disabled">{label}</div>
+                <div className="text-[9px] font-semibold text-foreground">{val}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+
+    /* 주요 지수 — 대형 2×2 */
+    case 'index-2x2':
+      return (
+        <div className="flex flex-col h-full gap-2">
+          <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">주요 지수</span>
+          <div className="flex flex-col gap-2.5">
+            {[
+              { name: 'KOSPI',  val: '2,685.42', chg: '+12.3',  pct: '+0.46%', up: true,  bars: [50,55,48,60,52,58,54,62] },
+              { name: 'KOSDAQ', val: '868.15',   chg: '-1.8',   pct: '-0.21%', up: false, bars: [60,55,58,52,56,50,54,48] },
+              { name: 'NASDAQ', val: '16,274',   chg: '+135.2', pct: '+0.83%', up: true,  bars: [45,52,48,58,54,62,58,68] },
+            ].map(({ name, val, chg, pct, up, bars }) => (
+              <div key={name} className="flex items-center gap-2">
+                <div className="flex-1 min-w-0">
+                  <div className="text-[9px] font-semibold text-foreground-disabled">{name}</div>
+                  <div className="text-[12px] font-extrabold text-foreground leading-none">{val}</div>
+                  <div className={`text-[9px] font-medium ${up ? 'text-up' : 'text-down'}`}>{chg} ({pct})</div>
+                </div>
+                <div className="flex items-end gap-px h-7 shrink-0">
+                  {bars.map((h, i) => (
+                    <div key={i} className={`w-1 rounded-sm ${up ? 'bg-up/50' : 'bg-down/50'}`} style={{ height: `${h}%` }} />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+
+    /* 포트폴리오 — 대형 2×2 */
+    case 'portfolio-2x2':
+      
+      return (
+        <div className="flex flex-col h-full gap-2">
+          <div className="flex items-center gap-3 shrink-0">
+            <div
+              className="w-16 h-16 rounded-full shrink-0"
+              style={{ background: 'conic-gradient(var(--color-chart-1) 0% 54%, var(--color-chart-2) 54% 72%, var(--color-chart-3) 72% 87%, var(--color-chart-4) 87% 100%)' }}
+            />
+            <div>
+              <div className="text-[9px] text-foreground-disabled">총 수익률</div>
+              <div className="text-[17px] font-extrabold text-up leading-none">+5.2%</div>
+              <div className="text-[9px] text-foreground-disabled mt-0.5">+4,280,000원</div>
+            </div>
+          </div>
+          <span className="text-[9px] text-foreground-disabled shrink-0">섹터별 비중</span>
+          <div className="flex flex-col gap-2">
+            {[
+              { name: 'IT·반도체', pct: 54, color: 'bg-chart-1' },
+              { name: '자동차',    pct: 18, color: 'bg-chart-2' },
+              { name: '에너지',    pct: 15, color: 'bg-chart-3' },
+              { name: '금융',      pct: 13, color: 'bg-chart-4' },
+            ].map(({ name, pct, color }) => (
+              <div key={name}>
+                <div className="flex justify-between mb-0.5">
+                  <span className="text-[9px] text-foreground-secondary">{name}</span>
+                  <span className="text-[9px] font-semibold text-foreground">{pct}%</span>
+                </div>
+                <div className="h-1.5 bg-surface-muted rounded-full overflow-hidden">
+                  <div className={`h-full rounded-full ${color}`} style={{ width: `${pct}%` }} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+
+    /* 환율 — 대형 2×2 */
+    case 'exchange-2x2':
+      return (
+        <div className="flex flex-col h-full gap-2">
+          <div className="shrink-0">
+            <div className="flex items-center justify-between">
+              <div className="text-[9px] text-foreground-disabled">USD / KRW</div>
+              <span className="text-[8px] text-foreground-disabled">09:30 기준</span>
+            </div>
+            <div className="text-[20px] font-extrabold text-foreground leading-none">1,378.50</div>
+            <div className="text-[10px] text-down">▼ -2.30 (-0.17%)</div>
+          </div>
+          <div className="h-10 bg-background rounded-lg flex items-end px-1.5 pb-1 gap-px shrink-0">
+            {[60, 58, 62, 55, 58, 52, 56, 50, 54, 48, 52, 46].map((h, i) => (
+              <div key={i} className="flex-1 bg-down/40 rounded-sm" style={{ height: `${h}%` }} />
+            ))}
+          </div>
+          <div className="flex flex-col gap-2">
+            {[
+              { pair: 'JPY / KRW', rate: '9.18',     chg: '+0.11%', up: true  },
+              { pair: 'EUR / KRW', rate: '1,502.30', chg: '-0.05%', up: false },
+              { pair: 'CNY / KRW', rate: '189.80',   chg: '+0.08%', up: true  },
+            ].map(({ pair, rate, chg, up }) => (
+              <div key={pair} className="flex items-center justify-between">
+                <span className="text-[10px] text-foreground-secondary">{pair}</span>
+                <div className="text-right">
+                  <span className="text-[11px] font-semibold text-foreground">{rate}</span>
+                  <span className={`text-[9px] ml-1.5 ${up ? 'text-up' : 'text-down'}`}>{chg}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+
+    /* 오늘의 시황 — 대형 2×2 */
+    case 'market-2x2':
+      return (
+        <div className="flex flex-col h-full gap-1.5">
+          <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">오늘의 시황</span>
+          <div className="flex flex-col gap-2">
+            {[
+              '美 CPI 예상치 하회… 나스닥 1% 상승',
+              'SK하이닉스 목표가 상향 조정',
+              '원/달러 환율 1,378원 하락 마감',
+              '코스피 외국인 순매수 이틀 연속',
+              '반도체 업황 긍정적… HBM 수요 증가',
+            ].map((title, i) => (
+              <div key={i} className="flex items-start gap-1.5">
+                <span className="text-[8px] text-foreground-disabled shrink-0 mt-0.5">{i + 1}</span>
+                <p className="text-[9px] text-foreground leading-snug">{title}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+
+    /* 관심종목 — 대형 2×2 */
+    case 'watchlist-2x2':
+      return (
+        <div className="flex flex-col h-full gap-1">
+          <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">관심종목</span>
+          <div className="flex flex-col gap-2">
+            {[
+              { name: '삼성전자',       price: '75,400',  pct: '+1.62%', up: true  },
+              { name: '현대차',         price: '221,500', pct: '-0.43%', up: false },
+              { name: 'LG에너지솔루션', price: '412,000', pct: '+0.91%', up: true  },
+              { name: 'POSCO홀딩스',    price: '378,500', pct: '+0.53%', up: true  },
+              { name: 'SK하이닉스',     price: '182,000', pct: '-0.82%', up: false },
+            ].map(({ name, price, pct, up }) => (
+              <div key={name} className="flex items-center justify-between">
+                <span className="text-[10px] font-medium text-foreground">{name}</span>
+                <div className="text-right">
+                  <div className="text-[10px] font-semibold text-foreground">{price}</div>
+                  <div className={`text-[9px] ${up ? 'text-up' : 'text-down'}`}>{pct}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+
+    /* 증권사 리포트 — 대형 2×2 */
+    case 'report-2x2':
+      return (
+        <div className="flex flex-col h-full gap-1.5">
+          <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">증권사 리포트</span>
+          <div className="flex flex-col gap-2">
+            {[
+              { title: '삼성전자 목표가 상향',         firm: '키움증권',    date: '3.18', desc: '반도체 업황 회복 기대감' },
+              { title: 'SK하이닉스 HBM 수요 긍정적',   firm: '삼성증권',    date: '3.17', desc: 'AI 서버 수요 지속 증가' },
+              { title: 'LG에너지 실적 전망 하향',      firm: 'NH투자증권',  date: '3.16', desc: 'EV 시장 성장 둔화 우려' },
+              { title: '현대차 글로벌 판매 호조 지속', firm: '한국투자증권', date: '3.15', desc: '북미 SUV 수요 견조' },
+              { title: '삼성바이오 수주 확대 기대',    firm: '미래에셋',    date: '3.14', desc: 'CMO 수주 파이프라인 확대' },
+              { title: 'NAVER 광고 회복세 긍정적',     firm: 'KB증권',      date: '3.13', desc: '디스플레이 광고 반등' },
+            ].map(({ title, firm, date, desc }, i) => (
+              <div key={i} className="border-b border-stroke last:border-0 pb-1.5 last:pb-0">
+                <div className="flex items-start justify-between gap-1">
+                  <span className="text-[10px] font-semibold text-foreground leading-snug">{title}</span>
+                  <span className="text-[8px] text-foreground-disabled shrink-0 mt-0.5">{date}</span>
+                </div>
+                <div className="flex items-center gap-1 mt-0.5">
+                  <span className="text-[8px] text-primary">{firm}</span>
+                  <span className="text-[8px] text-foreground-disabled">· {desc}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+
+    default:
+      return null
+  }
+}
+
+/* ── VariantPreview ─────────────────────────────────────── */
+function VariantPreview({ variant }) {
+  const { colSpan, rowSpan } = variant
+  return (
+    <div
+      className={cn(
+        'w-full border border-stroke rounded-xl p-3 bg-surface flex flex-col overflow-hidden',
+        aspectClass(colSpan, rowSpan),
+      )}
+    >
+      {/* 라벨 + 크기 배지 */}
+      <div className="flex items-center justify-between mb-2 shrink-0">
+        <span className="text-[8px] font-semibold text-foreground-disabled uppercase tracking-[.06em]">
+          {variant.label}
+        </span>
+        <SizeBadge colSpan={colSpan} rowSpan={rowSpan} />
+      </div>
+      {/* 미리보기 */}
+      <div className="flex-1 min-h-0 overflow-hidden">
+        <PreviewContent type={variant.preview} />
+      </div>
+    </div>
+  )
+}
+
+/* ── WidgetSizeList ─────────────────────────────────────── */
+export default function WidgetSizeList({ widgetType, onBack }) {
+  return (
+    <>
+      {/* 헤더 */}
+      <div className="px-4 pt-4 pb-3 border-b border-stroke shrink-0">
+        <button
+          onClick={onBack}
+          className="flex items-center gap-1 text-[12px] text-foreground-tertiary hover:text-primary transition-colors duration-[150ms] mb-3"
+        >
+          <ChevronLeft className="w-3.5 h-3.5" />
+          위젯 목록
+        </button>
+        <div className="text-[14px] font-bold text-foreground">{widgetType.name}</div>
+        <div className="text-[11px] text-foreground-disabled mt-0.5">{widgetType.description}</div>
+      </div>
+
+      {/* 사이즈 variant 목록 — 2열 그리드, 2-col 위젯은 full-width */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-4 py-4">
+        <div className="text-[10px] font-bold text-foreground-disabled uppercase tracking-[.07em] mb-3">
+          크기 선택
+        </div>
+        <div className="flex flex-col gap-3">
+          {widgetType.variants.map((variant) => (
+            <div
+              key={variant.id}
+              className={cn('relative group', widthClass(variant.colSpan))}
+            >
+              <VariantPreview variant={variant} />
+              {/* hover 추가 오버레이 */}
+              <button
+                aria-label={`${variant.label} 추가`}
+                className="absolute inset-0 rounded-xl opacity-0 group-hover:opacity-100 bg-primary/10 border border-primary flex items-center justify-center transition-opacity duration-[150ms]"
+              >
+                <div className="w-7 h-7 rounded-full bg-primary flex items-center justify-center shadow-primary-btn">
+                  <Plus className="w-3.5 h-3.5 text-white" />
+                </div>
+              </button>
+            </div>
+          ))}
+        </div>
+        <p className="text-[10px] text-foreground-disabled mt-4 text-center">
+          클릭하여 대시보드에 추가
+        </p>
+      </div>
+    </>
+  )
+}

--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -242,7 +242,7 @@ function PreviewContent({ type }) {
             <span className="text-[9px] text-foreground-disabled">종목별 비중</span>
             <span className="text-[10px] font-bold text-up">+5.2%</span>
           </div>
-          <div className="flex flex-col gap-1.5">
+          <div className="flex flex-col gap-0.9">
             {[
               { name: '삼성전자',       pct: 34, color: 'bg-chart-1' },
               { name: 'SK하이닉스',     pct: 20, color: 'bg-chart-2' },
@@ -413,9 +413,9 @@ function PreviewContent({ type }) {
             {weekCells.map(({ d, trades }, i) => (
               <div
                 key={i}
-                className={cn('flex flex-col items-start justify-start rounded p-1', trades ? 'bg-primary/10' : 'bg-background/50')}
+                className="flex flex-col items-start justify-start rounded p-1 bg-background/50"
               >
-                <span className={cn('text-[8px] leading-none mb-1', trades ? 'text-primary font-bold' : 'text-foreground')}>{d}</span>
+                <span className="text-[8px] leading-none mb-1 text-foreground">{d}</span>
                 {trades && trades.map((tr, j) => (
                   <div key={j} className="flex items-center gap-0.5 w-full mb-0.5">
                     <div className={cn('w-0.5 rounded-full shrink-0 self-stretch', tr.buy ? 'bg-up' : 'bg-down')} />

--- a/src/components/layout/EditPanel/WidgetTypeList.jsx
+++ b/src/components/layout/EditPanel/WidgetTypeList.jsx
@@ -1,0 +1,99 @@
+import { useState } from 'react'
+import { Search, ChevronRight } from 'lucide-react'
+import { WIDGET_TYPES, WIDGET_CATEGORIES } from '@/mocks/widgets'
+import { cn } from '@/lib/cn'
+
+export default function WidgetTypeList({ onSelectType }) {
+  const [query, setQuery] = useState('')
+  const [activeCategory, setActiveCategory] = useState('전체')
+
+  const filtered = WIDGET_TYPES.filter((w) => {
+    const matchCategory = activeCategory === '전체' || w.category === activeCategory
+    const matchQuery = query === '' || w.name.includes(query) || w.description.includes(query)
+    return matchCategory && matchQuery
+  })
+
+  // 카테고리별 그룹핑 (전체 선택 시 카테고리 헤더 표시)
+  const grouped = activeCategory === '전체'
+    ? WIDGET_CATEGORIES.slice(1).reduce((acc, cat) => {
+        const items = filtered.filter((w) => w.category === cat)
+        if (items.length) acc.push({ cat, items })
+        return acc
+      }, [])
+    : [{ cat: activeCategory, items: filtered }]
+
+  return (
+    <>
+      {/* 헤더 */}
+      <div className="px-4 pt-4 pb-3 border-b border-stroke shrink-0">
+        <div className="flex items-center justify-between mb-3">
+          <span className="text-[14px] font-bold text-foreground">위젯 추가</span>
+          <span className="text-[10px] text-foreground-disabled bg-surface-muted px-2 py-0.5 rounded-full">
+            9개 배치 중
+          </span>
+        </div>
+        {/* 검색 */}
+        <div className="flex items-center gap-2 bg-background border border-stroke rounded-xl px-3 py-2">
+          <Search className="w-3.5 h-3.5 text-foreground-disabled shrink-0" />
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="위젯 검색…"
+            className="flex-1 text-[12px] text-foreground placeholder:text-foreground-disabled bg-transparent outline-none"
+          />
+        </div>
+        {/* 카테고리 필터 */}
+        <div className="flex gap-1.5 mt-2.5 flex-wrap">
+          {WIDGET_CATEGORIES.map((cat) => (
+            <button
+              key={cat}
+              onClick={() => setActiveCategory(cat)}
+              className={cn(
+                'px-2.5 py-[3px] rounded-full text-[10px] font-semibold transition-colors duration-[150ms]',
+                activeCategory === cat
+                  ? 'bg-primary-light text-primary'
+                  : 'border border-stroke-input bg-surface text-foreground-tertiary hover:border-primary hover:text-primary',
+              )}
+            >
+              {cat}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* 위젯 타입 목록 */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-4 py-3 flex flex-col gap-4">
+        {grouped.map(({ cat, items }) => (
+          <div key={cat}>
+            <div className="text-[10px] font-bold text-foreground-disabled uppercase tracking-[.07em] mb-2">
+              {cat}
+            </div>
+            <div className="flex flex-col gap-1.5">
+              {items.map((widget) => (
+                <button
+                  key={widget.id}
+                  onClick={() => onSelectType(widget)}
+                  className="flex items-center gap-3 px-3 py-2.5 rounded-xl border border-stroke bg-surface hover:border-primary hover:bg-primary-light transition-all duration-[150ms] text-left group"
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="text-[12px] font-semibold text-foreground group-hover:text-primary transition-colors duration-[150ms]">
+                      {widget.name}
+                    </div>
+                    <div className="text-[10px] text-foreground-disabled mt-0.5">{widget.description}</div>
+                  </div>
+                  <ChevronRight className="w-3.5 h-3.5 text-foreground-disabled group-hover:text-primary shrink-0 transition-colors duration-[150ms]" />
+                </button>
+              ))}
+            </div>
+          </div>
+        ))}
+        {grouped.length === 0 && (
+          <div className="flex items-center justify-center h-24 text-[12px] text-foreground-disabled">
+            검색 결과가 없습니다
+          </div>
+        )}
+      </div>
+    </>
+  )
+}

--- a/src/components/layout/EditPanel/index.jsx
+++ b/src/components/layout/EditPanel/index.jsx
@@ -1,0 +1,20 @@
+import { useState } from 'react'
+import WidgetTypeList from './WidgetTypeList'
+import WidgetSizeList from './WidgetSizeList'
+
+export default function EditPanel() {
+  const [selectedType, setSelectedType] = useState(null)
+
+  return (
+    <aside className="w-chat-panel flex flex-col bg-surface border-l border-stroke shrink-0 overflow-hidden">
+      {selectedType ? (
+        <WidgetSizeList
+          widgetType={selectedType}
+          onBack={() => setSelectedType(null)}
+        />
+      ) : (
+        <WidgetTypeList onSelectType={setSelectedType} />
+      )}
+    </aside>
+  )
+}

--- a/src/components/layout/NavTabs.jsx
+++ b/src/components/layout/NavTabs.jsx
@@ -1,4 +1,5 @@
 import { useNavigate, useLocation } from 'react-router-dom'
+import { cn } from '@/lib/cn'
 
 const TABS = [
   { label: '홈',  path: '/' },
@@ -10,6 +11,7 @@ const TABS = [
 export default function NavTabs() {
   const navigate = useNavigate()
   const { pathname } = useLocation()
+  
 
   const isActive = (path) =>
     path === '/' ? pathname === '/' : pathname.startsWith(path)
@@ -20,12 +22,12 @@ export default function NavTabs() {
         <button
           key={path}
           onClick={() => navigate(path)}
-          className={[
+          className={cn(
             'px-4 py-1.5 text-[12px] rounded-lg transition-colors duration-[150ms]',
             isActive(path)
               ? 'bg-surface text-foreground font-semibold shadow-sm'
               : 'text-foreground-disabled hover:text-foreground-secondary',
-          ].join(' ')}
+          )}
         >
           {label}
         </button>

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,5 +1,6 @@
 import { LayoutGrid, TrendingUp, ArrowLeftRight, Wallet } from 'lucide-react'
 import { useNavigate, useLocation } from 'react-router-dom'
+import { cn } from '@/lib/cn'
 
 const ITEMS = [
   { icon: LayoutGrid,     path: '/',       label: '홈' },
@@ -22,12 +23,12 @@ export default function Sidebar() {
           key={path}
           onClick={() => navigate(path)}
           title={label}
-          className={[
+          className={cn(
             'w-9 h-9 flex items-center justify-center rounded-xl transition-colors duration-[150ms]',
             isActive(path)
               ? 'bg-primary-light text-primary'
               : 'text-foreground-disabled hover:text-foreground-secondary hover:bg-background',
-          ].join(' ')}
+          )}
         >
           <Icon className="w-[18px] h-[18px]" strokeWidth={isActive(path) ? 2.5 : 2} />
         </button>

--- a/src/components/ui/FilterChip.jsx
+++ b/src/components/ui/FilterChip.jsx
@@ -1,3 +1,5 @@
+import { cn } from '@/lib/cn'
+
 /**
  * 필터 선택 칩 (전체 / 국내 / 미국 등)
  *
@@ -10,13 +12,13 @@ export default function FilterChip({ isActive, onClick, children, className = ''
   return (
     <button
       onClick={onClick}
-      className={[
+      className={cn(
         'px-3 py-1 rounded-[20px] text-[11px] font-semibold whitespace-nowrap transition-colors duration-[120ms]',
         isActive
           ? 'bg-primary text-white'
           : 'bg-surface-muted text-foreground-tertiary hover:bg-stroke-input',
         className,
-      ].join(' ')}
+      )}
     >
       {children}
     </button>

--- a/src/components/ui/PeriodChip.jsx
+++ b/src/components/ui/PeriodChip.jsx
@@ -1,3 +1,5 @@
+import { cn } from '@/lib/cn'
+
 /**
  * 기간 선택 칩 (1일 / 1주 / 1달 등)
  *
@@ -10,13 +12,13 @@ export default function PeriodChip({ isActive, onClick, children, className = ''
   return (
     <button
       onClick={onClick}
-      className={[
+      className={cn(
         'px-2.5 py-1 rounded-md text-[10px] font-semibold transition-colors duration-[120ms]',
         isActive
           ? 'bg-foreground text-white'
           : 'bg-transparent text-foreground-disabled hover:text-foreground-secondary',
         className,
-      ].join(' ')}
+      )}
     >
       {children}
     </button>

--- a/src/components/ui/TabChip.jsx
+++ b/src/components/ui/TabChip.jsx
@@ -1,3 +1,5 @@
+import { cn } from '@/lib/cn'
+
 /**
  * 위젯 내 소형 탭 칩 (DESIGN.md §8 TabChip)
  *
@@ -8,12 +10,12 @@ export default function TabChip({ children, isActive = false, onClick }) {
   return (
     <button
       onClick={onClick}
-      className={[
+      className={cn(
         'px-[9px] py-[3px] text-[10px] font-semibold rounded-[6px] border-none cursor-pointer transition-colors duration-[150ms]',
         isActive
           ? 'bg-primary-light text-primary'
           : 'bg-transparent text-foreground-disabled hover:bg-surface-muted hover:text-foreground-secondary',
-      ].join(' ')}
+      )}
     >
       {children}
     </button>

--- a/src/components/widgets/EditHandle.jsx
+++ b/src/components/widgets/EditHandle.jsx
@@ -1,0 +1,11 @@
+export default function EditHandle({ onDelete }) {
+  return (
+    <button
+      aria-label="위젯 삭제"
+      onClick={(e) => { e.stopPropagation(); onDelete?.() }}
+      className="absolute -top-2 -left-2 z-20 w-[22px] h-[22px] rounded-full bg-danger border-2 border-surface text-white text-[14px] font-bold leading-none flex items-center justify-center shadow-delete-btn hover:opacity-85 transition-opacity duration-[150ms]"
+    >
+      −
+    </button>
+  )
+}

--- a/src/components/widgets/IndexWidget.jsx
+++ b/src/components/widgets/IndexWidget.jsx
@@ -3,6 +3,7 @@ import PriceChange from '@/components/ui/PriceChange'
 import TabChip from '@/components/ui/TabChip'
 import WidgetCard from './WidgetCard'
 import { HOME_INDICES } from '@/mocks/home'
+import { cn } from '@/lib/cn'
 
 const TABS = ['국내', '미국', '아시아']
 
@@ -29,10 +30,10 @@ export default function IndexWidget() {
         {HOME_INDICES.map((idx) => (
           <div
             key={idx.key}
-            className={[
+            className={cn(
               'text-center py-2 rounded-xl border',
               idx.change > 0 ? 'bg-up-bg border-up-border' : 'bg-down-bg border-down-border',
-            ].join(' ')}
+            )}
           >
             <div className="text-[9px] text-foreground-disabled mb-0.5">{idx.label}</div>
             <div className="text-[13px] font-bold text-foreground">{idx.value}</div>

--- a/src/components/widgets/RankingWidget.jsx
+++ b/src/components/widgets/RankingWidget.jsx
@@ -26,7 +26,7 @@ export default function RankingWidget() {
           ))}
         </div>
       </div>
-      <div className="flex-1 flex flex-col justify-between gap-0.5">
+      <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-0.5">
         {RANKING.map((stock) => (
           <div
             key={stock.rank}

--- a/src/components/widgets/WidgetCard.jsx
+++ b/src/components/widgets/WidgetCard.jsx
@@ -1,16 +1,33 @@
-export default function WidgetCard({ children, colSpan = 1, className = '' }) {
+import useEditModeStore from '@/store/useEditModeStore'
+import EditHandle from './EditHandle'
+
+export default function WidgetCard({ children, colSpan = 1, className = '', onDelete }) {
+  const { isEditMode } = useEditModeStore()
+
   return (
     <div
       className={[
-        'bg-surface border border-stroke rounded-2xl p-[14px_16px]',
-        'flex flex-col overflow-hidden cursor-pointer',
-        'transition-[border-color,box-shadow,transform] duration-[200ms]',
-        'hover:border-widget-border-hover hover:shadow-widget-hover hover:-translate-y-px',
+        'relative',
+        isEditMode
+          ? 'animate-wiggle cursor-grab'
+          : 'cursor-pointer transition-[transform] duration-[200ms] hover:-translate-y-px',
         colSpan === 2 ? 'col-span-2' : 'col-span-1',
         className,
       ].join(' ')}
     >
-      {children}
+      {isEditMode && <EditHandle onDelete={onDelete} />}
+      {/* 콘텐츠 클리핑 래퍼 — 핸들은 relative 부모 기준으로 바깥에 위치 */}
+      <div
+        className={[
+          'h-full bg-surface border rounded-2xl p-[14px_16px]',
+          'flex flex-col overflow-hidden',
+          isEditMode
+            ? 'border-stroke-input shadow-widget-edit'
+            : 'border-stroke transition-[border-color,box-shadow] duration-[200ms] hover:border-widget-border-hover hover:shadow-widget-hover',
+        ].join(' ')}
+      >
+        {children}
+      </div>
     </div>
   )
 }

--- a/src/components/widgets/WidgetCard.jsx
+++ b/src/components/widgets/WidgetCard.jsx
@@ -1,30 +1,31 @@
 import useEditModeStore from '@/store/useEditModeStore'
 import EditHandle from './EditHandle'
+import { cn } from '@/lib/cn'
 
 export default function WidgetCard({ children, colSpan = 1, className = '', onDelete }) {
   const { isEditMode } = useEditModeStore()
 
   return (
     <div
-      className={[
+      className={cn(
         'relative',
         isEditMode
           ? 'animate-wiggle cursor-grab'
           : 'cursor-pointer transition-[transform] duration-[200ms] hover:-translate-y-px',
         colSpan === 2 ? 'col-span-2' : 'col-span-1',
         className,
-      ].join(' ')}
+      )}
     >
       {isEditMode && <EditHandle onDelete={onDelete} />}
       {/* 콘텐츠 클리핑 래퍼 — 핸들은 relative 부모 기준으로 바깥에 위치 */}
       <div
-        className={[
+        className={cn(
           'h-full bg-surface border rounded-2xl p-[14px_16px]',
           'flex flex-col overflow-hidden',
           isEditMode
             ? 'border-stroke-input shadow-widget-edit'
             : 'border-stroke transition-[border-color,box-shadow] duration-[200ms] hover:border-widget-border-hover hover:shadow-widget-hover',
-        ].join(' ')}
+        )}
       >
         {children}
       </div>

--- a/src/lib/cn.js
+++ b/src/lib/cn.js
@@ -1,0 +1,6 @@
+import { clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs) {
+  return twMerge(clsx(inputs))
+}

--- a/src/mocks/widgets.js
+++ b/src/mocks/widgets.js
@@ -116,4 +116,4 @@ export const WIDGET_TYPES = [
   },
 ]
 
-export const WIDGET_CATEGORIES = ['전체', '계좌', '시세', '포트폴리오', '기타']
+export const WIDGET_CATEGORIES = ['전체', ...new Set(WIDGET_TYPES.map((w) => w.category))]

--- a/src/mocks/widgets.js
+++ b/src/mocks/widgets.js
@@ -1,0 +1,119 @@
+/**
+ * 위젯 편집 피커용 위젯 타입 & 사이즈 정의
+ * colSpan: 1 | 2  (그리드 열 수)
+ * rowSpan: 1 | 2  (그리드 행 수)
+ * preview: 프리뷰 렌더러 키 (WidgetSizeList의 PreviewContent에서 switch)
+ */
+export const WIDGET_TYPES = [
+  {
+    id: 'balance',
+    name: '계좌 잔고',
+    category: '계좌',
+    description: '총 평가자산 · 수익률',
+    variants: [
+      { id: 'balance-sm',  label: '소형',  colSpan: 1, rowSpan: 1, preview: 'balance-sm' },
+      { id: 'balance-lg',  label: '와이드', colSpan: 2, rowSpan: 1, preview: 'balance-lg' },
+      { id: 'balance-2x2', label: '대형',  colSpan: 2, rowSpan: 2, preview: 'balance-2x2' },
+    ],
+  },
+  {
+    id: 'stock-chart',
+    name: '주가 / 차트',
+    category: '시세',
+    description: '종목 현재가 · 미니 차트',
+    variants: [
+      { id: 'stock-sm',   label: '카드형',    colSpan: 1, rowSpan: 1, preview: 'stock-sm' },
+      { id: 'stock-tall', label: '차트형',    colSpan: 1, rowSpan: 1, preview: 'stock-tall' },
+      { id: 'stock-2x2',  label: '대형 차트', colSpan: 2, rowSpan: 2, preview: 'stock-2x2' },
+    ],
+  },
+  {
+    id: 'ranking',
+    name: '실시간 순위',
+    category: '시세',
+    description: '거래대금 · 상승률 · 거래량',
+    variants: [
+      { id: 'ranking-wide', label: '목록형', colSpan: 2, rowSpan: 1, preview: 'ranking-wide' },
+      { id: 'ranking-lg',   label: '확장형', colSpan: 2, rowSpan: 2, preview: 'ranking-lg' },
+    ],
+  },
+  {
+    id: 'index',
+    name: '주요 지수',
+    category: '시세',
+    description: 'KOSPI · KOSDAQ · NASDAQ',
+    variants: [
+      { id: 'index-sm',   label: '단일', colSpan: 1, rowSpan: 1, preview: 'index-sm' },
+      { id: 'index-wide', label: '복합', colSpan: 2, rowSpan: 1, preview: 'index-wide' },
+      { id: 'index-2x2',  label: '대형', colSpan: 2, rowSpan: 2, preview: 'index-2x2' },
+    ],
+  },
+  {
+    id: 'portfolio',
+    name: '포트폴리오',
+    category: '포트폴리오',
+    description: '보유 종목 비중 파이차트',
+    variants: [
+      { id: 'portfolio-sm',   label: '파이차트', colSpan: 1, rowSpan: 1, preview: 'portfolio-sm' },
+      { id: 'portfolio-wide', label: '상세',     colSpan: 2, rowSpan: 1, preview: 'portfolio-wide' },
+      { id: 'portfolio-2x2',  label: '대형',     colSpan: 2, rowSpan: 2, preview: 'portfolio-2x2' },
+    ],
+  },
+  {
+    id: 'exchange',
+    name: '환율',
+    category: '기타',
+    description: 'USD · JPY 실시간 환율',
+    variants: [
+      { id: 'exchange-sm',   label: '단일', colSpan: 1, rowSpan: 1, preview: 'exchange-sm' },
+      { id: 'exchange-wide', label: '복합', colSpan: 2, rowSpan: 1, preview: 'exchange-wide' },
+      { id: 'exchange-2x2',  label: '대형', colSpan: 2, rowSpan: 2, preview: 'exchange-2x2' },
+    ],
+  },
+  {
+    id: 'market-overview',
+    name: '오늘의 시황',
+    category: '기타',
+    description: '주요 시황 뉴스 헤드라인',
+    variants: [
+      { id: 'market-sm',   label: '헤드라인', colSpan: 1, rowSpan: 1, preview: 'market-sm' },
+      { id: 'market-wide', label: '상세',     colSpan: 2, rowSpan: 1, preview: 'market-wide' },
+      { id: 'market-2x2',  label: '대형',     colSpan: 2, rowSpan: 2, preview: 'market-2x2' },
+    ],
+  },
+  {
+    id: 'watchlist',
+    name: '관심종목',
+    category: '기타',
+    description: '등록된 관심 종목 리스트',
+    variants: [
+      { id: 'watchlist-sm',   label: '컴팩트', colSpan: 1, rowSpan: 1, preview: 'watchlist-sm' },
+      { id: 'watchlist-wide', label: '목록형', colSpan: 2, rowSpan: 1, preview: 'watchlist-wide' },
+      { id: 'watchlist-2x2',  label: '대형',   colSpan: 2, rowSpan: 2, preview: 'watchlist-2x2' },
+    ],
+  },
+  {
+    id: 'trade-history',
+    name: '거래내역',
+    category: '기타',
+    description: '달력 · 리스트 뷰',
+    variants: [
+      { id: 'trade-list', label: '목록형', colSpan: 1, rowSpan: 1, preview: 'trade-list' },
+      { id: 'trade-wide', label: '주간',   colSpan: 2, rowSpan: 1, preview: 'trade-wide' },
+      { id: 'trade-cal',  label: '캘린더', colSpan: 2, rowSpan: 2, preview: 'trade-cal' },
+    ],
+  },
+  {
+    id: 'report',
+    name: '증권사 리포트',
+    category: '기타',
+    description: '최신 증권사 리포트 목록',
+    variants: [
+      { id: 'report-sm',   label: '단일',   colSpan: 1, rowSpan: 1, preview: 'report-sm' },
+      { id: 'report-wide', label: '목록형', colSpan: 2, rowSpan: 1, preview: 'report-wide' },
+      { id: 'report-2x2',  label: '대형',   colSpan: 2, rowSpan: 2, preview: 'report-2x2' },
+    ],
+  },
+]
+
+export const WIDGET_CATEGORIES = ['전체', '계좌', '시세', '포트폴리오', '기타']

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,6 +1,7 @@
 import { Pencil } from 'lucide-react'
 import LiveDot from '@/components/ui/LiveDot'
 import useEditModeStore from '@/store/useEditModeStore'
+import { cn } from '@/lib/cn'
 import BalanceWidget from '@/components/widgets/BalanceWidget'
 import IndexWidget from '@/components/widgets/IndexWidget'
 import PortfolioWidget from '@/components/widgets/PortfolioWidget'
@@ -52,10 +53,10 @@ export default function HomePage() {
       </div>
 
       {/* 위젯 그리드: 4열 × 3행 */}
-      <div className={[
+      <div className={cn(
         'grid grid-cols-4 grid-rows-3 gap-[10px] flex-1 min-h-0',
         isEditMode ? 'overflow-visible' : 'overflow-hidden',
-      ].join(' ')}>
+      )}>
         {/* Row 1 */}
         <BalanceWidget />
         <IndexWidget />

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,4 +1,6 @@
+import { Pencil } from 'lucide-react'
 import LiveDot from '@/components/ui/LiveDot'
+import useEditModeStore from '@/store/useEditModeStore'
 import BalanceWidget from '@/components/widgets/BalanceWidget'
 import IndexWidget from '@/components/widgets/IndexWidget'
 import PortfolioWidget from '@/components/widgets/PortfolioWidget'
@@ -11,17 +13,42 @@ import AddWidgetSlot from '@/components/widgets/AddWidgetSlot'
 import { HOME_STOCKS } from '@/mocks/home'
 
 export default function HomePage() {
+  const { isEditMode } = useEditModeStore()
+
   return (
     <div className="flex flex-col h-full overflow-hidden p-3 gap-2.5">
       {/* 서브바 */}
       <div className="flex items-center justify-between shrink-0 px-1">
         <div className="flex items-center gap-2">
           <span className="text-[13px] font-bold text-foreground">나의 대시보드</span>
-          <div className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-background border border-stroke">
-            <LiveDot size="sm" />
-            <span className="text-[10px] text-foreground-disabled">실시간 반영</span>
-          </div>
+          {isEditMode ? (
+            <div className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-primary-light border border-primary-border">
+              <Pencil className="w-2.5 h-2.5 text-primary" strokeWidth={2.5} />
+              <span className="text-[10px] text-primary font-semibold">편집 중</span>
+            </div>
+          ) : (
+            <div className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-background border border-stroke">
+              <LiveDot size="sm" />
+              <span className="text-[10px] text-foreground-disabled">실시간 반영</span>
+            </div>
+          )}
         </div>
+        {isEditMode && (
+          <div className="flex items-center gap-2">
+            {/* 페이지 인디케이터 */}
+            <div className="flex items-center gap-1.5">
+              <div className="w-4 h-1.5 rounded-full bg-primary" />
+              <div className="w-1.5 h-1.5 rounded-full bg-stroke-input" />
+              <div className="w-1.5 h-1.5 rounded-full bg-stroke-input" />
+            </div>
+            <button className="flex items-center gap-1 px-2.5 py-1 rounded-lg border border-stroke-input bg-surface text-foreground-tertiary text-[11px] font-medium hover:border-primary hover:text-primary hover:bg-primary-light transition-all duration-[150ms]">
+              <svg className="w-[11px] h-[11px]" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h7" />
+              </svg>
+              페이지 편집
+            </button>
+          </div>
+        )}
       </div>
 
       {/* 위젯 그리드: 4열 × 3행 */}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -52,7 +52,10 @@ export default function HomePage() {
       </div>
 
       {/* 위젯 그리드: 4열 × 3행 */}
-      <div className="grid grid-cols-4 grid-rows-3 gap-[10px] flex-1 min-h-0">
+      <div className={[
+        'grid grid-cols-4 grid-rows-3 gap-[10px] flex-1 min-h-0',
+        isEditMode ? 'overflow-visible' : 'overflow-hidden',
+      ].join(' ')}>
         {/* Row 1 */}
         <BalanceWidget />
         <IndexWidget />
@@ -67,7 +70,7 @@ export default function HomePage() {
         <MarketOverviewWidget />
         <ExchangeWidget />
         <StockChartWidget stock={HOME_STOCKS[1]} />
-        <AddWidgetSlot />
+        {!isEditMode && <AddWidgetSlot />}
       </div>
     </div>
   )

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -18,7 +18,7 @@ export default function HomePage() {
   return (
     <div className="flex flex-col h-full overflow-hidden p-3 gap-2.5">
       {/* 서브바 */}
-      <div className="flex items-center justify-between shrink-0 px-1">
+      <div className="flex items-center justify-between shrink-0 px-1 h-7">
         <div className="flex items-center gap-2">
           <span className="text-[13px] font-bold text-foreground">나의 대시보드</span>
           {isEditMode ? (

--- a/src/store/useEditModeStore.js
+++ b/src/store/useEditModeStore.js
@@ -1,0 +1,10 @@
+import { create } from 'zustand'
+
+const useEditModeStore = create((set) => ({
+  isEditMode: false,
+  enterEditMode: () => set({ isEditMode: true }),
+  exitEditMode: () => set({ isEditMode: false }),
+  saveLayout: () => set({ isEditMode: false }),
+}))
+
+export default useEditModeStore


### PR DESCRIPTION
## Summary

- EditPanel 2단계 플로우 구현 (위젯 타입 선택 → 사이즈 선택)
- 10종 위젯 × 29개 variant 미리보기 콘텐츠 구현 (정확한 비율 반영)
- 편집 모드 진입 시 레이아웃 밀림 및 overflow 이슈 수정
- `cn()` 유틸 도입, `WIDGET_CATEGORIES` 데이터 기반 파생으로 확장성 개선

Closes #25

## Test plan

- [ ] EditPanel 열기 → 10종 위젯 타입 목록 확인
- [ ] 카테고리 필터 및 검색 동작 확인
- [ ] 각 위젯 선택 후 사이즈 선택 화면 진입 확인
- [ ] 29개 variant 미리보기 비율 및 콘텐츠 확인
- [ ] 위젯 hover 시 추가 오버레이 표시 확인
- [ ] 편집 모드 진입/해제 시 서브바 레이아웃 밀림 없는지 확인