### PR TITLE
fix(home): EditPanel 위젯 미리보기 비율을 실제 대시보드 셀 비율과 동기화

### DIFF
--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -1,25 +1,32 @@
 import { ChevronLeft, Plus } from 'lucide-react'
 import { cn } from '@/lib/cn'
+import useGridStore from '@/store/useGridStore'
+import { MIN_CELL_WIDTH, MIN_CELL_HEIGHT, GRID_GAP } from '@/lib/gridConstants'
 
-/* ── 비율 계산 ──────────────────────────────────────────────
-   패널 폭 = 2열 기준.
-   너비: colSpan=1 → w-1/2,  colSpan=2 → w-full
-   비율: 실제 대시보드 셀 비율 그대로
-     1×1 → aspect-square
-     2×1 → aspect-[2/1]
-     1×2 → aspect-[1/2] (현재 실제 사용하지는 x)
-     2×2 → aspect-square
+/* ── 너비 클래스 ─────────────────────────────────────────────
+   패널 usable width = 2열 기준 (336px).
+   colSpan=1 → w-1/2,  colSpan=2 → w-full
 ─────────────────────────────────────────────────────────── */
 function widthClass(colSpan) {
   return colSpan === 2 ? 'w-full' : 'w-1/2'
 }
 
-function aspectClass(colSpan, rowSpan) {
-  if (colSpan === 1 && rowSpan === 2) return 'aspect-[1/2]'
-  if (colSpan === 2 && rowSpan === 1) return 'aspect-[2/1]'
-  if (colSpan === 2 && rowSpan === 2) return 'aspect-square'
-  return 'aspect-square' // 1×1
+/* ── 실제 대시보드 셀 크기 기반 aspect-ratio 계산 ─────────────
+   cellWidth/cellHeight: ResizeObserver로 측정한 실제 셀 크기
+   0이면 아직 측정 전 → MIN_CELL 기준 폴백
+   반환값: 숫자 (w/h 비율)
+─────────────────────────────────────────────────────────── */
+function calcAspectRatio(colSpan, rowSpan, cellWidth, cellHeight, gap) {
+  const cw = cellWidth || MIN_CELL_WIDTH
+  const ch = cellHeight || MIN_CELL_HEIGHT
+  const g = gap ?? GRID_GAP
+  const w = colSpan * cw + (colSpan - 1) * g
+  const h = rowSpan * ch + (rowSpan - 1) * g
+  return w / h
 }
+
+// EditPanel 패널 usable width (w-chat-panel 368px - px-4*2 32px)
+const PANEL_USABLE_WIDTH = 336
 
 function SizeBadge({ colSpan, rowSpan }) {
   return (
@@ -783,12 +790,20 @@ function PreviewContent({ type }) {
 /* ── VariantPreview ─────────────────────────────────────── */
 function VariantPreview({ variant }) {
   const { colSpan, rowSpan } = variant
+  const { cellWidth, cellHeight, gap } = useGridStore()
+
+  // 실제 대시보드 비율 (숫자)
+  const ratio = calcAspectRatio(colSpan, rowSpan, cellWidth, cellHeight, gap)
+
+  // 최솟값 기준 minHeight — 대시보드가 최소 크기일 때 preview content가 잘리지 않는 하한
+  const previewWidth = colSpan === 2 ? PANEL_USABLE_WIDTH : PANEL_USABLE_WIDTH / 2
+  const minRatio = calcAspectRatio(colSpan, rowSpan, MIN_CELL_WIDTH, MIN_CELL_HEIGHT, GRID_GAP)
+  const minHeight = previewWidth / minRatio
+
   return (
     <div
-      className={cn(
-        'w-full border border-stroke rounded-xl p-3 bg-surface flex flex-col overflow-hidden',
-        aspectClass(colSpan, rowSpan),
-      )}
+      className="w-full border border-stroke rounded-xl p-3 bg-surface flex flex-col overflow-hidden"
+      style={{ aspectRatio: ratio, minHeight: `${minHeight}px` }}
     >
       {/* 라벨 + 크기 배지 */}
       <div className="flex items-center justify-between mb-2 shrink-0">

--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -14,14 +14,14 @@ function widthClass(colSpan) {
 /* ── 실제 대시보드 셀 크기 기반 aspect-ratio 계산 ─────────────
    cellWidth/cellHeight: ResizeObserver로 측정한 실제 셀 크기
    0이면 아직 측정 전 → MIN_CELL 기준 폴백
+   gap은 변하지 않는 상수(GRID_GAP)를 직접 사용
    반환값: 숫자 (w/h 비율)
 ─────────────────────────────────────────────────────────── */
-function calcAspectRatio(colSpan, rowSpan, cellWidth, cellHeight, gap) {
+function calcAspectRatio(colSpan, rowSpan, cellWidth, cellHeight) {
   const cw = cellWidth || MIN_CELL_WIDTH
   const ch = cellHeight || MIN_CELL_HEIGHT
-  const g = gap ?? GRID_GAP
-  const w = colSpan * cw + (colSpan - 1) * g
-  const h = rowSpan * ch + (rowSpan - 1) * g
+  const w = colSpan * cw + (colSpan - 1) * GRID_GAP
+  const h = rowSpan * ch + (rowSpan - 1) * GRID_GAP
   return w / h
 }
 
@@ -790,14 +790,15 @@ function PreviewContent({ type }) {
 /* ── VariantPreview ─────────────────────────────────────── */
 function VariantPreview({ variant }) {
   const { colSpan, rowSpan } = variant
-  const { cellWidth, cellHeight, gap } = useGridStore()
+  const { cellWidth, cellHeight } = useGridStore()
 
-  // 실제 대시보드 비율 (숫자)
-  const ratio = calcAspectRatio(colSpan, rowSpan, cellWidth, cellHeight, gap)
+  // 실제 대시보드 비율 (숫자) — ResizeObserver 측정값 기반
+  const ratio = calcAspectRatio(colSpan, rowSpan, cellWidth, cellHeight)
 
-  // 최솟값 기준 minHeight — 대시보드가 최소 크기일 때 preview content가 잘리지 않는 하한
+  // 최솟값 기준 minHeight — 대시보드가 MIN 크기일 때 preview content가 잘리지 않는 하한
+  // previewWidth: colSpan=1 → 패널 절반(168px), colSpan=2 → 패널 전체(336px)
   const previewWidth = colSpan === 2 ? PANEL_USABLE_WIDTH : PANEL_USABLE_WIDTH / 2
-  const minRatio = calcAspectRatio(colSpan, rowSpan, MIN_CELL_WIDTH, MIN_CELL_HEIGHT, GRID_GAP)
+  const minRatio = calcAspectRatio(colSpan, rowSpan, MIN_CELL_WIDTH, MIN_CELL_HEIGHT)
   const minHeight = previewWidth / minRatio
 
   return (

--- a/src/lib/gridConstants.js
+++ b/src/lib/gridConstants.js
@@ -1,0 +1,10 @@
+export const GRID_COLS = 4
+export const GRID_ROWS = 3
+export const GRID_GAP = 10
+
+// 위젯 내부 콘텐츠가 overflow 나지 않는 최소 셀 크기
+export const MIN_CELL_WIDTH = 160
+export const MIN_CELL_HEIGHT = 150
+
+export const MIN_GRID_WIDTH = MIN_CELL_WIDTH * GRID_COLS + GRID_GAP * (GRID_COLS - 1)
+export const MIN_GRID_HEIGHT = MIN_CELL_HEIGHT * GRID_ROWS + GRID_GAP * (GRID_ROWS - 1)

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,6 +1,8 @@
+import { useEffect, useRef } from 'react'
 import { Pencil } from 'lucide-react'
 import LiveDot from '@/components/ui/LiveDot'
 import useEditModeStore from '@/store/useEditModeStore'
+import useGridStore from '@/store/useGridStore'
 import { cn } from '@/lib/cn'
 import BalanceWidget from '@/components/widgets/BalanceWidget'
 import IndexWidget from '@/components/widgets/IndexWidget'
@@ -12,9 +14,27 @@ import MarketOverviewWidget from '@/components/widgets/MarketOverviewWidget'
 import ExchangeWidget from '@/components/widgets/ExchangeWidget'
 import AddWidgetSlot from '@/components/widgets/AddWidgetSlot'
 import { HOME_STOCKS } from '@/mocks/home'
+import { GRID_COLS, GRID_ROWS, GRID_GAP, MIN_GRID_WIDTH, MIN_GRID_HEIGHT } from '@/lib/gridConstants'
 
 export default function HomePage() {
   const { isEditMode } = useEditModeStore()
+  const { setCellSize } = useGridStore()
+  const gridRef = useRef(null)
+
+  useEffect(() => {
+    const el = gridRef.current
+    if (!el) return
+
+    const observer = new ResizeObserver(([entry]) => {
+      const { width, height } = entry.contentRect
+      const cellWidth = (width - GRID_GAP * (GRID_COLS - 1)) / GRID_COLS
+      const cellHeight = (height - GRID_GAP * (GRID_ROWS - 1)) / GRID_ROWS
+      setCellSize(cellWidth, cellHeight)
+    })
+
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [setCellSize])
 
   return (
     <div className="flex flex-col h-full overflow-hidden p-3 gap-2.5">
@@ -52,26 +72,36 @@ export default function HomePage() {
         )}
       </div>
 
-      {/* 위젯 그리드: 4열 × 3행 */}
+      {/* 스크롤 래퍼: 최솟값 이하로 줄어들면 스크롤 */}
       <div className={cn(
-        'grid grid-cols-4 grid-rows-3 gap-[10px] flex-1 min-h-0',
-        isEditMode ? 'overflow-visible' : 'overflow-hidden',
+        'flex-1 min-h-0',
+        isEditMode ? 'overflow-visible' : 'overflow-auto',
       )}>
-        {/* Row 1 */}
-        <BalanceWidget />
-        <IndexWidget />
-        <PortfolioWidget />
+        {/* 위젯 그리드: 4열 × 3행, 뷰포트 채움 / 최솟값 이하면 고정 */}
+        <div
+          ref={gridRef}
+          className="grid grid-cols-4 grid-rows-3 gap-[10px] w-full h-full"
+          style={{
+            minWidth: `${MIN_GRID_WIDTH}px`,
+            minHeight: `${MIN_GRID_HEIGHT}px`,
+          }}
+        >
+          {/* Row 1 */}
+          <BalanceWidget />
+          <IndexWidget />
+          <PortfolioWidget />
 
-        {/* Row 2 */}
-        <StockChartWidget stock={HOME_STOCKS[0]} />
-        <RankingWidget />
-        <WatchlistWidget />
+          {/* Row 2 */}
+          <StockChartWidget stock={HOME_STOCKS[0]} />
+          <RankingWidget />
+          <WatchlistWidget />
 
-        {/* Row 3 */}
-        <MarketOverviewWidget />
-        <ExchangeWidget />
-        <StockChartWidget stock={HOME_STOCKS[1]} />
-        {!isEditMode && <AddWidgetSlot />}
+          {/* Row 3 */}
+          <MarketOverviewWidget />
+          <ExchangeWidget />
+          <StockChartWidget stock={HOME_STOCKS[1]} />
+          {!isEditMode && <AddWidgetSlot />}
+        </div>
       </div>
     </div>
   )

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -14,7 +14,7 @@ import MarketOverviewWidget from '@/components/widgets/MarketOverviewWidget'
 import ExchangeWidget from '@/components/widgets/ExchangeWidget'
 import AddWidgetSlot from '@/components/widgets/AddWidgetSlot'
 import { HOME_STOCKS } from '@/mocks/home'
-import { GRID_COLS, GRID_ROWS, GRID_GAP, MIN_GRID_WIDTH, MIN_GRID_HEIGHT } from '@/lib/gridConstants'
+import { GRID_COLS, GRID_ROWS, GRID_GAP, MIN_GRID_WIDTH, MIN_GRID_HEIGHT, MIN_CELL_WIDTH, MIN_CELL_HEIGHT } from '@/lib/gridConstants'
 
 export default function HomePage() {
   const { isEditMode } = useEditModeStore()
@@ -24,6 +24,9 @@ export default function HomePage() {
   useEffect(() => {
     const el = gridRef.current
     if (!el) return
+
+    // ResizeObserver 콜백은 비동기 → 초기값을 MIN으로 설정해 측정 전 공백 방지
+    setCellSize(MIN_CELL_WIDTH, MIN_CELL_HEIGHT)
 
     const observer = new ResizeObserver(([entry]) => {
       const { width, height } = entry.contentRect

--- a/src/store/useGridStore.js
+++ b/src/store/useGridStore.js
@@ -3,7 +3,6 @@ import { create } from 'zustand'
 const useGridStore = create((set) => ({
   cellWidth: 0,
   cellHeight: 0,
-  gap: 10,
   setCellSize: (cellWidth, cellHeight) => set({ cellWidth, cellHeight }),
 }))
 

--- a/src/store/useGridStore.js
+++ b/src/store/useGridStore.js
@@ -1,0 +1,10 @@
+import { create } from 'zustand'
+
+const useGridStore = create((set) => ({
+  cellWidth: 0,
+  cellHeight: 0,
+  gap: 10,
+  setCellSize: (cellWidth, cellHeight) => set({ cellWidth, cellHeight }),
+}))
+
+export default useGridStore


### PR DESCRIPTION
## Summary

- `ResizeObserver`로 대시보드 그리드의 실제 셀 크기(`cellWidth`, `cellHeight`)를 측정
- `useGridStore` (Zustand)에 저장해 전역 접근 가능하도록 구성
- `WidgetSizeList`의 `VariantPreview`가 store 값으로 `aspect-ratio`를 동적 계산 → 항상 실제 대시보드 비율과 일치
- 최소 셀 크기(`160×150px`) 이하로 줄어들면 스크롤 전환 (가로/세로 모두)
- 공유 상수 `src/lib/gridConstants.js`로 분리

Closes #28

## Test plan

- [ ] 대시보드와 EditPanel 미리보기의 위젯 비율 일치 확인
- [ ] 창 크기를 키우고 줄일 때 EditPanel 미리보기 비율이 실시간 업데이트 확인
- [ ] 창을 최솟값 이하로 줄였을 때 스크롤 발동 확인
- [ ] 측정 전(초기 로드) 폴백 비율 정상 표시 확인