### PR TITLE
feat(home): 위젯 편집 패널에서 대시보드 위젯 추가/삭제

### DIFF
--- a/src/components/layout/AppHeader.jsx
+++ b/src/components/layout/AppHeader.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import NavTabs from './NavTabs'
 import useAuthStore from '@/store/useAuthStore'
 import useEditModeStore from '@/store/useEditModeStore'
+import useWidgetStore from '@/store/useWidgetStore'
 
 function Logo() {
   return (
@@ -61,6 +62,7 @@ function UserArea() {
 
 function EditModeActions() {
   const { exitEditMode, saveLayout } = useEditModeStore()
+  const { restoreSnapshot, clearSnapshot } = useWidgetStore()
   return (
     <div className="flex items-center gap-2">
       <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl bg-primary-light border border-primary-border">
@@ -68,13 +70,13 @@ function EditModeActions() {
         <span className="text-[12px] font-semibold text-primary">위젯 편집</span>
       </div>
       <button
-        onClick={exitEditMode}
+        onClick={() => { restoreSnapshot(); exitEditMode() }}
         className="px-3 py-1.5 rounded-xl border border-stroke-input text-[12px] text-foreground-tertiary font-medium hover:bg-surface-muted transition-colors duration-[150ms]"
       >
         취소
       </button>
       <button
-        onClick={saveLayout}
+        onClick={() => { clearSnapshot(); saveLayout() }}
         className="px-3 py-1.5 rounded-xl bg-primary text-white text-[12px] font-semibold hover:bg-primary-hover transition-colors duration-[150ms] shadow-primary-btn"
       >
         완료 · 저장
@@ -85,9 +87,10 @@ function EditModeActions() {
 
 function WidgetEditButton() {
   const { enterEditMode } = useEditModeStore()
+  const { snapshotWidgets } = useWidgetStore()
   return (
     <button
-      onClick={enterEditMode}
+      onClick={() => { snapshotWidgets(); enterEditMode() }}
       className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl border border-stroke text-foreground-secondary text-[12px] font-medium hover:border-primary hover:text-primary hover:bg-primary-light transition-all duration-[150ms]"
     >
       <LayoutGrid className="w-3.5 h-3.5" strokeWidth={2} />

--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -1,39 +1,24 @@
 import { ChevronLeft, Plus } from 'lucide-react'
 import { cn } from '@/lib/cn'
 import useGridStore from '@/store/useGridStore'
-import { MIN_CELL_WIDTH, MIN_CELL_HEIGHT, GRID_GAP } from '@/lib/gridConstants'
+import useWidgetStore, { canFitInGrid } from '@/store/useWidgetStore'
+import { GRID_GAP, MIN_CELL_WIDTH, MIN_CELL_HEIGHT } from '@/lib/gridConstants'
 
 /* ── 너비 클래스 ─────────────────────────────────────────────
-   패널 usable width = 2열 기준 (336px).
    colSpan=1 → w-1/2,  colSpan=2 → w-full
 ─────────────────────────────────────────────────────────── */
 function widthClass(colSpan) {
   return colSpan === 2 ? 'w-full' : 'w-1/2'
 }
 
-/* ── 실제 대시보드 셀 크기 기반 aspect-ratio 계산 ─────────────
-   cellWidth/cellHeight: ResizeObserver로 측정한 실제 셀 크기
-   0이면 아직 측정 전 → MIN_CELL 기준 폴백
-   gap은 변하지 않는 상수(GRID_GAP)를 직접 사용
-   반환값: 숫자 (w/h 비율)
+/* ── aspect-ratio 계산 ──────────────────────────────────────
+   previewCellWidth/Height: EditPanel 미열림(full-grid) 상태의
+   실제 셀 크기. 0이면 아직 측정 전 → MIN_CELL 기준 폴백.
 ─────────────────────────────────────────────────────────── */
-function calcAspectRatio(colSpan, rowSpan, cellWidth, cellHeight) {
-  const cw = cellWidth || MIN_CELL_WIDTH
-  const ch = cellHeight || MIN_CELL_HEIGHT
+function calcAspectRatio(colSpan, rowSpan, cw, ch) {
   const w = colSpan * cw + (colSpan - 1) * GRID_GAP
   const h = rowSpan * ch + (rowSpan - 1) * GRID_GAP
   return w / h
-}
-
-// EditPanel 패널 usable width (w-chat-panel 368px - px-4*2 32px)
-const PANEL_USABLE_WIDTH = 336
-
-function SizeBadge({ colSpan, rowSpan }) {
-  return (
-    <span className="text-[8px] font-semibold text-foreground-disabled bg-surface-muted px-1.5 py-0.5 rounded shrink-0">
-      {colSpan}×{rowSpan}
-    </span>
-  )
 }
 
 /* ── 위젯별 미리보기 콘텐츠 ─────────────────────────────── */
@@ -55,11 +40,13 @@ function PreviewContent({ type }) {
     /* 계좌 잔고 — 와이드 2×1 */
     case 'balance-lg':
       return (
-        <div className="flex items-center justify-between h-full gap-3">
-          <div className="flex flex-col justify-center gap-1">
+        <div className="flex items-start justify-between h-full gap-3">
+          <div className="flex flex-col justify-between h-full">
             <span className="text-[9px] text-foreground-disabled">총 평가자산</span>
-            <div className="text-[15px] font-extrabold text-foreground leading-none">84,320,000원</div>
-            <div className="text-[10px] text-up font-semibold">▲ +2,152,000원 (+2.61%)</div>
+            <div>
+              <div className="text-[15px] font-extrabold text-foreground leading-none">84,320,000원</div>
+              <div className="text-[10px] text-up font-semibold">▲ +2,152,000원 (+2.61%)</div>
+            </div>
           </div>
           <div className="flex flex-col gap-2 shrink-0">
             <div className="text-right">
@@ -192,25 +179,28 @@ function PreviewContent({ type }) {
     /* 주요 지수 — 복합 2×1 */
     case 'index-wide':
       return (
-        <div className="flex h-full divide-x divide-stroke">
-          {[
-            { name: 'KOSPI',  val: '2,685.42', chg: '+0.46%', up: true,  bars: [50,55,48,60,52,58,54,62] },
-            { name: 'KOSDAQ', val: '868.15',   chg: '-0.21%', up: false, bars: [60,55,58,52,56,50,54,48] },
-            { name: 'NASDAQ', val: '16,274',   chg: '+0.83%', up: true,  bars: [45,52,48,58,54,62,58,68] },
-          ].map(({ name, val, chg, up, bars }) => (
-            <div key={name} className="flex-1 flex flex-col justify-between items-center px-1 py-1">
-              <div className="text-center">
-                <span className="text-[9px] font-semibold text-foreground-disabled">{name}</span>
-                <div className="text-[11px] font-extrabold text-foreground leading-none">{val}</div>
-                <span className={`text-[9px] font-medium ${up ? 'text-up' : 'text-down'}`}>{chg}</span>
+        <div className="flex flex-col h-full gap-1">
+          <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">주요 지수</span>
+          <div className="flex flex-1 min-h-0 divide-x divide-stroke">
+            {[
+              { name: 'KOSPI',  val: '2,685.42', chg: '+0.46%', up: true,  bars: [50,55,48,60,52,58,54,62] },
+              { name: 'KOSDAQ', val: '868.15',   chg: '-0.21%', up: false, bars: [60,55,58,52,56,50,54,48] },
+              { name: 'NASDAQ', val: '16,274',   chg: '+0.83%', up: true,  bars: [45,52,48,58,54,62,58,68] },
+            ].map(({ name, val, chg, up, bars }) => (
+              <div key={name} className="flex-1 flex flex-col justify-between items-center px-1 py-1">
+                <div className="text-center">
+                  <span className="text-[9px] font-semibold text-foreground-disabled">{name}</span>
+                  <div className="text-[11px] font-extrabold text-foreground leading-none">{val}</div>
+                  <span className={`text-[9px] font-medium ${up ? 'text-up' : 'text-down'}`}>{chg}</span>
+                </div>
+                <div className="flex items-end gap-px h-6 w-full">
+                  {bars.map((h, i) => (
+                    <div key={i} className={`flex-1 rounded-sm ${up ? 'bg-up/50' : 'bg-down/50'}`} style={{ height: `${h}%` }} />
+                  ))}
+                </div>
               </div>
-              <div className="flex items-end gap-px h-6 w-full">
-                {bars.map((h, i) => (
-                  <div key={i} className={`flex-1 rounded-sm ${up ? 'bg-up/50' : 'bg-down/50'}`} style={{ height: `${h}%` }} />
-                ))}
-              </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
       )
 
@@ -289,8 +279,11 @@ function PreviewContent({ type }) {
     case 'exchange-wide':
       return (
         <div className="flex flex-col h-full gap-0.5">
-          <span className="text-[7px] text-foreground-disabled text-right shrink-0">09:30 기준</span>
-          <div className="flex flex-1 divide-x divide-stroke">
+          <div className="flex items-center justify-between shrink-0">
+            <span className="text-[9px] font-semibold text-foreground-disabled">환율</span>
+            <span className="text-[7px] text-foreground-disabled">09:30 기준</span>
+          </div>
+          <div className="flex flex-1 min-h-0 divide-x divide-stroke">
             {[
               { pair: 'USD/KRW', rate: '1,378.50', chg: '-0.17%', up: false, bars: [60,58,62,55,58,52,56,50] },
               { pair: 'JPY/KRW', rate: '9.18',     chg: '+0.11%', up: true,  bars: [45,48,50,52,49,54,52,56] },
@@ -317,7 +310,7 @@ function PreviewContent({ type }) {
     case 'market-sm':
       return (
         <div className="flex flex-col h-full gap-2">
-          <span className="text-[9px] font-semibold text-foreground-disabled">시황</span>
+          <span className="text-[9px] font-semibold text-foreground-disabled">오늘의 시황</span>
           <p className="text-[10px] text-foreground-secondary leading-snug">
             美 CPI 예상치 하회…<br />나스닥 1% 이상 상승.<br />반도체 섹터 강세.
           </p>
@@ -511,7 +504,7 @@ function PreviewContent({ type }) {
     case 'report-sm':
       return (
         <div className="flex flex-col justify-between h-full">
-          <span className="text-[8px] font-semibold text-foreground-disabled">리포트</span>
+          <span className="text-[8px] font-semibold text-foreground-disabled">증권사 리포트</span>
           <div>
             <div className="text-[9px] font-bold text-foreground leading-snug">삼성전자<br />목표가 상향</div>
             <div className="text-[8px] text-foreground-disabled mt-1">키움증권 · 3.18</div>
@@ -638,7 +631,9 @@ function PreviewContent({ type }) {
       
       return (
         <div className="flex flex-col h-full gap-2">
+          <span className="text-[9px] text-foreground-disabled shrink-0">섹터별 비중</span>
           <div className="flex items-center gap-3 shrink-0">
+            
             <div
               className="w-16 h-16 rounded-full shrink-0"
               style={{ background: 'conic-gradient(var(--color-chart-1) 0% 54%, var(--color-chart-2) 54% 72%, var(--color-chart-3) 72% 87%, var(--color-chart-4) 87% 100%)' }}
@@ -649,7 +644,7 @@ function PreviewContent({ type }) {
               <div className="text-[9px] text-foreground-disabled mt-0.5">+4,280,000원</div>
             </div>
           </div>
-          <span className="text-[9px] text-foreground-disabled shrink-0">섹터별 비중</span>
+          
           <div className="flex flex-col gap-2">
             {[
               { name: 'IT·반도체', pct: 54, color: 'bg-chart-1' },
@@ -790,31 +785,18 @@ function PreviewContent({ type }) {
 /* ── VariantPreview ─────────────────────────────────────── */
 function VariantPreview({ variant }) {
   const { colSpan, rowSpan } = variant
-  const { cellWidth, cellHeight } = useGridStore()
-
-  // 실제 대시보드 비율 (숫자) — ResizeObserver 측정값 기반
-  const ratio = calcAspectRatio(colSpan, rowSpan, cellWidth, cellHeight)
-
-  // 최솟값 기준 minHeight — 대시보드가 MIN 크기일 때 preview content가 잘리지 않는 하한
-  // previewWidth: colSpan=1 → 패널 절반(168px), colSpan=2 → 패널 전체(336px)
-  const previewWidth = colSpan === 2 ? PANEL_USABLE_WIDTH : PANEL_USABLE_WIDTH / 2
-  const minRatio = calcAspectRatio(colSpan, rowSpan, MIN_CELL_WIDTH, MIN_CELL_HEIGHT)
-  const minHeight = previewWidth / minRatio
+  const { previewCellWidth, previewCellHeight } = useGridStore()
+  const cw = previewCellWidth || MIN_CELL_WIDTH
+  const ch = previewCellHeight || MIN_CELL_HEIGHT
+  const ratio = calcAspectRatio(colSpan, rowSpan, cw, ch)
 
   return (
     <div
-      className="w-full border border-stroke rounded-xl p-3 bg-surface flex flex-col overflow-hidden"
-      style={{ aspectRatio: ratio, minHeight: `${minHeight}px` }}
+      className="w-full border border-stroke rounded-xl p-3 bg-surface overflow-hidden relative"
+      style={{ aspectRatio: ratio }}
     >
-      {/* 라벨 + 크기 배지 */}
-      <div className="flex items-center justify-between mb-2 shrink-0">
-        <span className="text-[8px] font-semibold text-foreground-disabled uppercase tracking-[.06em]">
-          {variant.label}
-        </span>
-        <SizeBadge colSpan={colSpan} rowSpan={rowSpan} />
-      </div>
-      {/* 미리보기 */}
-      <div className="flex-1 min-h-0 overflow-hidden">
+      {/* absolute inset-0으로 PreviewContent에 명확한 높이 전달 */}
+      <div className="absolute inset-0 p-3 overflow-hidden">
         <PreviewContent type={variant.preview} />
       </div>
     </div>
@@ -823,6 +805,8 @@ function VariantPreview({ variant }) {
 
 /* ── WidgetSizeList ─────────────────────────────────────── */
 export default function WidgetSizeList({ widgetType, onBack }) {
+  const { widgets, addWidget } = useWidgetStore()
+
   return (
     <>
       {/* 헤더 */}
@@ -844,23 +828,34 @@ export default function WidgetSizeList({ widgetType, onBack }) {
           크기 선택
         </div>
         <div className="flex flex-col gap-3">
-          {widgetType.variants.map((variant) => (
-            <div
-              key={variant.id}
-              className={cn('relative group', widthClass(variant.colSpan))}
-            >
-              <VariantPreview variant={variant} />
-              {/* hover 추가 오버레이 */}
-              <button
-                aria-label={`${variant.label} 추가`}
-                className="absolute inset-0 rounded-xl opacity-0 group-hover:opacity-100 bg-primary/10 border border-primary flex items-center justify-center transition-opacity duration-[150ms]"
+          {widgetType.variants.map((variant) => {
+            const canAdd = canFitInGrid(widgets, variant.colSpan, variant.rowSpan)
+            return (
+              <div
+                key={variant.id}
+                className={cn('relative group', widthClass(variant.colSpan))}
               >
-                <div className="w-7 h-7 rounded-full bg-primary flex items-center justify-center shadow-primary-btn">
-                  <Plus className="w-3.5 h-3.5 text-white" />
-                </div>
-              </button>
-            </div>
-          ))}
+                <VariantPreview variant={variant} />
+                {canAdd ? (
+                  /* hover 추가 오버레이 */
+                  <button
+                    aria-label={`${variant.label} 추가`}
+                    onClick={() => { addWidget(widgetType.id, variant); onBack() }}
+                    className="absolute inset-0 rounded-xl opacity-0 group-hover:opacity-100 bg-primary/10 border border-primary flex items-center justify-center transition-opacity duration-[150ms]"
+                  >
+                    <div className="w-7 h-7 rounded-full bg-primary flex items-center justify-center shadow-primary-btn">
+                      <Plus className="w-3.5 h-3.5 text-white" />
+                    </div>
+                  </button>
+                ) : (
+                  /* 공간 부족 오버레이 — 항상 표시 */
+                  <div className="absolute inset-0 rounded-xl bg-background/60 border border-stroke flex items-center justify-center">
+                    <span className="text-[10px] text-foreground-disabled font-medium">공간 부족</span>
+                  </div>
+                )}
+              </div>
+            )
+          })}
         </div>
         <p className="text-[10px] text-foreground-disabled mt-4 text-center">
           클릭하여 대시보드에 추가

--- a/src/components/layout/EditPanel/WidgetTypeList.jsx
+++ b/src/components/layout/EditPanel/WidgetTypeList.jsx
@@ -1,9 +1,11 @@
 import { useState } from 'react'
 import { Search, ChevronRight } from 'lucide-react'
 import { WIDGET_TYPES, WIDGET_CATEGORIES } from '@/mocks/widgets'
+import useWidgetStore from '@/store/useWidgetStore'
 import { cn } from '@/lib/cn'
 
 export default function WidgetTypeList({ onSelectType }) {
+  const { widgets } = useWidgetStore()
   const [query, setQuery] = useState('')
   const [activeCategory, setActiveCategory] = useState('전체')
 
@@ -29,7 +31,7 @@ export default function WidgetTypeList({ onSelectType }) {
         <div className="flex items-center justify-between mb-3">
           <span className="text-[14px] font-bold text-foreground">위젯 추가</span>
           <span className="text-[10px] text-foreground-disabled bg-surface-muted px-2 py-0.5 rounded-full">
-            9개 배치 중
+            {widgets.length}개 배치 중
           </span>
         </div>
         {/* 검색 */}

--- a/src/components/widgets/BalanceWidget.jsx
+++ b/src/components/widgets/BalanceWidget.jsx
@@ -4,41 +4,99 @@ import useAuthStore from '@/store/useAuthStore'
 import WidgetCard from './WidgetCard'
 import { BALANCE } from '@/mocks/home'
 
-export default function BalanceWidget() {
+export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, rowSpan = 1, onDelete }) {
   const { isAuthenticated } = useAuthStore()
 
   return (
-    <WidgetCard className="relative">
-      <div className="flex items-center justify-between mb-2">
+    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+      <div className="flex items-center justify-between mb-2 shrink-0">
         <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">계좌 잔고</span>
         <LiveDot />
       </div>
-      <div className="flex-1 flex flex-col justify-between">
-        <div>
-          <div className="text-[10px] text-foreground-disabled mb-0.5">총 평가자산</div>
-          <div className="text-[18px] font-bold leading-tight tracking-tight text-foreground">
-            {BALANCE.total}
-            <span className="text-[11px] font-medium text-foreground-tertiary ml-0.5">원</span>
+
+      {variant === 'balance-lg' ? (
+        <div className="flex items-center justify-between flex-1 gap-4">
+          <div className="flex flex-col gap-1.5">
+            <div className="text-[10px] text-foreground-disabled">총 평가자산</div>
+            <div className="text-[18px] font-bold leading-tight tracking-tight text-foreground">
+              {BALANCE.total}<span className="text-[11px] font-medium text-foreground-tertiary ml-0.5">원</span>
+            </div>
+            <div className="text-[11px] font-semibold text-up">▲ {BALANCE.profit} ({BALANCE.profitRate})</div>
           </div>
-          <div className="text-[11px] font-semibold text-up mt-0.5">▲ {BALANCE.profit} ({BALANCE.profitRate})</div>
-        </div>
-        <div className="flex flex-col gap-1 pt-2 border-t border-stroke-subtle mt-2">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-1.5">
+          <div className="flex flex-col gap-2 shrink-0">
+            <div className="flex items-center gap-2 px-3 py-2 rounded-xl bg-surface-subtle">
               <span className="text-[13px]">🇰🇷</span>
-              <span className="text-[10px] text-foreground-tertiary">KRW</span>
+              <div>
+                <div className="text-[9px] text-foreground-disabled">KRW</div>
+                <div className="text-[12px] font-semibold text-foreground">{BALANCE.krw}</div>
+              </div>
             </div>
-            <span className="text-[10px] font-semibold text-foreground-secondary">{BALANCE.krw}</span>
-          </div>
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-1.5">
+            <div className="flex items-center gap-2 px-3 py-2 rounded-xl bg-surface-subtle">
               <span className="text-[13px]">🇺🇸</span>
-              <span className="text-[10px] text-foreground-tertiary">USD</span>
+              <div>
+                <div className="text-[9px] text-foreground-disabled">USD</div>
+                <div className="text-[12px] font-semibold text-foreground">{BALANCE.usd}</div>
+              </div>
             </div>
-            <span className="text-[10px] font-semibold text-foreground-secondary">{BALANCE.usd}</span>
           </div>
         </div>
-      </div>
+      ) : variant === 'balance-2x2' ? (
+        <div className="flex flex-col flex-1 gap-2.5">
+          <div>
+            <div className="text-[10px] text-foreground-disabled">총 평가자산</div>
+            <div className="text-[22px] font-bold leading-tight tracking-tight text-foreground mt-0.5">
+              {BALANCE.total}<span className="text-[12px] font-medium text-foreground-tertiary ml-0.5">원</span>
+            </div>
+            <div className="text-[12px] font-semibold text-up mt-0.5">▲ {BALANCE.profit} ({BALANCE.profitRate})</div>
+          </div>
+          <div className="grid grid-cols-2 gap-2 shrink-0">
+            {[
+              { label: '투자원금', val: '82,180,000', color: 'text-foreground' },
+              { label: '평가손익', val: BALANCE.profit, color: 'text-up' },
+              { label: '당일손익', val: '+342,000',    color: 'text-up' },
+              { label: '수익률',   val: BALANCE.profitRate, color: 'text-up' },
+            ].map(({ label, val, color }) => (
+              <div key={label} className="bg-background rounded-xl px-3 py-2">
+                <div className="text-[9px] text-foreground-disabled">{label}</div>
+                <div className={`text-[12px] font-bold ${color} mt-0.5`}>{val}</div>
+              </div>
+            ))}
+          </div>
+          <div className="flex-1 min-h-0 bg-background rounded-xl flex items-end px-2 pb-2 pt-2 gap-px">
+            {[30, 45, 38, 60, 52, 65, 55, 70, 62, 78, 68, 85].map((h, i) => (
+              <div key={i} className="flex-1 bg-up/50 rounded-sm" style={{ height: `${h}%` }} />
+            ))}
+          </div>
+        </div>
+      ) : (
+        /* balance-sm (default) */
+        <div className="flex-1 flex flex-col justify-between">
+          <div>
+            <div className="text-[10px] text-foreground-disabled mb-0.5">총 평가자산</div>
+            <div className="text-[18px] font-bold leading-tight tracking-tight text-foreground">
+              {BALANCE.total}<span className="text-[11px] font-medium text-foreground-tertiary ml-0.5">원</span>
+            </div>
+            <div className="text-[11px] font-semibold text-up mt-0.5">▲ {BALANCE.profit} ({BALANCE.profitRate})</div>
+          </div>
+          <div className="flex flex-col gap-1 pt-2 border-t border-stroke-subtle mt-2">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-1.5">
+                <span className="text-[13px]">🇰🇷</span>
+                <span className="text-[10px] text-foreground-tertiary">KRW</span>
+              </div>
+              <span className="text-[10px] font-semibold text-foreground-secondary">{BALANCE.krw}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-1.5">
+                <span className="text-[13px]">🇺🇸</span>
+                <span className="text-[10px] text-foreground-tertiary">USD</span>
+              </div>
+              <span className="text-[10px] font-semibold text-foreground-secondary">{BALANCE.usd}</span>
+            </div>
+          </div>
+        </div>
+      )}
+
       {!isAuthenticated && <LockedOverlay message="계좌 정보를 보려면" />}
     </WidgetCard>
   )

--- a/src/components/widgets/ExchangeWidget.jsx
+++ b/src/components/widgets/ExchangeWidget.jsx
@@ -4,33 +4,120 @@ import useAuthStore from '@/store/useAuthStore'
 import WidgetCard from './WidgetCard'
 import { EXCHANGE } from '@/mocks/home'
 
-export default function ExchangeWidget() {
-  const { isAuthenticated } = useAuthStore()
+const EXCHANGE_EXTENDED = [
+  ...EXCHANGE,
+  { flag: '🇪🇺', pair: 'EUR / KRW', rate: '1,502.30', change: -0.05 },
+]
 
+function ExchangeRow({ flag, pair, rate, change }) {
+  const isUp = change > 0
   return (
-    <WidgetCard className="relative">
+    <div className="flex items-center gap-2 py-1.5 px-2 rounded-xl bg-surface-subtle">
+      <span className="text-[16px]">{flag}</span>
+      <div className="flex-1">
+        <div className="text-[9px] text-foreground-disabled">{pair}</div>
+        <div className="flex items-baseline gap-1">
+          <span className="text-[15px] font-bold text-foreground">{rate}</span>
+          <span className={`text-[9px] ${isUp ? 'text-up' : 'text-down'}`}>
+            {isUp ? '▲' : '▼'}{Math.abs(change)}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function ExchangeWidget({ variant = 'exchange-sm', colSpan = 1, rowSpan = 1, onDelete }) {
+  const { isAuthenticated } = useAuthStore()
+  const usd = EXCHANGE[0]
+
+  if (variant === 'exchange-wide') {
+    return (
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+        <div className="flex items-center justify-between mb-1 shrink-0">
+          <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
+          <LiveDot />
+        </div>
+        <div className="flex-1 flex divide-x divide-stroke">
+          {EXCHANGE_EXTENDED.map(({ flag, pair, rate, change }) => {
+            const isUp = change > 0
+            return (
+              <div key={pair} className="flex-1 flex flex-col items-center justify-center px-2 gap-1">
+                <span className="text-[16px]">{flag}</span>
+                <div className="text-center">
+                  <div className="text-[9px] text-foreground-disabled">{pair.split(' / ')[0]} / KRW</div>
+                  <div className="text-[13px] font-bold text-foreground">{rate}</div>
+                  <div className={`text-[9px] ${isUp ? 'text-up' : 'text-down'}`}>
+                    {isUp ? '▲' : '▼'} {Math.abs(change)}
+                  </div>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+        {!isAuthenticated && <LockedOverlay message="환율 정보를 보려면" />}
+      </WidgetCard>
+    )
+  }
+
+  if (variant === 'exchange-2x2') {
+    return (
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+        <div className="flex items-center justify-between mb-1 shrink-0">
+          <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
+          <LiveDot />
+        </div>
+        <div className="shrink-0">
+          <div className="text-[9px] text-foreground-disabled">USD / KRW</div>
+          <div className="text-[22px] font-bold text-foreground leading-tight">{usd.rate}</div>
+          <div className={`text-[10px] ${usd.change > 0 ? 'text-up' : 'text-down'}`}>
+            {usd.change > 0 ? '▲' : '▼'} {Math.abs(usd.change)}
+          </div>
+        </div>
+        <div className="h-10 bg-background rounded-xl flex items-end px-1.5 pb-1 gap-px my-2 shrink-0">
+          {[60, 58, 62, 55, 58, 52, 56, 50, 54, 48, 52, 46].map((h, i) => (
+            <div key={i} className="flex-1 bg-down/40 rounded-sm" style={{ height: `${h}%` }} />
+          ))}
+        </div>
+        <div className="flex-1 flex flex-col gap-2 min-h-0 overflow-y-auto">
+          {EXCHANGE_EXTENDED.slice(1).map(({ flag, pair, rate, change }) => {
+            const isUp = change > 0
+            return (
+              <div key={pair} className="flex items-center justify-between px-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-[14px]">{flag}</span>
+                  <span className="text-[10px] text-foreground-secondary">{pair}</span>
+                </div>
+                <div className="text-right">
+                  <span className="text-[12px] font-semibold text-foreground">{rate}</span>
+                  <span className={`text-[9px] ml-1.5 ${isUp ? 'text-up' : 'text-down'}`}>
+                    {isUp ? '▲' : '▼'} {Math.abs(change)}
+                  </span>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+        <button
+          onClick={(e) => e.stopPropagation()}
+          className="w-full py-1.5 rounded-xl bg-primary-light text-primary text-[10px] font-bold hover:bg-primary-dim transition-colors duration-[150ms] mt-2 shrink-0"
+        >
+          환전하기 →
+        </button>
+        {!isAuthenticated && <LockedOverlay message="환율 정보를 보려면" />}
+      </WidgetCard>
+    )
+  }
+
+  /* exchange-sm (default) */
+  return (
+    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
       <div className="flex items-center justify-between mb-1">
         <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
         <LiveDot />
       </div>
       <div className="flex-1 flex flex-col justify-between">
-        {EXCHANGE.map((item) => {
-          const isUp = item.change > 0
-          return (
-            <div key={item.pair} className="flex items-center gap-2 py-1.5 px-2 rounded-xl bg-surface-subtle">
-              <span className="text-[16px]">{item.flag}</span>
-              <div className="flex-1">
-                <div className="text-[9px] text-foreground-disabled">{item.pair}</div>
-                <div className="flex items-baseline gap-1">
-                  <span className="text-[15px] font-bold text-foreground">{item.rate}</span>
-                  <span className={`text-[9px] ${isUp ? 'text-up' : 'text-down'}`}>
-                    {isUp ? '▲' : '▼'}{Math.abs(item.change)}
-                  </span>
-                </div>
-              </div>
-            </div>
-          )
-        })}
+        {EXCHANGE.map((item) => <ExchangeRow key={item.pair} {...item} />)}
         <button
           onClick={(e) => e.stopPropagation()}
           className="w-full py-1.5 rounded-xl bg-primary-light text-primary text-[10px] font-bold hover:bg-primary-dim transition-colors duration-[150ms]"

--- a/src/components/widgets/IndexWidget.jsx
+++ b/src/components/widgets/IndexWidget.jsx
@@ -6,12 +6,63 @@ import { HOME_INDICES } from '@/mocks/home'
 import { cn } from '@/lib/cn'
 
 const TABS = ['국내', '미국', '아시아']
+const BARS = [50, 55, 48, 60, 52, 58, 54, 62]
 
-export default function IndexWidget() {
+export default function IndexWidget({ variant = 'index-wide', colSpan = 2, rowSpan = 1, onDelete }) {
   const [activeTab, setActiveTab] = useState('국내')
 
+  if (variant === 'index-sm') {
+    const kospi = HOME_INDICES[0]
+    return (
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+        <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase shrink-0">주요 지수</span>
+        <div className="flex-1 min-h-0 bg-background rounded-xl flex items-end px-1.5 pb-1.5 pt-2 gap-px my-1">
+          {BARS.map((h, i) => (
+            <div key={i} className="flex-1 bg-up/50 rounded-sm" style={{ height: `${h}%` }} />
+          ))}
+        </div>
+        <div className="shrink-0">
+          <div className="text-[9px] text-foreground-disabled">{kospi.label}</div>
+          <div className="text-[16px] font-bold text-foreground leading-tight">{kospi.value}</div>
+          <PriceChange value={kospi.change} className="text-[10px]" />
+        </div>
+      </WidgetCard>
+    )
+  }
+
+  if (variant === 'index-2x2') {
+    return (
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+        <div className="flex items-center justify-between mb-2 shrink-0">
+          <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">주요 지수</span>
+        </div>
+        <div className="flex flex-col flex-1 gap-3">
+          {HOME_INDICES.slice(0, 3).map((idx) => (
+            <div key={idx.key} className="flex items-center gap-3">
+              <div className="flex-1 min-w-0">
+                <div className="text-[9px] text-foreground-disabled">{idx.label}</div>
+                <div className="text-[15px] font-bold text-foreground leading-tight">{idx.value}</div>
+                <PriceChange value={idx.change} className="text-[10px]" />
+              </div>
+              <div className="flex items-end gap-px h-8 shrink-0">
+                {BARS.map((h, i) => (
+                  <div
+                    key={i}
+                    className={cn('w-1.5 rounded-sm', idx.change > 0 ? 'bg-up/50' : 'bg-down/50')}
+                    style={{ height: `${h}%` }}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </WidgetCard>
+    )
+  }
+
+  /* index-wide (default) */
   return (
-    <WidgetCard colSpan={2}>
+    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
       <div className="flex items-center justify-between mb-2">
         <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">주요 지수</span>
         <div className="flex gap-1">

--- a/src/components/widgets/MarketOverviewWidget.jsx
+++ b/src/components/widgets/MarketOverviewWidget.jsx
@@ -1,9 +1,39 @@
 import WidgetCard from './WidgetCard'
 import { MARKET_OVERVIEW } from '@/mocks/home'
 
-export default function MarketOverviewWidget() {
+const NEWS_LIST = [
+  '美 CPI 예상치 하회… 나스닥 1% 상승',
+  'SK하이닉스 목표가 상향 조정',
+  '원/달러 환율 1,378원 하락 마감',
+  '코스피 외국인 순매수 이틀 연속',
+  '반도체 업황 긍정적… HBM 수요 증가',
+]
+
+export default function MarketOverviewWidget({ variant = 'market-sm', colSpan = 1, rowSpan = 1, onDelete }) {
+  const news = variant === 'market-2x2' ? NEWS_LIST : NEWS_LIST.slice(0, 4)
+
+  if (variant === 'market-wide' || variant === 'market-2x2') {
+    return (
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+        <div className="flex items-center justify-between mb-2 shrink-0">
+          <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">오늘의 시황</span>
+          <span className="text-[9px] text-foreground-disabled">{MARKET_OVERVIEW.time}</span>
+        </div>
+        <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-2">
+          {news.map((item, i) => (
+            <div key={i} className="flex items-start gap-2 px-1">
+              <span className="text-[10px] font-semibold text-primary shrink-0 mt-px">{i + 1}</span>
+              <p className="text-[10px] text-foreground-secondary leading-relaxed">{item}</p>
+            </div>
+          ))}
+        </div>
+      </WidgetCard>
+    )
+  }
+
+  /* market-sm (default) */
   return (
-    <WidgetCard>
+    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
       <div className="flex items-center justify-between mb-2">
         <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">오늘의 시황</span>
         <span className="text-[9px] text-foreground-disabled">{MARKET_OVERVIEW.time}</span>

--- a/src/components/widgets/PortfolioWidget.jsx
+++ b/src/components/widgets/PortfolioWidget.jsx
@@ -3,44 +3,96 @@ import useAuthStore from '@/store/useAuthStore'
 import WidgetCard from './WidgetCard'
 import { PORTFOLIO } from '@/mocks/home'
 
-export default function PortfolioWidget() {
+const PIE_BG = 'conic-gradient(var(--color-chart-1) 0% 34%, var(--color-chart-2) 34% 54%, var(--color-chart-3) 54% 69%, var(--color-chart-4) 69% 81%, var(--color-chart-5) 81% 100%)'
+
+function PieDonut({ size = 52, innerSize = 32 }) {
+  return (
+    <div className="relative shrink-0">
+      <div className="rounded-full" style={{ width: size, height: size, background: PIE_BG }} />
+      <div className="absolute inset-0 flex items-center justify-center">
+        <div
+          className="rounded-full bg-surface shadow-inner flex items-center justify-center"
+          style={{ width: innerSize, height: innerSize }}
+        >
+          <span className="text-[9px] font-bold text-up">{PORTFOLIO.returnRate}</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1, rowSpan = 1, onDelete }) {
   const { isAuthenticated } = useAuthStore()
 
   return (
-    <WidgetCard className="relative">
-      <div className="flex items-center justify-between mb-1">
+    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+      <div className="flex items-center justify-between mb-1 shrink-0">
         <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">포트폴리오</span>
         <span className="text-[10px] font-semibold text-primary">5종목</span>
       </div>
-      <div className="flex items-center gap-2.5 flex-1">
-        {/* 도넛 파이 차트 */}
-        <div className="relative shrink-0">
-          <div
-            className="w-[52px] h-[52px] rounded-full"
-            style={{ background: 'conic-gradient(var(--color-chart-1) 0% 34%, var(--color-chart-2) 34% 54%, var(--color-chart-3) 54% 69%, var(--color-chart-4) 69% 81%, var(--color-chart-5) 81% 100%)' }}
-          />
-          <div className="absolute inset-0 flex items-center justify-center">
-            <div className="w-8 h-8 rounded-full bg-surface shadow-inner flex items-center justify-center">
-              <span className="text-[9px] font-bold text-up">{PORTFOLIO.returnRate}</span>
-            </div>
+
+      {variant === 'portfolio-wide' ? (
+        <div className="flex items-center gap-3 flex-1">
+          <PieDonut />
+          <div className="flex-1 flex flex-col gap-2">
+            {PORTFOLIO.items.map((item) => (
+              <div key={item.name}>
+                <div className="flex justify-between mb-0.5">
+                  <span className="text-[10px] text-foreground-tertiary">{item.name}</span>
+                  <span className="text-[10px] font-semibold text-foreground">{item.ratio}%</span>
+                </div>
+                <div className="h-[3px] bg-surface-muted rounded-full overflow-hidden">
+                  <div className="h-full rounded-full" style={{ width: `${item.ratio}%`, background: item.color }} />
+                </div>
+              </div>
+            ))}
           </div>
         </div>
-        {/* 종목 비율 리스트 */}
-        <div className="flex-1 flex flex-col gap-[3px]">
-          {PORTFOLIO.items.map((item) => (
-            <div key={item.name} className="flex items-center justify-between">
-              <div className="flex items-center gap-1">
-                <div className="w-[6px] h-[6px] rounded-sm shrink-0" style={{ background: item.color }} />
-                <span className="text-[10px] text-foreground-tertiary">{item.name}</span>
-              </div>
-              <div className="flex items-center gap-1">
-                <div className="h-[3px] rounded-full opacity-80" style={{ width: item.barWidth, background: item.color }} />
-                <span className="text-[9px] font-medium text-foreground">{item.ratio}%</span>
-              </div>
+      ) : variant === 'portfolio-2x2' ? (
+        <div className="flex flex-col flex-1 gap-3">
+          <div className="flex items-center gap-3 shrink-0">
+            <PieDonut size={68} innerSize={40} />
+            <div>
+              <div className="text-[9px] text-foreground-disabled">총 수익률</div>
+              <div className="text-[22px] font-bold text-up leading-tight">{PORTFOLIO.returnRate}</div>
+              <div className="text-[9px] text-foreground-disabled mt-0.5">+4,280,000원</div>
             </div>
-          ))}
+          </div>
+          <div className="flex flex-col gap-2.5 flex-1">
+            {PORTFOLIO.items.map((item) => (
+              <div key={item.name}>
+                <div className="flex justify-between mb-0.5">
+                  <span className="text-[10px] text-foreground-tertiary">{item.name}</span>
+                  <span className="text-[10px] font-semibold text-foreground">{item.ratio}%</span>
+                </div>
+                <div className="h-[4px] bg-surface-muted rounded-full overflow-hidden">
+                  <div className="h-full rounded-full" style={{ width: `${item.ratio}%`, background: item.color }} />
+                </div>
+              </div>
+            ))}
+          </div>
         </div>
-      </div>
+      ) : (
+        /* portfolio-sm (default) */
+        <div className="flex items-center gap-2.5 flex-1">
+          <PieDonut />
+          <div className="flex-1 flex flex-col gap-[3px]">
+            {PORTFOLIO.items.map((item) => (
+              <div key={item.name} className="flex items-center justify-between">
+                <div className="flex items-center gap-1">
+                  <div className="w-[6px] h-[6px] rounded-sm shrink-0" style={{ background: item.color }} />
+                  <span className="text-[10px] text-foreground-tertiary">{item.name}</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <div className="h-[3px] rounded-full opacity-80" style={{ width: item.barWidth, background: item.color }} />
+                  <span className="text-[9px] font-medium text-foreground">{item.ratio}%</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       {!isAuthenticated && <LockedOverlay message="포트폴리오를 보려면" />}
     </WidgetCard>
   )

--- a/src/components/widgets/RankingWidget.jsx
+++ b/src/components/widgets/RankingWidget.jsx
@@ -7,11 +7,21 @@ import { RANKING } from '@/mocks/home'
 
 const TABS = ['거래대금', '급상승', '거래량', '🇺🇸 미국']
 
-export default function RankingWidget() {
+const RANKING_EXTENDED = [
+  ...RANKING,
+  { rank: 6,  name: '카카오',        label: 'K',   color: 'yellow',  price: '44,150',  change:  0.38, volume: '0.4조' },
+  { rank: 7,  name: 'NAVER',         label: 'N',   color: 'green',   price: '210,000', change: -0.92, volume: '0.3조' },
+  { rank: 8,  name: 'KB금융',        label: 'KB',  color: 'primary', price: '82,400',  change:  1.15, volume: '0.3조' },
+  { rank: 9,  name: '셀트리온',      label: '셀트', color: 'teal',   price: '172,300', change:  2.40, volume: '0.2조' },
+  { rank: 10, name: '기아',          label: '기',  color: 'warning', price: '128,000', change:  0.76, volume: '0.2조' },
+]
+
+export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, rowSpan = 1, onDelete }) {
   const [activeTab, setActiveTab] = useState('거래대금')
+  const items = variant === 'ranking-lg' ? RANKING_EXTENDED : RANKING
 
   return (
-    <WidgetCard colSpan={2}>
+    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
       <div className="flex items-center justify-between mb-1.5">
         <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">실시간 순위</span>
         <div className="flex gap-0.5">
@@ -27,7 +37,7 @@ export default function RankingWidget() {
         </div>
       </div>
       <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-0.5">
-        {RANKING.map((stock) => (
+        {items.map((stock) => (
           <div
             key={stock.rank}
             className="flex items-center gap-2.5 px-1.5 py-1.5 rounded-xl hover:bg-surface-subtle transition-colors cursor-pointer"

--- a/src/components/widgets/ReportWidget.jsx
+++ b/src/components/widgets/ReportWidget.jsx
@@ -1,0 +1,79 @@
+import WidgetCard from './WidgetCard'
+
+const REPORTS = [
+  { title: '삼성전자 목표가 상향',          firm: '키움증권',    date: '3.18', desc: '반도체 업황 회복 기대감' },
+  { title: 'SK하이닉스 HBM 수요 긍정적',    firm: '삼성증권',    date: '3.17', desc: 'AI 서버 수요 지속 증가' },
+  { title: 'LG에너지 실적 전망 하향',       firm: 'NH투자증권',  date: '3.16', desc: 'EV 시장 성장 둔화 우려' },
+  { title: '현대차 글로벌 판매 호조 지속',  firm: '한국투자증권', date: '3.15', desc: '북미 SUV 수요 견조' },
+  { title: '삼성바이오 수주 확대 기대',     firm: '미래에셋',    date: '3.14', desc: 'CMO 수주 파이프라인 확대' },
+  { title: 'NAVER 광고 회복세 긍정적',      firm: 'KB증권',      date: '3.13', desc: '디스플레이 광고 반등' },
+]
+
+export default function ReportWidget({ variant = 'report-sm', colSpan = 1, rowSpan = 1, onDelete }) {
+  /* ── report-wide: 목록형 2×1 ── */
+  if (variant === 'report-wide') {
+    return (
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+        <div className="flex items-center justify-between mb-2 shrink-0">
+          <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">증권사 리포트</span>
+        </div>
+        <div className="flex-1 flex flex-col gap-2 min-h-0 overflow-y-auto">
+          {REPORTS.slice(0, 4).map(({ title, firm, date }) => (
+            <div key={title} className="flex items-start justify-between gap-2">
+              <p className="text-[10px] text-foreground leading-snug truncate">{title}</p>
+              <div className="flex items-center gap-1 shrink-0">
+                <span className="text-[9px] text-primary">{firm}</span>
+                <span className="text-[8px] text-foreground-disabled">{date}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </WidgetCard>
+    )
+  }
+
+  /* ── report-2x2: 상세 목록형 2×2 ── */
+  if (variant === 'report-2x2') {
+    return (
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+        <div className="flex items-center justify-between mb-2 shrink-0">
+          <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">증권사 리포트</span>
+        </div>
+        <div className="flex-1 flex flex-col gap-2 min-h-0 overflow-y-auto">
+          {REPORTS.map(({ title, firm, date, desc }) => (
+            <div key={title} className="border-b border-stroke last:border-0 pb-2 last:pb-0">
+              <div className="flex items-start justify-between gap-1">
+                <span className="text-[11px] font-semibold text-foreground leading-snug">{title}</span>
+                <span className="text-[9px] text-foreground-disabled shrink-0 mt-0.5">{date}</span>
+              </div>
+              <div className="flex items-center gap-1 mt-0.5">
+                <span className="text-[9px] text-primary">{firm}</span>
+                <span className="text-[9px] text-foreground-disabled">· {desc}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </WidgetCard>
+    )
+  }
+
+  /* ── report-sm: 단일 카드 1×1 (default) ── */
+  const latest = REPORTS[0]
+  return (
+    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+      <div className="flex items-center justify-between mb-2 shrink-0">
+        <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">증권사 리포트</span>
+      </div>
+      <div className="flex-1 flex flex-col justify-between min-h-0">
+        <div>
+          <p className="text-[12px] font-bold text-foreground leading-snug">{latest.title}</p>
+          <p className="text-[10px] text-foreground-disabled mt-1">{latest.desc}</p>
+        </div>
+        <div className="flex items-center gap-1">
+          <span className="text-[10px] text-primary font-semibold">{latest.firm}</span>
+          <span className="text-[9px] text-foreground-disabled">· {latest.date}</span>
+        </div>
+      </div>
+    </WidgetCard>
+  )
+}

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -1,14 +1,82 @@
+import { useId } from 'react'
 import StockAvatar from '@/components/ui/StockAvatar'
 import PriceChange from '@/components/ui/PriceChange'
 import WidgetCard from './WidgetCard'
+import { HOME_STOCKS } from '@/mocks/home'
 
-export default function StockChartWidget({ stock }) {
+export default function StockChartWidget({ variant = 'stock-sm', colSpan = 1, rowSpan = 1, onDelete, config = {} }) {
+  const uid = useId()
+  const stockId = config.stockId ?? 'samsung'
+  const stock = HOME_STOCKS.find((s) => s.id === stockId) ?? HOME_STOCKS[0]
   const isUp = stock.change > 0
   const strokeColor = isUp ? 'var(--color-up)' : 'var(--color-down)'
-  const fillId = `spark-fill-${stock.id}`
+  const fillId = `spark-fill-${uid}`
 
+  if (variant === 'stock-tall') {
+    return (
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+        <div className="flex items-center justify-between mb-1 shrink-0">
+          <div className="flex items-center gap-1.5">
+            <StockAvatar name={stock.label} color={stock.color} size="sm" />
+            <div className="text-[12px] font-bold text-foreground">{stock.name}</div>
+          </div>
+          <PriceChange value={stock.change} variant="badge" />
+        </div>
+        <div className="flex-1 min-h-0 bg-background rounded-xl flex items-end px-2 pb-2 pt-2 gap-px my-1">
+          {[42, 58, 50, 72, 60, 68, 55, 80, 70, 85, 75, 90].map((h, i) => (
+            <div key={i} className={`flex-1 rounded-sm ${isUp ? 'bg-up/50' : 'bg-down/50'}`} style={{ height: `${h}%` }} />
+          ))}
+        </div>
+        <div className="shrink-0">
+          <div className={`text-[18px] font-bold leading-tight ${isUp ? 'text-up' : 'text-down'}`}>{stock.price}</div>
+          <div className={`text-[10px] ${isUp ? 'text-up' : 'text-down'}`}>
+            {isUp ? '▲' : '▼'} {stock.changeAmt}원 ({isUp ? '+' : ''}{stock.change}%)
+          </div>
+        </div>
+      </WidgetCard>
+    )
+  }
+
+  if (variant === 'stock-2x2') {
+    return (
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+        <div className="flex items-start justify-between mb-1.5 shrink-0">
+          <div className="flex items-center gap-2">
+            <StockAvatar name={stock.label} color={stock.color} size="sm" />
+            <div>
+              <div className="text-[13px] font-bold text-foreground">{stock.name}</div>
+              <div className="text-[9px] text-foreground-disabled">{stock.code}</div>
+            </div>
+          </div>
+          <div className="text-right">
+            <div className={`text-[18px] font-bold leading-tight ${isUp ? 'text-up' : 'text-down'}`}>{stock.price}</div>
+            <PriceChange value={stock.change} className="text-[10px]" />
+          </div>
+        </div>
+        <div className="flex-1 min-h-0 bg-background rounded-xl flex items-end px-2 pb-2 pt-2 gap-px my-1.5">
+          {[38, 52, 44, 58, 48, 62, 50, 68, 56, 72, 60, 78, 65, 82, 70, 88, 75, 90, 78, 85].map((h, i) => (
+            <div key={i} className={`flex-1 rounded-sm ${isUp ? 'bg-up/50' : 'bg-down/50'}`} style={{ height: `${h}%` }} />
+          ))}
+        </div>
+        <div className="flex justify-between shrink-0">
+          {[
+            { label: '시가', val: stock.open },
+            { label: '고가', val: stock.high },
+            { label: '저가', val: stock.low },
+          ].map(({ label, val }) => (
+            <div key={label} className="text-center">
+              <div className="text-[9px] text-foreground-disabled">{label}</div>
+              <div className="text-[11px] font-semibold text-foreground">{val}</div>
+            </div>
+          ))}
+        </div>
+      </WidgetCard>
+    )
+  }
+
+  /* stock-sm (default) */
   return (
-    <WidgetCard>
+    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
       <div className="flex items-center gap-2 mb-1">
         <StockAvatar name={stock.label} color={stock.color} size="sm" />
         <div className="flex-1 min-w-0">

--- a/src/components/widgets/TradeHistoryWidget.jsx
+++ b/src/components/widgets/TradeHistoryWidget.jsx
@@ -1,0 +1,128 @@
+import WidgetCard from './WidgetCard'
+import { cn } from '@/lib/cn'
+
+const TRADES = [
+  { name: '삼성전자',       type: '매수', qty: '10주', date: '3.18' },
+  { name: 'SK하이닉스',     type: '매도', qty: '5주',  date: '3.17' },
+  { name: 'LG에너지솔루션', type: '매수', qty: '3주',  date: '3.16' },
+  { name: 'NAVER',          type: '매도', qty: '2주',  date: '3.15' },
+  { name: '현대차',         type: '매수', qty: '7주',  date: '3.14' },
+]
+
+const WEEK_DAYS = ['일', '월', '화', '수', '목', '금', '토']
+const WEEK_CELLS = [
+  { d: 16, trades: null },
+  { d: 17, trades: [{ s: '현대차',  buy: true  }] },
+  { d: 18, trades: [{ s: '삼성',    buy: true  }, { s: 'NAVER', buy: false }] },
+  { d: 19, trades: [{ s: 'LG에너',  buy: true  }] },
+  { d: 20, trades: [{ s: 'SK하이',  buy: false }] },
+  { d: 21, trades: [{ s: '삼성',    buy: true  }, { s: 'SK',    buy: false }] },
+  { d: 22, trades: null },
+]
+
+const MONTH_CELLS = [
+  null, null, null, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+  15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, null,
+]
+const TRADE_MAP = {
+  3:  [{ s: '삼성', t: true  }, { s: 'SK하이', t: false }],
+  7:  [{ s: '현대차', t: true }],
+  12: [{ s: 'LG에너', t: true  }, { s: 'NAVER',  t: false }],
+  18: [{ s: '삼성',   t: true  }, { s: 'SK',     t: false }],
+  25: [{ s: '포스코',  t: false }],
+}
+
+export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1, rowSpan = 1, onDelete }) {
+  /* ── trade-wide: 주간 캘린더 2×1 ── */
+  if (variant === 'trade-wide') {
+    return (
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+        <div className="flex items-center justify-between mb-2 shrink-0">
+          <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">거래내역</span>
+          <span className="text-[9px] text-foreground-disabled">2026년 3월</span>
+        </div>
+        <div className="grid grid-cols-7 gap-0.5 shrink-0 mb-1">
+          {WEEK_DAYS.map((d) => (
+            <div key={d} className="text-center text-[8px] font-semibold text-foreground-disabled">{d}</div>
+          ))}
+        </div>
+        <div className="grid grid-cols-7 gap-0.5 flex-1 min-h-0">
+          {WEEK_CELLS.map(({ d, trades }, i) => (
+            <div key={i} className="flex flex-col items-start rounded-lg p-1 bg-background/50">
+              <span className="text-[9px] leading-none mb-1 text-foreground">{d}</span>
+              {trades && trades.map((tr, j) => (
+                <div key={j} className="flex items-center gap-0.5 w-full mb-0.5">
+                  <div className={cn('w-0.5 rounded-full shrink-0 self-stretch', tr.buy ? 'bg-up' : 'bg-down')} />
+                  <span className="text-[8px] leading-snug truncate text-foreground">{tr.s}</span>
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </WidgetCard>
+    )
+  }
+
+  /* ── trade-cal: 월간 캘린더 2×2 ── */
+  if (variant === 'trade-cal') {
+    return (
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+        <div className="flex items-center justify-between mb-2 shrink-0">
+          <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">거래내역</span>
+          <span className="text-[9px] text-foreground-disabled">2026년 3월</span>
+        </div>
+        <div className="grid grid-cols-7 gap-0.5 shrink-0 mb-1">
+          {WEEK_DAYS.map((d) => (
+            <div key={d} className="text-center text-[8px] font-semibold text-foreground-disabled">{d}</div>
+          ))}
+        </div>
+        <div className="grid grid-cols-7 gap-0.5 flex-1 min-h-0">
+          {MONTH_CELLS.map((d, i) => {
+            const trades = d ? TRADE_MAP[d] : null
+            return (
+              <div key={i} className="flex flex-col items-start rounded p-0.5">
+                <span className={cn('text-[9px] leading-none mb-px', d ? 'text-foreground' : 'invisible')}>
+                  {d ?? '0'}
+                </span>
+                {trades && trades.slice(0, 2).map((tr, j) => (
+                  <div key={j} className="flex items-center gap-px w-full">
+                    <div className={cn('w-0.5 rounded-full shrink-0 self-stretch', tr.t ? 'bg-up' : 'bg-down')} />
+                    <span className="text-[7px] leading-snug truncate text-foreground">{tr.s}</span>
+                  </div>
+                ))}
+              </div>
+            )
+          })}
+        </div>
+      </WidgetCard>
+    )
+  }
+
+  /* ── trade-list: 목록형 1×1 (default) ── */
+  return (
+    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+      <div className="flex items-center justify-between mb-2 shrink-0">
+        <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">거래내역</span>
+      </div>
+      <div className="flex-1 flex flex-col gap-1.5 min-h-0 overflow-y-auto">
+        {TRADES.map(({ name, type, qty, date }) => (
+          <div key={`${name}-${date}`} className="flex items-center justify-between">
+            <div className="flex items-center gap-1.5 min-w-0">
+              <span className={cn(
+                'text-[8px] font-semibold px-1 py-px rounded shrink-0',
+                type === '매수' ? 'text-up bg-up/10' : 'text-down bg-down/10',
+              )}>
+                {type}
+              </span>
+              <span className="text-[10px] text-foreground truncate">{name}</span>
+            </div>
+            <div className="flex items-center gap-1.5 shrink-0">
+              <span className="text-[9px] text-foreground-disabled">{qty}</span>
+              <span className="text-[8px] text-foreground-disabled">{date}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </WidgetCard>
+  )
+}

--- a/src/components/widgets/WatchlistWidget.jsx
+++ b/src/components/widgets/WatchlistWidget.jsx
@@ -3,10 +3,18 @@ import StockAvatar from '@/components/ui/StockAvatar'
 import WidgetCard from './WidgetCard'
 import { WATCHLIST } from '@/mocks/home'
 
-export default function WatchlistWidget() {
+const WATCHLIST_EXTENDED = [
+  ...WATCHLIST,
+  { name: 'POSCO홀딩스', label: 'P',  color: 'warning', price: '₩378,500', change:  0.53 },
+  { name: 'SK하이닉스',  label: 'SK', color: 'yellow',  price: '₩195,500', change:  2.35 },
+]
+
+export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1, rowSpan = 1, onDelete }) {
+  const items = variant === 'watchlist-sm' ? WATCHLIST : WATCHLIST_EXTENDED
+
   return (
-    <WidgetCard>
-      <div className="flex items-center justify-between mb-2">
+    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+      <div className="flex items-center justify-between mb-2 shrink-0">
         <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">관심 종목</span>
         <button
           onClick={(e) => e.stopPropagation()}
@@ -15,8 +23,8 @@ export default function WatchlistWidget() {
           + 추가
         </button>
       </div>
-      <div className="flex-1 flex flex-col justify-between gap-0.5">
-        {WATCHLIST.map((stock, i) => (
+      <div className={`flex-1 flex flex-col gap-0.5 ${variant === 'watchlist-sm' ? 'justify-between' : 'min-h-0 overflow-y-auto'}`}>
+        {items.map((stock, i) => (
           <div key={stock.name}>
             <div className="flex items-center gap-2 py-1 hover:bg-surface-subtle rounded-xl px-1 transition-colors cursor-pointer">
               <StockAvatar name={stock.label} color={stock.color} size="sm" />
@@ -26,7 +34,7 @@ export default function WatchlistWidget() {
               </div>
               <PriceChange value={stock.change} className="text-[10px]" />
             </div>
-            {i < WATCHLIST.length - 1 && <div className="h-px bg-stroke-subtle mx-1" />}
+            {i < items.length - 1 && <div className="h-px bg-stroke-subtle mx-1" />}
           </div>
         ))}
       </div>

--- a/src/components/widgets/WidgetCard.jsx
+++ b/src/components/widgets/WidgetCard.jsx
@@ -2,7 +2,7 @@ import useEditModeStore from '@/store/useEditModeStore'
 import EditHandle from './EditHandle'
 import { cn } from '@/lib/cn'
 
-export default function WidgetCard({ children, colSpan = 1, className = '', onDelete }) {
+export default function WidgetCard({ children, colSpan = 1, rowSpan = 1, className = '', onDelete }) {
   const { isEditMode } = useEditModeStore()
 
   return (
@@ -13,6 +13,7 @@ export default function WidgetCard({ children, colSpan = 1, className = '', onDe
           ? 'animate-wiggle cursor-grab'
           : 'cursor-pointer transition-[transform] duration-[200ms] hover:-translate-y-px',
         colSpan === 2 ? 'col-span-2' : 'col-span-1',
+        rowSpan === 2 && 'row-span-2',
         className,
       )}
     >

--- a/src/components/widgets/widgetRegistry.js
+++ b/src/components/widgets/widgetRegistry.js
@@ -1,0 +1,23 @@
+import BalanceWidget from './BalanceWidget'
+import IndexWidget from './IndexWidget'
+import PortfolioWidget from './PortfolioWidget'
+import StockChartWidget from './StockChartWidget'
+import RankingWidget from './RankingWidget'
+import WatchlistWidget from './WatchlistWidget'
+import MarketOverviewWidget from './MarketOverviewWidget'
+import ExchangeWidget from './ExchangeWidget'
+import TradeHistoryWidget from './TradeHistoryWidget'
+import ReportWidget from './ReportWidget'
+
+export const WIDGET_REGISTRY = {
+  'balance':         BalanceWidget,
+  'index':           IndexWidget,
+  'portfolio':       PortfolioWidget,
+  'stock-chart':     StockChartWidget,
+  'ranking':         RankingWidget,
+  'watchlist':       WatchlistWidget,
+  'market-overview': MarketOverviewWidget,
+  'exchange':        ExchangeWidget,
+  'trade-history':   TradeHistoryWidget,
+  'report':          ReportWidget,
+}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -3,23 +3,22 @@ import { Pencil } from 'lucide-react'
 import LiveDot from '@/components/ui/LiveDot'
 import useEditModeStore from '@/store/useEditModeStore'
 import useGridStore from '@/store/useGridStore'
+import useWidgetStore from '@/store/useWidgetStore'
 import { cn } from '@/lib/cn'
-import BalanceWidget from '@/components/widgets/BalanceWidget'
-import IndexWidget from '@/components/widgets/IndexWidget'
-import PortfolioWidget from '@/components/widgets/PortfolioWidget'
-import StockChartWidget from '@/components/widgets/StockChartWidget'
-import RankingWidget from '@/components/widgets/RankingWidget'
-import WatchlistWidget from '@/components/widgets/WatchlistWidget'
-import MarketOverviewWidget from '@/components/widgets/MarketOverviewWidget'
-import ExchangeWidget from '@/components/widgets/ExchangeWidget'
 import AddWidgetSlot from '@/components/widgets/AddWidgetSlot'
-import { HOME_STOCKS } from '@/mocks/home'
+import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry'
 import { GRID_COLS, GRID_ROWS, GRID_GAP, MIN_GRID_WIDTH, MIN_GRID_HEIGHT, MIN_CELL_WIDTH, MIN_CELL_HEIGHT } from '@/lib/gridConstants'
 
 export default function HomePage() {
   const { isEditMode } = useEditModeStore()
-  const { setCellSize } = useGridStore()
+  const { setCellSize, setPreviewCellSize } = useGridStore()
+  const { widgets, removeWidget } = useWidgetStore()
   const gridRef = useRef(null)
+  const isEditModeRef = useRef(isEditMode)
+
+  useEffect(() => {
+    isEditModeRef.current = isEditMode
+  }, [isEditMode])
 
   useEffect(() => {
     const el = gridRef.current
@@ -33,11 +32,15 @@ export default function HomePage() {
       const cellWidth = (width - GRID_GAP * (GRID_COLS - 1)) / GRID_COLS
       const cellHeight = (height - GRID_GAP * (GRID_ROWS - 1)) / GRID_ROWS
       setCellSize(cellWidth, cellHeight)
+      // EditPanel 미열림 상태(full grid)의 셀 크기만 preview 기준으로 저장
+      if (!isEditModeRef.current) {
+        setPreviewCellSize(cellWidth, cellHeight)
+      }
     })
 
     observer.observe(el)
     return () => observer.disconnect()
-  }, [setCellSize])
+  }, [setCellSize, setPreviewCellSize])
 
   return (
     <div className="flex flex-col h-full overflow-hidden p-3 gap-2.5">
@@ -89,20 +92,20 @@ export default function HomePage() {
             minHeight: `${MIN_GRID_HEIGHT}px`,
           }}
         >
-          {/* Row 1 */}
-          <BalanceWidget />
-          <IndexWidget />
-          <PortfolioWidget />
-
-          {/* Row 2 */}
-          <StockChartWidget stock={HOME_STOCKS[0]} />
-          <RankingWidget />
-          <WatchlistWidget />
-
-          {/* Row 3 */}
-          <MarketOverviewWidget />
-          <ExchangeWidget />
-          <StockChartWidget stock={HOME_STOCKS[1]} />
+          {widgets.map((w) => {
+            const Component = WIDGET_REGISTRY[w.widgetTypeId]
+            if (!Component) return null
+            return (
+              <Component
+                key={w.instanceId}
+                variant={w.variantId}
+                colSpan={w.colSpan}
+                rowSpan={w.rowSpan}
+                config={w.config}
+                onDelete={() => removeWidget(w.instanceId)}
+              />
+            )
+          })}
           {!isEditMode && <AddWidgetSlot />}
         </div>
       </div>

--- a/src/store/useGridStore.js
+++ b/src/store/useGridStore.js
@@ -4,6 +4,13 @@ const useGridStore = create((set) => ({
   cellWidth: 0,
   cellHeight: 0,
   setCellSize: (cellWidth, cellHeight) => set({ cellWidth, cellHeight }),
+
+  // EditPanel 미리보기용 — edit mode 진입 전 마지막 full-grid 셀 크기
+  // 창 최대화 상태를 기준으로 올바른 위젯 비율을 제공
+  previewCellWidth: 0,
+  previewCellHeight: 0,
+  setPreviewCellSize: (previewCellWidth, previewCellHeight) =>
+    set({ previewCellWidth, previewCellHeight }),
 }))
 
 export default useGridStore

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -1,0 +1,78 @@
+import { create } from 'zustand'
+import { GRID_COLS, GRID_ROWS } from '@/lib/gridConstants'
+
+/* ── 그리드 배치 시뮬레이션 ────────────────────────────────
+   CSS grid auto-placement(row-first)를 모방해 빈 셀 탐색.
+   widgets를 순서대로 배치 후 새 위젯이 들어갈 자리가 있는지 확인.
+──────────────────────────────────────────────────────────── */
+function _tryPlace(grid, colSpan, rowSpan) {
+  for (let row = 0; row <= GRID_ROWS - rowSpan; row++) {
+    for (let col = 0; col <= GRID_COLS - colSpan; col++) {
+      let ok = true
+      outer: for (let r = row; r < row + rowSpan; r++) {
+        for (let c = col; c < col + colSpan; c++) {
+          if (grid[r][c]) { ok = false; break outer }
+        }
+      }
+      if (ok) {
+        for (let r = row; r < row + rowSpan; r++)
+          for (let c = col; c < col + colSpan; c++)
+            grid[r][c] = true
+        return true
+      }
+    }
+  }
+  return false
+}
+
+export function canFitInGrid(widgets, colSpan, rowSpan) {
+  const grid = Array.from({ length: GRID_ROWS }, () => Array(GRID_COLS).fill(false))
+  for (const w of widgets) _tryPlace(grid, w.colSpan, w.rowSpan)
+  return _tryPlace(grid, colSpan, rowSpan)
+}
+
+const INITIAL_WIDGETS = [
+  { instanceId: 'w1', widgetTypeId: 'balance',         variantId: 'balance-sm',   colSpan: 1, rowSpan: 1 },
+  { instanceId: 'w2', widgetTypeId: 'index',           variantId: 'index-wide',   colSpan: 2, rowSpan: 1 },
+  { instanceId: 'w3', widgetTypeId: 'portfolio',       variantId: 'portfolio-sm', colSpan: 1, rowSpan: 1 },
+  { instanceId: 'w4', widgetTypeId: 'stock-chart',     variantId: 'stock-sm',     colSpan: 1, rowSpan: 1, config: { stockId: 'samsung'  } },
+  { instanceId: 'w5', widgetTypeId: 'ranking',         variantId: 'ranking-wide', colSpan: 2, rowSpan: 1 },
+  { instanceId: 'w6', widgetTypeId: 'watchlist',       variantId: 'watchlist-sm', colSpan: 1, rowSpan: 1 },
+  { instanceId: 'w7', widgetTypeId: 'market-overview', variantId: 'market-sm',    colSpan: 1, rowSpan: 1 },
+  { instanceId: 'w8', widgetTypeId: 'exchange',        variantId: 'exchange-sm',  colSpan: 1, rowSpan: 1 },
+  { instanceId: 'w9', widgetTypeId: 'stock-chart',     variantId: 'stock-sm',     colSpan: 1, rowSpan: 1, config: { stockId: 'skhynix' } },
+]
+
+const useWidgetStore = create((set) => ({
+  widgets: INITIAL_WIDGETS,
+
+  // 편집 모드 진입 시 스냅샷 저장 → 취소 시 복원
+  _snapshot: null,
+  snapshotWidgets: () => set((state) => ({ _snapshot: state.widgets })),
+  restoreSnapshot: () =>
+    set((state) => ({ widgets: state._snapshot ?? state.widgets, _snapshot: null })),
+  clearSnapshot: () => set({ _snapshot: null }),
+
+  addWidget: (widgetTypeId, variant) =>
+    set((state) => {
+      if (!canFitInGrid(state.widgets, variant.colSpan, variant.rowSpan)) return state
+      return {
+        widgets: [
+          ...state.widgets,
+          {
+            instanceId: crypto.randomUUID(),
+            widgetTypeId,
+            variantId: variant.id,
+            colSpan: variant.colSpan,
+            rowSpan: variant.rowSpan,
+          },
+        ],
+      }
+    }),
+  removeWidget: (instanceId) =>
+    set((state) => ({
+      widgets: state.widgets.filter((w) => w.instanceId !== instanceId),
+    })),
+}))
+
+export default useWidgetStore


### PR DESCRIPTION
Closes #32

## 구현 내용

### 1. 위젯 variant 시스템
- 기존 8종 위젯에 `variant` / `colSpan` / `rowSpan` / `onDelete` prop 추가, variant별 레이아웃 분기 구현
- `WidgetCard`: `rowSpan` prop 추가 (row-span-2 지원)
- 신규 위젯 2종 구현: `TradeHistoryWidget` (list/wide/cal), `ReportWidget` (sm/wide/2x2)
- `widgetRegistry.js`: widgetTypeId → 컴포넌트 매핑 테이블 (10종)

### 2. 동적 위젯 스토어
- `useWidgetStore`: 위젯 인스턴스 목록 관리 (addWidget / removeWidget)
- `canFitInGrid()`: CSS grid auto-placement 시뮬레이션 — 4열×3행 초과 시 추가 차단
- 편집 모드 스냅샷: 진입 시 저장, 취소 시 복원, 저장 시 폐기
- `HomePage`: `useWidgetStore` 기반 동적 렌더링으로 전환

### 3. EditPanel → 대시보드 연동
- 위젯 선택 → 사이즈 선택 → 추가 클릭 → 대시보드 즉시 반영
- 공간 부족 variant에 오버레이 표시, 클릭 비활성화
- 배치 위젯 수 동적 표시 (`n개 배치 중`)

### 4. EditPanel 미리보기 UX 개선
- `previewCellSize` 스냅샷: EditPanel 미열림(full-grid) 상태의 실제 셀 비율 기준으로 미리보기 안정화
- `absolute inset-0` 레이아웃으로 `h-full` 참조 정확도 개선
- 미리보기 카드 라벨/배지 제거, 콘텐츠만 표시
- 각 위젯 미리보기 텍스트·레이아웃 세부 수정 (총 평가자산, 주요 지수, 환율, 섹터별 비중 등)

### 5. 편집 취소 시 원상 복원
- "취소" 버튼: 편집 중 추가/삭제한 위젯을 진입 전 상태로 롤백
- "완료·저장" 버튼: 현재 상태 확정

## 변경 파일
- `src/store/useWidgetStore.js` (신규)
- `src/store/useGridStore.js`
- `src/components/widgets/widgetRegistry.js` (신규)
- `src/components/widgets/TradeHistoryWidget.jsx` (신규)
- `src/components/widgets/ReportWidget.jsx` (신규)
- `src/components/widgets/WidgetCard.jsx` + 기존 위젯 8종
- `src/components/layout/EditPanel/WidgetSizeList.jsx`
- `src/components/layout/EditPanel/WidgetTypeList.jsx`
- `src/components/layout/AppHeader.jsx`
- `src/pages/HomePage.jsx`