### PR TITLE
docs(widget): 위젯 사이즈 확정 프로토타입 추가

### DIFF
--- a/front-mvp/grid-a-4x4.html
+++ b/front-mvp/grid-a-4x4.html
@@ -1,0 +1,279 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <title>SOL Lite — 그리드 A안 (4×4)</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { background:#F4F6FA; font-family:'Pretendard',-apple-system,sans-serif; height:100vh; overflow:hidden; color:#191F28; padding-top:28px; }
+    .up { color:#E8393E; } .down { color:#0075E8; }
+    .up-bg { background:#FFF0F1; color:#E8393E; }
+    .down-bg { background:#EFF6FF; color:#0075E8; }
+
+    .app-header { height:54px; background:#fff; border-bottom:1px solid #EAECF0; display:flex; align-items:center; padding:0 16px; gap:12px; flex-shrink:0; }
+    .app-body   { height:calc(100vh - 54px - 28px); display:flex; overflow:hidden; }
+    .sidebar    { width:56px; flex-shrink:0; background:#fff; border-right:1px solid #EAECF0; display:flex; flex-direction:column; align-items:center; padding:14px 0; gap:4px; }
+    .nav-icon   { width:40px; height:40px; border-radius:12px; display:flex; align-items:center; justify-content:center; color:#9CA3AF; cursor:pointer; }
+    .nav-icon.active { background:#EEF2FF; color:#0046FF; }
+
+    .card { background:#fff; border:1px solid #EAECF0; border-radius:16px; padding:12px 14px; overflow:hidden; display:flex; flex-direction:column; position:relative; cursor:pointer; transition:box-shadow .15s,border-color .15s; }
+    .card:hover { border-color:#BFD0FF; box-shadow:0 4px 16px rgba(0,70,255,.08); }
+    .lbl { font-size:9px; font-weight:600; color:#9CA3AF; letter-spacing:.05em; text-transform:uppercase; margin-bottom:5px; }
+
+    /* A안: 4열 × 4행 */
+    .grid { display:grid; grid-template-columns:repeat(4,1fr); grid-template-rows:repeat(4,1fr); gap:10px; width:100%; height:100%; }
+    .c2 { grid-column:span 2; }
+    .r2 { grid-row:span 2; }
+
+    .bar { border-radius:2px; align-self:flex-end; }
+    .pie { border-radius:50%; background:conic-gradient(#0046FF 0% 34%,#00A878 34% 54%,#FF9500 54% 69%,#EF4444 69% 81%,#8B5CF6 81% 100%); flex-shrink:0; }
+    .slot { border:2px dashed #E5E7EB; border-radius:16px; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:5px; cursor:pointer; }
+    .slot:hover { border-color:#0046FF; background:#F5F7FF; }
+    .tag { font-size:8px; font-weight:600; padding:1px 5px; border-radius:3px; }
+
+    /* 채팅 패널 */
+    .cp { width:368px; flex-shrink:0; background:#FAFBFC; border-left:1px solid #EAECF0; display:flex; flex-direction:column; }
+    .cp-head { height:48px; display:flex; align-items:center; gap:8px; padding:0 16px; border-bottom:1px solid #EAECF0; flex-shrink:0; }
+    .cp-msgs { flex:1; overflow-y:auto; padding:12px 16px; display:flex; flex-direction:column; gap:10px; }
+    .cp-foot { height:56px; display:flex; align-items:center; gap:8px; padding:0 12px; border-top:1px solid #EAECF0; flex-shrink:0; }
+    .ai-bbl { background:#fff; border:1px solid #EAECF0; border-radius:12px 12px 12px 3px; padding:9px 12px; max-width:280px; font-size:11px; color:#374151; line-height:1.6; }
+    .me-bbl { background:#0046FF; border-radius:12px 12px 3px 12px; padding:9px 12px; max-width:220px; margin-left:auto; font-size:11px; color:#fff; line-height:1.6; }
+    .av { width:24px; height:24px; border-radius:50%; background:#0046FF; display:flex; align-items:center; justify-content:center; flex-shrink:0; margin-top:2px; }
+
+    .compare-banner { position:fixed; top:0; left:0; right:0; z-index:100; background:#0046FF; color:#fff; font-size:11px; font-weight:700; text-align:center; padding:5px; }
+  </style>
+</head>
+<body>
+
+<div class="compare-banner">A안 — 4열 × 4행 (16셀) · 전체 위젯 10종 · 채팅 패널 상시 오픈 · 가용 너비 ≈ 240px/셀 @1440</div>
+
+<!-- Header -->
+<header class="app-header">
+  <div style="display:flex;align-items:center;gap:8px;margin-right:6px;">
+    <div style="width:28px;height:28px;border-radius:9px;background:#0046FF;display:flex;align-items:center;justify-content:center;">
+      <svg style="width:14px;height:14px;" fill="none" stroke="white" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"/></svg>
+    </div>
+    <span style="font-size:15px;font-weight:700;color:#111827;">SOL <span style="color:#0046FF;">Lite</span></span>
+  </div>
+  <nav style="display:flex;gap:3px;">
+    <button style="padding:5px 11px;border-radius:8px;background:#EEF2FF;color:#0046FF;font-size:12px;font-weight:600;">홈</button>
+    <button style="padding:5px 11px;border-radius:8px;color:#9CA3AF;font-size:12px;">시세</button>
+    <button style="padding:5px 11px;border-radius:8px;color:#9CA3AF;font-size:12px;">투자</button>
+    <button style="padding:5px 11px;border-radius:8px;color:#9CA3AF;font-size:12px;">자산</button>
+  </nav>
+  <div style="flex:1;"></div>
+  <button style="display:flex;align-items:center;gap:5px;padding:5px 11px;border-radius:10px;border:1px solid #E5E7EB;color:#6B7280;font-size:12px;">
+    <svg style="width:13px;height:13px;" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+    위젯 편집
+  </button>
+  <div style="display:flex;align-items:center;gap:6px;padding-left:8px;border-left:1px solid #F3F4F6;margin-left:4px;">
+    <div style="width:28px;height:28px;border-radius:50%;background:#0046FF;color:#fff;font-size:11px;font-weight:700;display:flex;align-items:center;justify-content:center;">김</div>
+    <div><div style="font-size:11px;font-weight:600;color:#111827;">김SOL</div><div style="font-size:9px;color:#9CA3AF;">주문가능 7,478만원</div></div>
+  </div>
+</header>
+
+<div class="app-body">
+  <!-- Sidebar -->
+  <div class="sidebar">
+    <div class="nav-icon active"><svg style="width:20px;height:20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg></div>
+    <div class="nav-icon"><svg style="width:20px;height:20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/></svg></div>
+    <div class="nav-icon"><svg style="width:20px;height:20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4zM3 12a9 9 0 1118 0A9 9 0 013 12z"/></svg></div>
+    <div class="nav-icon"><svg style="width:20px;height:20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/></svg></div>
+  </div>
+
+  <!-- Main -->
+  <main style="flex:1;min-width:0;display:flex;flex-direction:column;overflow:hidden;padding:12px;gap:10px;">
+    <!-- 서브바 -->
+    <div style="display:flex;align-items:center;justify-content:space-between;flex-shrink:0;height:24px;padding:0 2px;">
+      <span style="font-size:13px;font-weight:700;">나의 대시보드</span>
+      <div style="display:flex;align-items:center;gap:4px;padding:2px 8px;border-radius:100px;background:#fff;border:1px solid #EAECF0;">
+        <span style="width:5px;height:5px;border-radius:50%;background:#34D399;display:inline-block;"></span>
+        <span style="font-size:10px;color:#9CA3AF;">실시간 반영</span>
+      </div>
+    </div>
+
+    <!-- 4×4 그리드 -->
+    <div style="flex:1;min-height:0;">
+      <div class="grid" style="min-width:620px;min-height:540px;">
+
+        <!-- ─── Row 1 ─── -->
+        <!-- [1] 계좌 잔고 1×1 -->
+        <div class="card">
+          <div class="lbl">계좌 잔고</div>
+          <div style="flex:1;display:flex;flex-direction:column;justify-content:space-between;">
+            <span style="font-size:9px;color:#9CA3AF;">총 평가자산</span>
+            <div>
+              <div style="font-size:17px;font-weight:800;line-height:1.1;">84,320,000</div>
+              <div style="font-size:9px;font-weight:600;margin-top:3px;" class="up">▲ +2,152,000원 (+2.61%)</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- [2] 주요 지수 2×1 -->
+        <div class="card c2">
+          <div class="lbl">주요 지수</div>
+          <div style="flex:1;display:flex;">
+            <div style="flex:1;display:flex;flex-direction:column;justify-content:space-between;align-items:center;padding:0 6px;border-right:1px solid #F3F4F6;">
+              <div style="text-align:center;"><div style="font-size:9px;color:#9CA3AF;">KOSPI</div><div style="font-size:15px;font-weight:800;line-height:1.1;">2,685.42</div><div style="font-size:9px;" class="up">▲ +0.46%</div></div>
+              <div style="display:flex;align-items:flex-end;gap:1px;height:22px;width:100%;"><div class="bar" style="flex:1;background:#FECACA;height:45%;"></div><div class="bar" style="flex:1;background:#FCA5A5;height:58%;"></div><div class="bar" style="flex:1;background:#F87171;height:70%;"></div><div class="bar" style="flex:1;background:#EF4444;height:80%;"></div><div class="bar" style="flex:1;background:#DC2626;height:90%;"></div></div>
+            </div>
+            <div style="flex:1;display:flex;flex-direction:column;justify-content:space-between;align-items:center;padding:0 6px;border-right:1px solid #F3F4F6;">
+              <div style="text-align:center;"><div style="font-size:9px;color:#9CA3AF;">KOSDAQ</div><div style="font-size:15px;font-weight:800;line-height:1.1;">868.15</div><div style="font-size:9px;" class="down">▼ −0.21%</div></div>
+              <div style="display:flex;align-items:flex-end;gap:1px;height:22px;width:100%;"><div class="bar" style="flex:1;background:#BFDBFE;height:60%;"></div><div class="bar" style="flex:1;background:#93C5FD;height:50%;"></div><div class="bar" style="flex:1;background:#60A5FA;height:43%;"></div><div class="bar" style="flex:1;background:#3B82F6;height:38%;"></div><div class="bar" style="flex:1;background:#2563EB;height:35%;"></div></div>
+            </div>
+            <div style="flex:1;display:flex;flex-direction:column;justify-content:space-between;align-items:center;padding:0 6px;">
+              <div style="text-align:center;"><div style="font-size:9px;color:#9CA3AF;">NASDAQ</div><div style="font-size:15px;font-weight:800;line-height:1.1;">16,274</div><div style="font-size:9px;" class="up">▲ +0.83%</div></div>
+              <div style="display:flex;align-items:flex-end;gap:1px;height:22px;width:100%;"><div class="bar" style="flex:1;background:#FECACA;height:40%;"></div><div class="bar" style="flex:1;background:#FCA5A5;height:55%;"></div><div class="bar" style="flex:1;background:#F87171;height:68%;"></div><div class="bar" style="flex:1;background:#EF4444;height:78%;"></div><div class="bar" style="flex:1;background:#DC2626;height:88%;"></div></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- [3] 포트폴리오 1×1 -->
+        <div class="card">
+          <div class="lbl">포트폴리오</div>
+          <div style="flex:1;display:flex;align-items:center;gap:8px;">
+            <div class="pie" style="width:38px;height:38px;"></div>
+            <div style="display:flex;flex-direction:column;gap:3px;">
+              <div style="display:flex;align-items:center;gap:3px;"><div style="width:5px;height:5px;border-radius:50%;background:#0046FF;"></div><span style="font-size:9px;color:#6B7280;">삼성 34%</span></div>
+              <div style="display:flex;align-items:center;gap:3px;"><div style="width:5px;height:5px;border-radius:50%;background:#00A878;"></div><span style="font-size:9px;color:#6B7280;">SK하이 20%</span></div>
+              <div style="display:flex;align-items:center;gap:3px;"><div style="width:5px;height:5px;border-radius:50%;background:#FF9500;"></div><span style="font-size:9px;color:#6B7280;">LG에너 15%</span></div>
+              <div style="display:flex;align-items:center;gap:3px;"><div style="width:5px;height:5px;border-radius:50%;background:#EF4444;"></div><span style="font-size:9px;color:#6B7280;">기타 31%</span></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- ─── Row 2 + Row 3 ─── -->
+
+        <!-- [4] 주가/차트 2×2 -->
+        <div class="card c2 r2" style="border-color:#BFD0FF;background:linear-gradient(135deg,#f8f9ff,#fff);">
+          <div style="display:flex;align-items:flex-start;justify-content:space-between;flex-shrink:0;margin-bottom:4px;">
+            <div><div style="font-size:12px;font-weight:700;">SK하이닉스</div><div style="font-size:8px;color:#9CA3AF;">000660 · KOSPI</div></div>
+            <div style="text-align:right;"><div style="font-size:17px;font-weight:800;line-height:1.1;">182,000</div><div style="font-size:9px;" class="up">▲ +3,500 (+1.96%)</div></div>
+          </div>
+          <div style="background:#F9FAFB;border-radius:10px;flex:1;display:flex;align-items:flex-end;padding:8px;gap:2px;min-height:0;margin:3px 0;">
+            <div class="bar" style="flex:1;background:#FECACA;height:35%;"></div><div class="bar" style="flex:1;background:#FECACA;height:42%;"></div><div class="bar" style="flex:1;background:#FCA5A5;height:38%;"></div><div class="bar" style="flex:1;background:#FCA5A5;height:52%;"></div><div class="bar" style="flex:1;background:#F87171;height:56%;"></div><div class="bar" style="flex:1;background:#F87171;height:62%;"></div><div class="bar" style="flex:1;background:#EF4444;height:68%;"></div><div class="bar" style="flex:1;background:#EF4444;height:73%;"></div><div class="bar" style="flex:1;background:#DC2626;height:78%;"></div><div class="bar" style="flex:1;background:#DC2626;height:83%;"></div><div class="bar" style="flex:1;background:#B91C1C;height:88%;"></div><div class="bar" style="flex:1;background:#B91C1C;height:93%;"></div>
+          </div>
+          <div style="display:flex;justify-content:space-between;flex-shrink:0;">
+            <div style="text-align:center;"><div style="font-size:8px;color:#9CA3AF;">시가</div><div style="font-size:10px;font-weight:600;">178,500</div></div>
+            <div style="text-align:center;"><div style="font-size:8px;color:#9CA3AF;">고가</div><div style="font-size:10px;font-weight:600;" class="up">183,000</div></div>
+            <div style="text-align:center;"><div style="font-size:8px;color:#9CA3AF;">저가</div><div style="font-size:10px;font-weight:600;" class="down">177,200</div></div>
+            <div style="text-align:center;"><div style="font-size:8px;color:#9CA3AF;">거래량</div><div style="font-size:10px;font-weight:600;">8.2M</div></div>
+          </div>
+          <div style="position:absolute;top:10px;right:10px;background:#EEF2FF;color:#0046FF;font-size:8px;font-weight:700;padding:2px 5px;border-radius:3px;">2×2</div>
+        </div>
+
+        <!-- [5] 실시간 순위 2×1 -->
+        <div class="card c2">
+          <div class="lbl">실시간 순위</div>
+          <div style="display:flex;gap:3px;margin-bottom:5px;">
+            <span class="tag" style="background:#EEF2FF;color:#0046FF;">거래대금</span>
+            <span class="tag" style="color:#9CA3AF;">상승률</span>
+            <span class="tag" style="color:#9CA3AF;">거래량</span>
+          </div>
+          <div style="flex:1;display:flex;flex-direction:column;gap:4px;overflow:hidden;">
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">1</span><span style="font-size:11px;font-weight:500;">삼성전자</span></div><span style="font-size:10px;font-weight:600;" class="up">+1.62%</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">2</span><span style="font-size:11px;font-weight:500;">SK하이닉스</span></div><span style="font-size:10px;font-weight:600;" class="up">+2.35%</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">3</span><span style="font-size:11px;font-weight:500;">LG에너지솔루션</span></div><span style="font-size:10px;font-weight:600;" class="down">−0.87%</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">4</span><span style="font-size:11px;font-weight:500;">POSCO홀딩스</span></div><span style="font-size:10px;font-weight:600;" class="up">+0.54%</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">5</span><span style="font-size:11px;font-weight:500;">현대차</span></div><span style="font-size:10px;font-weight:600;" class="down">−1.20%</span></div>
+          </div>
+        </div>
+
+        <!-- [6] 오늘의 시황 1×1 (row3, col3 — 2×2 차트 오른쪽 아래) -->
+        <div class="card">
+          <div class="lbl">오늘의 시황</div>
+          <div style="flex:1;display:flex;flex-direction:column;gap:4px;overflow:hidden;">
+            <p style="font-size:10px;color:#6B7280;line-height:1.5;">美 CPI 하회, 나스닥 1% ↑</p>
+            <p style="font-size:10px;color:#6B7280;line-height:1.5;">SK하이닉스 목표가 상향</p>
+            <p style="font-size:10px;color:#6B7280;line-height:1.5;">원/달러 1,378원 마감</p>
+          </div>
+        </div>
+
+        <!-- [7] 관심종목 1×1 -->
+        <div class="card">
+          <div class="lbl">관심종목</div>
+          <div style="flex:1;display:flex;flex-direction:column;gap:4px;overflow:hidden;">
+            <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;">삼성전자</span><span style="font-size:9px;font-weight:600;" class="up">+1.62%</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;">현대차</span><span style="font-size:9px;font-weight:600;" class="down">−0.43%</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;">LG에너지</span><span style="font-size:9px;font-weight:600;" class="up">+0.91%</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;">SK하이닉스</span><span style="font-size:9px;font-weight:600;" class="down">−0.82%</span></div>
+          </div>
+        </div>
+
+        <!-- ─── Row 4 ─── -->
+
+        <!-- [8] 환율 2×1 -->
+        <div class="card c2">
+          <div class="lbl">환율</div>
+          <div style="flex:1;display:flex;gap:12px;">
+            <div style="flex:1;display:flex;flex-direction:column;justify-content:space-between;">
+              <div>
+                <div style="font-size:9px;color:#9CA3AF;">USD / KRW</div>
+                <div style="font-size:17px;font-weight:800;line-height:1.1;">1,378.50</div>
+                <div style="font-size:9px;margin-top:2px;" class="down">▼ −2.30 (−0.17%)</div>
+              </div>
+              <div style="display:flex;align-items:flex-end;gap:1px;height:20px;">
+                <div class="bar" style="flex:1;background:#BFDBFE;height:70%;"></div><div class="bar" style="flex:1;background:#93C5FD;height:60%;"></div><div class="bar" style="flex:1;background:#60A5FA;height:55%;"></div><div class="bar" style="flex:1;background:#3B82F6;height:50%;"></div><div class="bar" style="flex:1;background:#2563EB;height:45%;"></div>
+              </div>
+            </div>
+            <div style="display:flex;flex-direction:column;justify-content:center;gap:6px;font-size:9px;padding-left:12px;border-left:1px solid #F3F4F6;">
+              <div><div style="color:#9CA3AF;margin-bottom:1px;">JPY / KRW</div><div style="font-weight:600;" class="up">9.18 ▲ +0.05%</div></div>
+              <div><div style="color:#9CA3AF;margin-bottom:1px;">EUR / KRW</div><div style="font-weight:600;" class="down">1,502 ▼ −0.22%</div></div>
+              <div><div style="color:#9CA3AF;margin-bottom:1px;">CNY / KRW</div><div style="font-weight:600;" class="up">191.3 ▲ +0.11%</div></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- [9] 거래내역 1×1 -->
+        <div class="card">
+          <div class="lbl">거래내역</div>
+          <div style="flex:1;display:flex;flex-direction:column;gap:4px;overflow:hidden;">
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:3px;"><span class="tag up-bg">매수</span><span style="font-size:10px;">삼성전자</span></div><span style="font-size:9px;color:#9CA3AF;">10주</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:3px;"><span class="tag down-bg">매도</span><span style="font-size:10px;">SK하이닉스</span></div><span style="font-size:9px;color:#9CA3AF;">5주</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:3px;"><span class="tag up-bg">매수</span><span style="font-size:10px;">LG에너지</span></div><span style="font-size:9px;color:#9CA3AF;">3주</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:3px;"><span class="tag down-bg">매도</span><span style="font-size:10px;">POSCO</span></div><span style="font-size:9px;color:#9CA3AF;">7주</span></div>
+          </div>
+        </div>
+
+        <!-- [10] 증권사 리포트 1×1 -->
+        <div class="card">
+          <div class="lbl">증권사 리포트</div>
+          <div style="flex:1;display:flex;flex-direction:column;justify-content:space-between;overflow:hidden;">
+            <div>
+              <p style="font-size:11px;font-weight:700;line-height:1.4;">삼성전자 목표가 상향</p>
+              <p style="font-size:9px;color:#9CA3AF;margin-top:3px;">반도체 업황 회복 기대감으로 목표주가 9만원으로 상향</p>
+            </div>
+            <div style="display:flex;align-items:center;gap:4px;">
+              <span style="font-size:9px;color:#0046FF;font-weight:600;">키움증권</span>
+              <span style="font-size:8px;color:#9CA3AF;">· 2026.03.18</span>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </main>
+
+  <!-- 채팅 패널 (368px) -->
+  <div class="cp">
+    <div class="cp-head">
+      <svg style="width:14px;height:14px;" fill="none" stroke="#0046FF" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/></svg>
+      <span style="font-size:13px;font-weight:600;">SOL AI</span>
+      <span style="width:6px;height:6px;border-radius:50%;background:#34D399;display:inline-block;margin-left:2px;"></span>
+    </div>
+    <div class="cp-msgs">
+      <div style="display:flex;gap:8px;"><div class="av"><svg style="width:11px;height:11px;" fill="none" stroke="white" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/></svg></div><div class="ai-bbl">안녕하세요! 오늘의 시장 동향이나 종목 분석을 도와드릴게요.</div></div>
+      <div style="display:flex;justify-content:flex-end;"><div class="me-bbl">SK하이닉스 지금 사도 돼?</div></div>
+      <div style="display:flex;gap:8px;"><div class="av"><svg style="width:11px;height:11px;" fill="none" stroke="white" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/></svg></div><div class="ai-bbl">SK하이닉스는 현재 <strong style="color:#E8393E;">+1.96%</strong> 상승 중이에요. HBM 수요 증가로 목표주가 상향 리포트가 나왔습니다. 단기 모멘텀은 긍정적이나 분할 매수를 권장해요.</div></div>
+    </div>
+    <div class="cp-foot">
+      <input type="text" placeholder="AI에게 물어보세요..." style="flex:1;height:32px;padding:0 12px;border-radius:8px;background:#F4F6FA;font-size:12px;border:1px solid #E5E7EB;outline:none;"/>
+      <button style="width:32px;height:32px;display:flex;align-items:center;justify-content:center;border-radius:8px;background:#0046FF;border:none;cursor:pointer;"><svg style="width:13px;height:13px;" fill="none" stroke="white" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/></svg></button>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/front-mvp/grid-b-6x3.html
+++ b/front-mvp/grid-b-6x3.html
@@ -1,0 +1,281 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <title>SOL Lite — 그리드 B안 (6×3)</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { background:#F4F6FA; font-family:'Pretendard',-apple-system,sans-serif; height:100vh; overflow:hidden; color:#191F28; padding-top:28px; }
+    .up { color:#E8393E; } .down { color:#0075E8; }
+    .up-bg { background:#FFF0F1; color:#E8393E; }
+    .down-bg { background:#EFF6FF; color:#0075E8; }
+
+    .app-header { height:54px; background:#fff; border-bottom:1px solid #EAECF0; display:flex; align-items:center; padding:0 16px; gap:12px; flex-shrink:0; }
+    .app-body   { height:calc(100vh - 54px - 28px); display:flex; overflow:hidden; }
+    .sidebar    { width:56px; flex-shrink:0; background:#fff; border-right:1px solid #EAECF0; display:flex; flex-direction:column; align-items:center; padding:14px 0; gap:4px; }
+    .nav-icon   { width:40px; height:40px; border-radius:12px; display:flex; align-items:center; justify-content:center; color:#9CA3AF; cursor:pointer; }
+    .nav-icon.active { background:#EEF2FF; color:#0046FF; }
+
+    .card { background:#fff; border:1px solid #EAECF0; border-radius:14px; padding:11px 13px; overflow:hidden; display:flex; flex-direction:column; position:relative; cursor:pointer; transition:box-shadow .15s,border-color .15s; }
+    .card:hover { border-color:#BFD0FF; box-shadow:0 4px 16px rgba(0,70,255,.08); }
+    .lbl { font-size:9px; font-weight:600; color:#9CA3AF; letter-spacing:.05em; text-transform:uppercase; margin-bottom:5px; }
+
+    /* B안: 6열 × 3행 */
+    .grid { display:grid; grid-template-columns:repeat(6,1fr); grid-template-rows:repeat(3,1fr); gap:8px; width:100%; height:100%; }
+    .c2 { grid-column:span 2; }
+    .c3 { grid-column:span 3; }
+    .r2 { grid-row:span 2; }
+
+    .bar { border-radius:2px; align-self:flex-end; }
+    .pie { border-radius:50%; background:conic-gradient(#0046FF 0% 34%,#00A878 34% 54%,#FF9500 54% 69%,#EF4444 69% 81%,#8B5CF6 81% 100%); flex-shrink:0; }
+    .slot { border:2px dashed #E5E7EB; border-radius:14px; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:5px; cursor:pointer; }
+    .slot:hover { border-color:#0046FF; background:#F5F7FF; }
+    .tag { font-size:8px; font-weight:600; padding:1px 5px; border-radius:3px; }
+
+    /* 채팅 패널 */
+    .cp { width:368px; flex-shrink:0; background:#FAFBFC; border-left:1px solid #EAECF0; display:flex; flex-direction:column; }
+    .cp-head { height:48px; display:flex; align-items:center; gap:8px; padding:0 16px; border-bottom:1px solid #EAECF0; flex-shrink:0; }
+    .cp-msgs { flex:1; overflow-y:auto; padding:12px 16px; display:flex; flex-direction:column; gap:10px; }
+    .cp-foot { height:56px; display:flex; align-items:center; gap:8px; padding:0 12px; border-top:1px solid #EAECF0; flex-shrink:0; }
+    .ai-bbl { background:#fff; border:1px solid #EAECF0; border-radius:12px 12px 12px 3px; padding:9px 12px; max-width:280px; font-size:11px; color:#374151; line-height:1.6; }
+    .me-bbl { background:#0046FF; border-radius:12px 12px 3px 12px; padding:9px 12px; max-width:220px; margin-left:auto; font-size:11px; color:#fff; line-height:1.6; }
+    .av { width:24px; height:24px; border-radius:50%; background:#0046FF; display:flex; align-items:center; justify-content:center; flex-shrink:0; margin-top:2px; }
+
+    .compare-banner { position:fixed; top:0; left:0; right:0; z-index:100; background:#7C3AED; color:#fff; font-size:11px; font-weight:700; text-align:center; padding:5px; }
+  </style>
+</head>
+<body>
+
+<div class="compare-banner">B안 — 6열 × 3행 (18셀) · 전체 위젯 10종 · 채팅 패널 상시 오픈 · 가용 너비 ≈ 159px/셀 @1440 ⚠️ 셀이 좁음</div>
+
+<!-- Header -->
+<header class="app-header">
+  <div style="display:flex;align-items:center;gap:8px;margin-right:6px;">
+    <div style="width:28px;height:28px;border-radius:9px;background:#0046FF;display:flex;align-items:center;justify-content:center;">
+      <svg style="width:14px;height:14px;" fill="none" stroke="white" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"/></svg>
+    </div>
+    <span style="font-size:15px;font-weight:700;color:#111827;">SOL <span style="color:#0046FF;">Lite</span></span>
+  </div>
+  <nav style="display:flex;gap:3px;">
+    <button style="padding:5px 11px;border-radius:8px;background:#EEF2FF;color:#0046FF;font-size:12px;font-weight:600;">홈</button>
+    <button style="padding:5px 11px;border-radius:8px;color:#9CA3AF;font-size:12px;">시세</button>
+    <button style="padding:5px 11px;border-radius:8px;color:#9CA3AF;font-size:12px;">투자</button>
+    <button style="padding:5px 11px;border-radius:8px;color:#9CA3AF;font-size:12px;">자산</button>
+  </nav>
+  <div style="flex:1;"></div>
+  <button style="display:flex;align-items:center;gap:5px;padding:5px 11px;border-radius:10px;border:1px solid #E5E7EB;color:#6B7280;font-size:12px;">
+    <svg style="width:13px;height:13px;" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+    위젯 편집
+  </button>
+  <div style="display:flex;align-items:center;gap:6px;padding-left:8px;border-left:1px solid #F3F4F6;margin-left:4px;">
+    <div style="width:28px;height:28px;border-radius:50%;background:#0046FF;color:#fff;font-size:11px;font-weight:700;display:flex;align-items:center;justify-content:center;">김</div>
+    <div><div style="font-size:11px;font-weight:600;color:#111827;">김SOL</div><div style="font-size:9px;color:#9CA3AF;">주문가능 7,478만원</div></div>
+  </div>
+</header>
+
+<div class="app-body">
+  <!-- Sidebar -->
+  <div class="sidebar">
+    <div class="nav-icon active"><svg style="width:20px;height:20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg></div>
+    <div class="nav-icon"><svg style="width:20px;height:20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/></svg></div>
+    <div class="nav-icon"><svg style="width:20px;height:20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4zM3 12a9 9 0 1118 0A9 9 0 013 12z"/></svg></div>
+    <div class="nav-icon"><svg style="width:20px;height:20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/></svg></div>
+  </div>
+
+  <!-- Main -->
+  <main style="flex:1;min-width:0;display:flex;flex-direction:column;overflow:hidden;padding:12px;gap:8px;">
+    <!-- 서브바 -->
+    <div style="display:flex;align-items:center;justify-content:space-between;flex-shrink:0;height:24px;padding:0 2px;">
+      <span style="font-size:13px;font-weight:700;">나의 대시보드</span>
+      <div style="display:flex;align-items:center;gap:4px;padding:2px 8px;border-radius:100px;background:#fff;border:1px solid #EAECF0;">
+        <span style="width:5px;height:5px;border-radius:50%;background:#34D399;display:inline-block;"></span>
+        <span style="font-size:10px;color:#9CA3AF;">실시간 반영</span>
+      </div>
+    </div>
+
+    <!-- 6×3 그리드 -->
+    <div style="flex:1;min-height:0;">
+      <div class="grid" style="min-width:700px;min-height:480px;">
+
+        <!-- ─── Row 1 (6 cols) ─── -->
+
+        <!-- [1] 계좌 잔고 1×1 -->
+        <div class="card">
+          <div class="lbl">계좌 잔고</div>
+          <div style="flex:1;display:flex;flex-direction:column;justify-content:space-between;">
+            <span style="font-size:9px;color:#9CA3AF;">총 평가자산</span>
+            <div>
+              <div style="font-size:14px;font-weight:800;line-height:1.1;">84,320,000</div>
+              <div style="font-size:9px;font-weight:600;margin-top:2px;" class="up">▲ +2.61%</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- [2] 주요 지수 2×1 -->
+        <div class="card c2">
+          <div class="lbl">주요 지수</div>
+          <div style="flex:1;display:flex;">
+            <div style="flex:1;display:flex;flex-direction:column;justify-content:space-between;align-items:center;padding:0 5px;border-right:1px solid #F3F4F6;">
+              <div style="text-align:center;"><div style="font-size:8px;color:#9CA3AF;">KOSPI</div><div style="font-size:13px;font-weight:800;line-height:1.1;">2,685</div><div style="font-size:8px;" class="up">▲ +0.46%</div></div>
+              <div style="display:flex;align-items:flex-end;gap:1px;height:18px;width:100%;"><div class="bar" style="flex:1;background:#FECACA;height:45%;"></div><div class="bar" style="flex:1;background:#F87171;height:65%;"></div><div class="bar" style="flex:1;background:#DC2626;height:85%;"></div></div>
+            </div>
+            <div style="flex:1;display:flex;flex-direction:column;justify-content:space-between;align-items:center;padding:0 5px;border-right:1px solid #F3F4F6;">
+              <div style="text-align:center;"><div style="font-size:8px;color:#9CA3AF;">KOSDAQ</div><div style="font-size:13px;font-weight:800;line-height:1.1;">868</div><div style="font-size:8px;" class="down">▼ −0.21%</div></div>
+              <div style="display:flex;align-items:flex-end;gap:1px;height:18px;width:100%;"><div class="bar" style="flex:1;background:#BFDBFE;height:60%;"></div><div class="bar" style="flex:1;background:#60A5FA;height:42%;"></div><div class="bar" style="flex:1;background:#2563EB;height:35%;"></div></div>
+            </div>
+            <div style="flex:1;display:flex;flex-direction:column;justify-content:space-between;align-items:center;padding:0 5px;">
+              <div style="text-align:center;"><div style="font-size:8px;color:#9CA3AF;">NASDAQ</div><div style="font-size:13px;font-weight:800;line-height:1.1;">16,274</div><div style="font-size:8px;" class="up">▲ +0.83%</div></div>
+              <div style="display:flex;align-items:flex-end;gap:1px;height:18px;width:100%;"><div class="bar" style="flex:1;background:#FECACA;height:42%;"></div><div class="bar" style="flex:1;background:#F87171;height:65%;"></div><div class="bar" style="flex:1;background:#DC2626;height:85%;"></div></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- [3] 포트폴리오 1×1 -->
+        <div class="card">
+          <div class="lbl">포트폴리오</div>
+          <div style="flex:1;display:flex;align-items:center;gap:6px;">
+            <div class="pie" style="width:34px;height:34px;"></div>
+            <div style="display:flex;flex-direction:column;gap:2px;">
+              <div style="display:flex;align-items:center;gap:2px;"><div style="width:5px;height:5px;border-radius:50%;background:#0046FF;"></div><span style="font-size:8px;color:#6B7280;">삼성 34%</span></div>
+              <div style="display:flex;align-items:center;gap:2px;"><div style="width:5px;height:5px;border-radius:50%;background:#00A878;"></div><span style="font-size:8px;color:#6B7280;">SK하이 20%</span></div>
+              <div style="display:flex;align-items:center;gap:2px;"><div style="width:5px;height:5px;border-radius:50%;background:#FF9500;"></div><span style="font-size:8px;color:#6B7280;">LG에너 15%</span></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- [4] 환율 2×1 -->
+        <div class="card c2">
+          <div class="lbl">환율</div>
+          <div style="flex:1;display:flex;gap:6px;">
+            <div style="flex:1;display:flex;flex-direction:column;justify-content:space-between;border-right:1px solid #F3F4F6;padding-right:6px;">
+              <div style="font-size:8px;color:#9CA3AF;">USD / KRW</div>
+              <div style="font-size:14px;font-weight:800;line-height:1.1;">1,378.50</div>
+              <div style="font-size:8px;" class="down">▼ −0.17%</div>
+            </div>
+            <div style="flex:1;display:flex;flex-direction:column;justify-content:space-around;font-size:8px;">
+              <div style="display:flex;justify-content:space-between;"><span style="color:#9CA3AF;">JPY</span><span class="up">9.18 ▲</span></div>
+              <div style="display:flex;justify-content:space-between;"><span style="color:#9CA3AF;">EUR</span><span class="down">1,502 ▼</span></div>
+              <div style="display:flex;justify-content:space-between;"><span style="color:#9CA3AF;">CNY</span><span class="up">191.3 ▲</span></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- ─── Row 2 ─── -->
+
+        <!-- [5] 주가/차트 2×2 (col1-2, row2-3) -->
+        <div class="card c2 r2" style="border-color:#7C3AED;background:linear-gradient(135deg,#faf8ff,#fff);">
+          <div style="display:flex;align-items:flex-start;justify-content:space-between;flex-shrink:0;margin-bottom:3px;">
+            <div><div style="font-size:11px;font-weight:700;">SK하이닉스</div><div style="font-size:8px;color:#9CA3AF;">000660 · KOSPI</div></div>
+            <div style="text-align:right;"><div style="font-size:15px;font-weight:800;line-height:1.1;">182,000</div><div style="font-size:8px;" class="up">▲ +1.96%</div></div>
+          </div>
+          <div style="background:#F9FAFB;border-radius:8px;flex:1;display:flex;align-items:flex-end;padding:6px;gap:2px;min-height:0;margin:3px 0;">
+            <div class="bar" style="flex:1;background:#FECACA;height:35%;"></div><div class="bar" style="flex:1;background:#FECACA;height:42%;"></div><div class="bar" style="flex:1;background:#FCA5A5;height:38%;"></div><div class="bar" style="flex:1;background:#FCA5A5;height:52%;"></div><div class="bar" style="flex:1;background:#F87171;height:56%;"></div><div class="bar" style="flex:1;background:#F87171;height:62%;"></div><div class="bar" style="flex:1;background:#EF4444;height:68%;"></div><div class="bar" style="flex:1;background:#EF4444;height:73%;"></div><div class="bar" style="flex:1;background:#DC2626;height:80%;"></div><div class="bar" style="flex:1;background:#DC2626;height:85%;"></div><div class="bar" style="flex:1;background:#B91C1C;height:90%;"></div>
+          </div>
+          <div style="display:flex;justify-content:space-between;flex-shrink:0;">
+            <div style="text-align:center;"><div style="font-size:7px;color:#9CA3AF;">시가</div><div style="font-size:9px;font-weight:600;">178,500</div></div>
+            <div style="text-align:center;"><div style="font-size:7px;color:#9CA3AF;">고가</div><div style="font-size:9px;font-weight:600;" class="up">183,000</div></div>
+            <div style="text-align:center;"><div style="font-size:7px;color:#9CA3AF;">저가</div><div style="font-size:9px;font-weight:600;" class="down">177,200</div></div>
+            <div style="text-align:center;"><div style="font-size:7px;color:#9CA3AF;">거래량</div><div style="font-size:9px;font-weight:600;">8.2M</div></div>
+          </div>
+          <div style="position:absolute;top:9px;right:9px;background:#F3EEFF;color:#7C3AED;font-size:8px;font-weight:700;padding:1px 5px;border-radius:3px;">2×2</div>
+        </div>
+
+        <!-- [6] 실시간 순위 2×1 (col3-4, row2) -->
+        <div class="card c2">
+          <div class="lbl">실시간 순위</div>
+          <div style="display:flex;gap:3px;margin-bottom:4px;">
+            <span class="tag" style="background:#EEF2FF;color:#0046FF;">거래대금</span>
+            <span class="tag" style="color:#9CA3AF;">상승률</span>
+          </div>
+          <div style="flex:1;display:flex;flex-direction:column;gap:3px;overflow:hidden;">
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:5px;"><span style="font-size:8px;color:#9CA3AF;width:8px;">1</span><span style="font-size:10px;font-weight:500;">삼성전자</span></div><span style="font-size:9px;font-weight:600;" class="up">+1.62%</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:5px;"><span style="font-size:8px;color:#9CA3AF;width:8px;">2</span><span style="font-size:10px;font-weight:500;">SK하이닉스</span></div><span style="font-size:9px;font-weight:600;" class="up">+2.35%</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:5px;"><span style="font-size:8px;color:#9CA3AF;width:8px;">3</span><span style="font-size:10px;font-weight:500;">LG에너지</span></div><span style="font-size:9px;font-weight:600;" class="down">−0.87%</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:5px;"><span style="font-size:8px;color:#9CA3AF;width:8px;">4</span><span style="font-size:10px;font-weight:500;">POSCO홀딩스</span></div><span style="font-size:9px;font-weight:600;" class="up">+0.54%</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:5px;"><span style="font-size:8px;color:#9CA3AF;width:8px;">5</span><span style="font-size:10px;font-weight:500;">현대차</span></div><span style="font-size:9px;font-weight:600;" class="down">−1.20%</span></div>
+          </div>
+        </div>
+
+        <!-- [7] 오늘의 시황 1×1 (col5, row2) -->
+        <div class="card">
+          <div class="lbl">오늘의 시황</div>
+          <div style="flex:1;display:flex;flex-direction:column;gap:3px;overflow:hidden;">
+            <p style="font-size:9px;color:#6B7280;line-height:1.5;">美 CPI 하회, 나스닥 1% ↑</p>
+            <p style="font-size:9px;color:#6B7280;line-height:1.5;">SK하이닉스 목표가 상향</p>
+            <p style="font-size:9px;color:#6B7280;line-height:1.5;">원/달러 1,378원 마감</p>
+          </div>
+        </div>
+
+        <!-- [8] 관심종목 1×1 (col6, row2) -->
+        <div class="card">
+          <div class="lbl">관심종목</div>
+          <div style="flex:1;display:flex;flex-direction:column;gap:3px;overflow:hidden;">
+            <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:9px;font-weight:500;">삼성전자</span><span style="font-size:8px;font-weight:600;" class="up">+1.62%</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:9px;font-weight:500;">현대차</span><span style="font-size:8px;font-weight:600;" class="down">−0.43%</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:9px;font-weight:500;">LG에너지</span><span style="font-size:8px;font-weight:600;" class="up">+0.91%</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:9px;font-weight:500;">SK하이닉스</span><span style="font-size:8px;font-weight:600;" class="down">−0.82%</span></div>
+          </div>
+        </div>
+
+        <!-- ─── Row 3 (col1-2 → 2×2 차트 계속) ─── -->
+
+        <!-- [9] 거래내역 2×1 (col3-4, row3) -->
+        <div class="card c2">
+          <div class="lbl">거래내역</div>
+          <div style="flex:1;display:flex;flex-direction:column;gap:4px;overflow:hidden;">
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:3px;"><span class="tag up-bg">매수</span><span style="font-size:10px;">삼성전자</span></div><div style="text-align:right;"><div style="font-size:9px;color:#9CA3AF;">75,400원</div><div style="font-size:8px;color:#9CA3AF;">10주</div></div></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:3px;"><span class="tag down-bg">매도</span><span style="font-size:10px;">SK하이닉스</span></div><div style="text-align:right;"><div style="font-size:9px;color:#9CA3AF;">182,000원</div><div style="font-size:8px;color:#9CA3AF;">5주</div></div></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:3px;"><span class="tag up-bg">매수</span><span style="font-size:10px;">LG에너지</span></div><div style="text-align:right;"><div style="font-size:9px;color:#9CA3AF;">398,000원</div><div style="font-size:8px;color:#9CA3AF;">3주</div></div></div>
+          </div>
+        </div>
+
+        <!-- [10] 증권사 리포트 1×1 (col5, row3) -->
+        <div class="card">
+          <div class="lbl">증권사 리포트</div>
+          <div style="flex:1;display:flex;flex-direction:column;justify-content:space-between;overflow:hidden;">
+            <div>
+              <p style="font-size:10px;font-weight:700;line-height:1.4;">삼성전자 목표가 상향</p>
+              <p style="font-size:8px;color:#9CA3AF;margin-top:2px;">반도체 업황 회복 기대감</p>
+            </div>
+            <div style="display:flex;align-items:center;gap:3px;">
+              <span style="font-size:8px;color:#0046FF;font-weight:600;">키움증권</span>
+              <span style="font-size:7px;color:#9CA3AF;">· 03.18</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- 위젯 추가 슬롯 (col6, row3) -->
+        <div class="slot">
+          <div style="width:24px;height:24px;border-radius:50%;border:2px dashed #D1D5DB;display:flex;align-items:center;justify-content:center;">
+            <svg style="width:11px;height:11px;" fill="none" stroke="#9CA3AF" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
+          </div>
+          <span style="font-size:9px;color:#9CA3AF;">위젯 추가</span>
+        </div>
+
+      </div>
+    </div>
+  </main>
+
+  <!-- 채팅 패널 (368px) -->
+  <div class="cp">
+    <div class="cp-head">
+      <svg style="width:14px;height:14px;" fill="none" stroke="#0046FF" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/></svg>
+      <span style="font-size:13px;font-weight:600;">SOL AI</span>
+      <span style="width:6px;height:6px;border-radius:50%;background:#34D399;display:inline-block;margin-left:2px;"></span>
+    </div>
+    <div class="cp-msgs">
+      <div style="display:flex;gap:8px;"><div class="av"><svg style="width:11px;height:11px;" fill="none" stroke="white" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/></svg></div><div class="ai-bbl">안녕하세요! 오늘의 시장 동향이나 종목 분석을 도와드릴게요.</div></div>
+      <div style="display:flex;justify-content:flex-end;"><div class="me-bbl">SK하이닉스 지금 사도 돼?</div></div>
+      <div style="display:flex;gap:8px;"><div class="av"><svg style="width:11px;height:11px;" fill="none" stroke="white" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/></svg></div><div class="ai-bbl">현재 <strong style="color:#E8393E;">+1.96%</strong> 상승 중이에요. HBM 수요 증가로 목표주가 상향 리포트가 나왔습니다. 분할 매수를 권장해요.</div></div>
+    </div>
+    <div class="cp-foot">
+      <input type="text" placeholder="AI에게 물어보세요..." style="flex:1;height:32px;padding:0 12px;border-radius:8px;background:#F4F6FA;font-size:12px;border:1px solid #E5E7EB;outline:none;"/>
+      <button style="width:32px;height:32px;display:flex;align-items:center;justify-content:center;border-radius:8px;background:#0046FF;border:none;cursor:pointer;"><svg style="width:13px;height:13px;" fill="none" stroke="white" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/></svg></button>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/front-mvp/grid-b-6x4.html
+++ b/front-mvp/grid-b-6x4.html
@@ -1,0 +1,313 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <title>SOL Lite — 그리드 B안 (6×4)</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { background:#F4F6FA; font-family:'Pretendard',-apple-system,sans-serif; height:100vh; overflow:hidden; color:#191F28; padding-top:28px; }
+    .up { color:#E8393E; } .down { color:#0075E8; }
+    .up-bg { background:#FFF0F1; color:#E8393E; }
+    .down-bg { background:#EFF6FF; color:#0075E8; }
+
+    .app-header { height:54px; background:#fff; border-bottom:1px solid #EAECF0; display:flex; align-items:center; padding:0 16px; gap:12px; flex-shrink:0; }
+    .app-body   { height:calc(100vh - 54px - 28px); display:flex; overflow:hidden; }
+    .sidebar    { width:56px; flex-shrink:0; background:#fff; border-right:1px solid #EAECF0; display:flex; flex-direction:column; align-items:center; padding:14px 0; gap:4px; }
+    .nav-icon   { width:40px; height:40px; border-radius:12px; display:flex; align-items:center; justify-content:center; color:#9CA3AF; cursor:pointer; }
+    .nav-icon.active { background:#EEF2FF; color:#0046FF; }
+
+    .card { background:#fff; border:1px solid #EAECF0; border-radius:14px; padding:11px 13px; overflow:hidden; display:flex; flex-direction:column; position:relative; cursor:pointer; transition:box-shadow .15s,border-color .15s; }
+    .card:hover { border-color:#BFD0FF; box-shadow:0 4px 16px rgba(0,70,255,.08); }
+    .lbl { font-size:9px; font-weight:600; color:#9CA3AF; letter-spacing:.05em; text-transform:uppercase; margin-bottom:5px; }
+
+    /* B안: 6열 × 4행 */
+    .grid { display:grid; grid-template-columns:repeat(6,1fr); grid-template-rows:repeat(4,1fr); gap:8px; width:100%; height:100%; }
+    .c2 { grid-column:span 2; }
+    .c3 { grid-column:span 3; }
+    .r2 { grid-row:span 2; }
+
+    .bar { border-radius:2px; align-self:flex-end; }
+    .pie { border-radius:50%; background:conic-gradient(#0046FF 0% 34%,#00A878 34% 54%,#FF9500 54% 69%,#EF4444 69% 81%,#8B5CF6 81% 100%); flex-shrink:0; }
+    .tag { font-size:8px; font-weight:600; padding:1px 5px; border-radius:3px; }
+
+    /* 사이즈 배지 — 각 카드 우하단 */
+    .size-badge {
+      position:absolute; bottom:8px; right:8px;
+      font-size:9px; font-weight:700; padding:2px 7px; border-radius:4px;
+      display:flex; align-items:center; gap:3px;
+      pointer-events:none;
+    }
+    .size-badge .dot { width:5px; height:5px; border-radius:50%; }
+
+    /* 채팅 패널 */
+    .cp { width:368px; flex-shrink:0; background:#FAFBFC; border-left:1px solid #EAECF0; display:flex; flex-direction:column; }
+    .cp-head { height:48px; display:flex; align-items:center; gap:8px; padding:0 16px; border-bottom:1px solid #EAECF0; flex-shrink:0; }
+    .cp-msgs { flex:1; overflow-y:auto; padding:12px 16px; display:flex; flex-direction:column; gap:10px; }
+    .cp-foot { height:56px; display:flex; align-items:center; gap:8px; padding:0 12px; border-top:1px solid #EAECF0; flex-shrink:0; }
+    .ai-bbl { background:#fff; border:1px solid #EAECF0; border-radius:12px 12px 12px 3px; padding:9px 12px; max-width:280px; font-size:11px; color:#374151; line-height:1.6; }
+    .me-bbl { background:#0046FF; border-radius:12px 12px 3px 12px; padding:9px 12px; max-width:220px; margin-left:auto; font-size:11px; color:#fff; line-height:1.6; }
+    .av { width:24px; height:24px; border-radius:50%; background:#0046FF; display:flex; align-items:center; justify-content:center; flex-shrink:0; margin-top:2px; }
+
+    .compare-banner { position:fixed; top:0; left:0; right:0; z-index:100; background:#7C3AED; color:#fff; font-size:11px; font-weight:700; text-align:center; padding:5px; }
+  </style>
+</head>
+<body>
+
+<div class="compare-banner">B안 — 6열 × 4행 (24셀) · 모든 사이즈 타입 표시 · 채팅 패널 상시 오픈</div>
+
+<!-- Header -->
+<header class="app-header">
+  <div style="display:flex;align-items:center;gap:8px;margin-right:6px;">
+    <div style="width:28px;height:28px;border-radius:9px;background:#0046FF;display:flex;align-items:center;justify-content:center;">
+      <svg style="width:14px;height:14px;" fill="none" stroke="white" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"/></svg>
+    </div>
+    <span style="font-size:15px;font-weight:700;color:#111827;">SOL <span style="color:#0046FF;">Lite</span></span>
+  </div>
+  <nav style="display:flex;gap:3px;">
+    <button style="padding:5px 11px;border-radius:8px;background:#EEF2FF;color:#0046FF;font-size:12px;font-weight:600;">홈</button>
+    <button style="padding:5px 11px;border-radius:8px;color:#9CA3AF;font-size:12px;">시세</button>
+    <button style="padding:5px 11px;border-radius:8px;color:#9CA3AF;font-size:12px;">투자</button>
+    <button style="padding:5px 11px;border-radius:8px;color:#9CA3AF;font-size:12px;">자산</button>
+  </nav>
+  <div style="flex:1;"></div>
+  <button style="display:flex;align-items:center;gap:5px;padding:5px 11px;border-radius:10px;border:1px solid #E5E7EB;color:#6B7280;font-size:12px;">
+    <svg style="width:13px;height:13px;" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+    위젯 편집
+  </button>
+  <div style="display:flex;align-items:center;gap:6px;padding-left:8px;border-left:1px solid #F3F4F6;margin-left:4px;">
+    <div style="width:28px;height:28px;border-radius:50%;background:#0046FF;color:#fff;font-size:11px;font-weight:700;display:flex;align-items:center;justify-content:center;">김</div>
+    <div><div style="font-size:11px;font-weight:600;color:#111827;">김SOL</div><div style="font-size:9px;color:#9CA3AF;">주문가능 7,478만원</div></div>
+  </div>
+</header>
+
+<div class="app-body">
+  <!-- Sidebar -->
+  <div class="sidebar">
+    <div class="nav-icon active"><svg style="width:20px;height:20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg></div>
+    <div class="nav-icon"><svg style="width:20px;height:20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/></svg></div>
+    <div class="nav-icon"><svg style="width:20px;height:20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4zM3 12a9 9 0 1118 0A9 9 0 013 12z"/></svg></div>
+    <div class="nav-icon"><svg style="width:20px;height:20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/></svg></div>
+  </div>
+
+  <!-- Main -->
+  <main style="flex:1;min-width:0;display:flex;flex-direction:column;overflow:hidden;padding:12px;gap:8px;">
+    <div style="display:flex;align-items:center;justify-content:space-between;flex-shrink:0;height:24px;padding:0 2px;">
+      <span style="font-size:13px;font-weight:700;">나의 대시보드</span>
+      <div style="display:flex;align-items:center;gap:4px;padding:2px 8px;border-radius:100px;background:#fff;border:1px solid #EAECF0;">
+        <span style="width:5px;height:5px;border-radius:50%;background:#34D399;display:inline-block;"></span>
+        <span style="font-size:10px;color:#9CA3AF;">실시간 반영</span>
+      </div>
+    </div>
+
+    <div style="flex:1;min-height:0;">
+      <div class="grid" style="min-width:700px;min-height:560px;">
+
+        <!-- ══════════════════════════════════════
+             Row 1: 3×1 | 1×1 | 1×1 | 1×1
+             6 = 3 + 1 + 1 + 1
+        ══════════════════════════════════════ -->
+
+        <!-- 주요 지수 ── 3×1 (화면 절반 너비) -->
+        <div class="card c3" style="border-color:#7C3AED;">
+          <div class="lbl">주요 지수</div>
+          <div style="flex:1;display:flex;">
+            <div style="flex:1;display:flex;flex-direction:column;justify-content:space-between;align-items:center;padding:0 8px;border-right:1px solid #F3F4F6;">
+              <div style="text-align:center;"><div style="font-size:9px;color:#9CA3AF;">KOSPI</div><div style="font-size:15px;font-weight:800;line-height:1.1;">2,685.42</div><div style="font-size:9px;" class="up">▲ +0.46%</div></div>
+              <div style="display:flex;align-items:flex-end;gap:2px;height:22px;width:100%;"><div class="bar" style="flex:1;background:#FECACA;height:45%;"></div><div class="bar" style="flex:1;background:#FCA5A5;height:58%;"></div><div class="bar" style="flex:1;background:#F87171;height:70%;"></div><div class="bar" style="flex:1;background:#EF4444;height:80%;"></div><div class="bar" style="flex:1;background:#DC2626;height:90%;"></div></div>
+            </div>
+            <div style="flex:1;display:flex;flex-direction:column;justify-content:space-between;align-items:center;padding:0 8px;border-right:1px solid #F3F4F6;">
+              <div style="text-align:center;"><div style="font-size:9px;color:#9CA3AF;">KOSDAQ</div><div style="font-size:15px;font-weight:800;line-height:1.1;">868.15</div><div style="font-size:9px;" class="down">▼ −0.21%</div></div>
+              <div style="display:flex;align-items:flex-end;gap:2px;height:22px;width:100%;"><div class="bar" style="flex:1;background:#BFDBFE;height:60%;"></div><div class="bar" style="flex:1;background:#93C5FD;height:50%;"></div><div class="bar" style="flex:1;background:#60A5FA;height:42%;"></div><div class="bar" style="flex:1;background:#3B82F6;height:36%;"></div><div class="bar" style="flex:1;background:#2563EB;height:32%;"></div></div>
+            </div>
+            <div style="flex:1;display:flex;flex-direction:column;justify-content:space-between;align-items:center;padding:0 8px;">
+              <div style="text-align:center;"><div style="font-size:9px;color:#9CA3AF;">NASDAQ</div><div style="font-size:15px;font-weight:800;line-height:1.1;">16,274</div><div style="font-size:9px;" class="up">▲ +0.83%</div></div>
+              <div style="display:flex;align-items:flex-end;gap:2px;height:22px;width:100%;"><div class="bar" style="flex:1;background:#FECACA;height:42%;"></div><div class="bar" style="flex:1;background:#FCA5A5;height:55%;"></div><div class="bar" style="flex:1;background:#F87171;height:68%;"></div><div class="bar" style="flex:1;background:#EF4444;height:78%;"></div><div class="bar" style="flex:1;background:#DC2626;height:88%;"></div></div>
+            </div>
+          </div>
+          <div class="size-badge" style="background:#F3EEFF;color:#7C3AED;"><div class="dot" style="background:#7C3AED;"></div>3×1 · 하프 와이드</div>
+        </div>
+
+        <!-- 계좌 잔고 ── 1×1 -->
+        <div class="card">
+          <div class="lbl">계좌 잔고</div>
+          <div style="flex:1;display:flex;flex-direction:column;justify-content:space-between;">
+            <span style="font-size:9px;color:#9CA3AF;">총 평가자산</span>
+            <div>
+              <div style="font-size:15px;font-weight:800;line-height:1.1;">84,320,000</div>
+              <div style="font-size:9px;font-weight:600;margin-top:2px;" class="up">▲ +2.61%</div>
+            </div>
+          </div>
+          <div class="size-badge" style="background:#EEF2FF;color:#0046FF;"><div class="dot" style="background:#0046FF;"></div>1×1 · 소형</div>
+        </div>
+
+        <!-- 포트폴리오 ── 1×1 -->
+        <div class="card">
+          <div class="lbl">포트폴리오</div>
+          <div style="flex:1;display:flex;align-items:center;gap:6px;">
+            <div class="pie" style="width:34px;height:34px;"></div>
+            <div style="display:flex;flex-direction:column;gap:2px;">
+              <div style="display:flex;align-items:center;gap:2px;"><div style="width:5px;height:5px;border-radius:50%;background:#0046FF;"></div><span style="font-size:8px;color:#6B7280;">삼성 34%</span></div>
+              <div style="display:flex;align-items:center;gap:2px;"><div style="width:5px;height:5px;border-radius:50%;background:#00A878;"></div><span style="font-size:8px;color:#6B7280;">SK하이 20%</span></div>
+              <div style="display:flex;align-items:center;gap:2px;"><div style="width:5px;height:5px;border-radius:50%;background:#FF9500;"></div><span style="font-size:8px;color:#6B7280;">기타 46%</span></div>
+            </div>
+          </div>
+          <div class="size-badge" style="background:#EEF2FF;color:#0046FF;"><div class="dot" style="background:#0046FF;"></div>1×1 · 소형</div>
+        </div>
+
+        <!-- 환율 ── 1×1 -->
+        <div class="card">
+          <div class="lbl">환율</div>
+          <div style="flex:1;display:flex;flex-direction:column;justify-content:space-between;">
+            <div>
+              <div style="font-size:8px;color:#9CA3AF;">USD / KRW</div>
+              <div style="font-size:14px;font-weight:800;line-height:1.1;">1,378.50</div>
+              <div style="font-size:8px;margin-top:1px;" class="down">▼ −0.17%</div>
+            </div>
+            <div style="font-size:8px;display:flex;flex-direction:column;gap:2px;">
+              <div style="display:flex;justify-content:space-between;"><span style="color:#9CA3AF;">JPY</span><span class="up">9.18 ▲</span></div>
+              <div style="display:flex;justify-content:space-between;"><span style="color:#9CA3AF;">EUR</span><span class="down">1,502 ▼</span></div>
+            </div>
+          </div>
+          <div class="size-badge" style="background:#EEF2FF;color:#0046FF;"><div class="dot" style="background:#0046FF;"></div>1×1 · 소형</div>
+        </div>
+
+        <!-- ══════════════════════════════════════
+             Row 2–3: 3×2 | 2×2 | 1×2
+             6 = 3 + 2 + 1  (×2행)
+        ══════════════════════════════════════ -->
+
+        <!-- 주가/차트 ── 3×2 (화면 절반 너비 × 2행) -->
+        <div class="card c3 r2" style="border-color:#7C3AED;background:linear-gradient(135deg,#faf8ff,#fff);">
+          <div style="display:flex;align-items:flex-start;justify-content:space-between;flex-shrink:0;margin-bottom:4px;">
+            <div><div style="font-size:12px;font-weight:700;">SK하이닉스</div><div style="font-size:8px;color:#9CA3AF;">000660 · KOSPI</div></div>
+            <div style="text-align:right;"><div style="font-size:18px;font-weight:800;line-height:1.1;">182,000</div><div style="font-size:9px;" class="up">▲ +3,500 (+1.96%)</div></div>
+          </div>
+          <div style="background:#F9FAFB;border-radius:10px;flex:1;display:flex;align-items:flex-end;padding:10px;gap:2px;min-height:0;margin:4px 0;">
+            <div class="bar" style="flex:1;background:#FECACA;height:30%;"></div><div class="bar" style="flex:1;background:#FECACA;height:38%;"></div><div class="bar" style="flex:1;background:#FCA5A5;height:35%;"></div><div class="bar" style="flex:1;background:#FCA5A5;height:47%;"></div><div class="bar" style="flex:1;background:#F87171;height:52%;"></div><div class="bar" style="flex:1;background:#F87171;height:58%;"></div><div class="bar" style="flex:1;background:#EF4444;height:63%;"></div><div class="bar" style="flex:1;background:#EF4444;height:70%;"></div><div class="bar" style="flex:1;background:#DC2626;height:74%;"></div><div class="bar" style="flex:1;background:#DC2626;height:79%;"></div><div class="bar" style="flex:1;background:#B91C1C;height:84%;"></div><div class="bar" style="flex:1;background:#B91C1C;height:90%;"></div><div class="bar" style="flex:1;background:#991B1B;height:93%;"></div><div class="bar" style="flex:1;background:#991B1B;height:96%;"></div>
+          </div>
+          <div style="display:flex;justify-content:space-between;flex-shrink:0;">
+            <div style="text-align:center;"><div style="font-size:8px;color:#9CA3AF;">시가</div><div style="font-size:10px;font-weight:600;">178,500</div></div>
+            <div style="text-align:center;"><div style="font-size:8px;color:#9CA3AF;">고가</div><div style="font-size:10px;font-weight:600;" class="up">183,000</div></div>
+            <div style="text-align:center;"><div style="font-size:8px;color:#9CA3AF;">저가</div><div style="font-size:10px;font-weight:600;" class="down">177,200</div></div>
+            <div style="text-align:center;"><div style="font-size:8px;color:#9CA3AF;">거래량</div><div style="font-size:10px;font-weight:600;">8.2M</div></div>
+          </div>
+          <div class="size-badge" style="background:#F3EEFF;color:#7C3AED;"><div class="dot" style="background:#7C3AED;"></div>3×2 · 하프 대형</div>
+        </div>
+
+        <!-- 실시간 순위 ── 2×2 -->
+        <div class="card c2 r2" style="border-color:#0046FF;">
+          <div class="lbl">실시간 순위</div>
+          <div style="display:flex;gap:3px;margin-bottom:6px;">
+            <span class="tag" style="background:#EEF2FF;color:#0046FF;">거래대금</span>
+            <span class="tag" style="color:#9CA3AF;">상승률</span>
+            <span class="tag" style="color:#9CA3AF;">거래량</span>
+          </div>
+          <div style="flex:1;display:flex;flex-direction:column;gap:5px;overflow:hidden;">
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">1</span><span style="font-size:11px;font-weight:500;">삼성전자</span></div><span style="font-size:10px;font-weight:600;" class="up">+1.62%</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">2</span><span style="font-size:11px;font-weight:500;">SK하이닉스</span></div><span style="font-size:10px;font-weight:600;" class="up">+2.35%</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">3</span><span style="font-size:11px;font-weight:500;">LG에너지솔루션</span></div><span style="font-size:10px;font-weight:600;" class="down">−0.87%</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">4</span><span style="font-size:11px;font-weight:500;">POSCO홀딩스</span></div><span style="font-size:10px;font-weight:600;" class="up">+0.54%</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">5</span><span style="font-size:11px;font-weight:500;">현대차</span></div><span style="font-size:10px;font-weight:600;" class="down">−1.20%</span></div>
+            <div style="height:1px;background:#F3F4F6;"></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">6</span><span style="font-size:11px;font-weight:500;">카카오뱅크</span></div><span style="font-size:10px;font-weight:600;" class="up">+0.91%</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">7</span><span style="font-size:11px;font-weight:500;">셀트리온</span></div><span style="font-size:10px;font-weight:600;" class="down">−0.33%</span></div>
+          </div>
+          <div class="size-badge" style="background:#EEF2FF;color:#0046FF;"><div class="dot" style="background:#0046FF;"></div>2×2 · 대형</div>
+        </div>
+
+        <!-- 관심종목 ── 1×2 (세로형) -->
+        <div class="card r2" style="border-color:#00A878;">
+          <div class="lbl">관심종목</div>
+          <div style="flex:1;display:flex;flex-direction:column;gap:4px;overflow:hidden;">
+            <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;">삼성전자</span><span style="font-size:9px;font-weight:600;" class="up">+1.62%</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;">SK하이닉스</span><span style="font-size:9px;font-weight:600;" class="up">+2.35%</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;">LG에너지</span><span style="font-size:9px;font-weight:600;" class="up">+0.91%</span></div>
+            <div style="height:1px;background:#F3F4F6;"></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;">현대차</span><span style="font-size:9px;font-weight:600;" class="down">−0.43%</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;">POSCO홀딩스</span><span style="font-size:9px;font-weight:600;" class="up">+0.54%</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;">카카오</span><span style="font-size:9px;font-weight:600;" class="down">−1.12%</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;">셀트리온</span><span style="font-size:9px;font-weight:600;" class="down">−0.33%</span></div>
+          </div>
+          <div class="size-badge" style="background:#ECFDF5;color:#00A878;"><div class="dot" style="background:#00A878;"></div>1×2 · 세로형</div>
+        </div>
+
+        <!-- ══════════════════════════════════════
+             Row 4: 2×1 | 2×1 | 2×1
+             6 = 2 + 2 + 2
+        ══════════════════════════════════════ -->
+
+        <!-- 거래내역 ── 2×1 -->
+        <div class="card c2" style="border-color:#F59E0B;">
+          <div class="lbl">거래내역</div>
+          <div style="flex:1;display:flex;flex-direction:column;gap:5px;overflow:hidden;">
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:4px;"><span class="tag up-bg">매수</span><span style="font-size:10px;font-weight:500;">삼성전자</span></div><div style="text-align:right;"><span style="font-size:10px;">75,400원</span><span style="font-size:9px;color:#9CA3AF;margin-left:4px;">10주</span></div></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:4px;"><span class="tag down-bg">매도</span><span style="font-size:10px;font-weight:500;">SK하이닉스</span></div><div style="text-align:right;"><span style="font-size:10px;">182,000원</span><span style="font-size:9px;color:#9CA3AF;margin-left:4px;">5주</span></div></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:4px;"><span class="tag up-bg">매수</span><span style="font-size:10px;font-weight:500;">LG에너지솔루션</span></div><div style="text-align:right;"><span style="font-size:10px;">398,000원</span><span style="font-size:9px;color:#9CA3AF;margin-left:4px;">3주</span></div></div>
+          </div>
+          <div class="size-badge" style="background:#FFFBEB;color:#F59E0B;"><div class="dot" style="background:#F59E0B;"></div>2×1 · 와이드</div>
+        </div>
+
+        <!-- 오늘의 시황 ── 2×1 -->
+        <div class="card c2" style="border-color:#F59E0B;">
+          <div class="lbl">오늘의 시황</div>
+          <div style="flex:1;display:flex;flex-direction:column;gap:5px;overflow:hidden;">
+            <p style="font-size:10px;color:#374151;line-height:1.5;font-weight:500;">美 CPI 예상치 하회, 나스닥 1% 상승</p>
+            <p style="font-size:10px;color:#374151;line-height:1.5;">SK하이닉스 목표가 상향 조정 — 키움증권</p>
+            <p style="font-size:10px;color:#374151;line-height:1.5;">원/달러 환율 1,378원 하락 마감</p>
+          </div>
+          <div class="size-badge" style="background:#FFFBEB;color:#F59E0B;"><div class="dot" style="background:#F59E0B;"></div>2×1 · 와이드</div>
+        </div>
+
+        <!-- 증권사 리포트 ── 2×1 -->
+        <div class="card c2" style="border-color:#F59E0B;">
+          <div class="lbl">증권사 리포트</div>
+          <div style="flex:1;display:flex;flex-direction:column;justify-content:space-between;overflow:hidden;">
+            <div>
+              <p style="font-size:11px;font-weight:700;line-height:1.4;">삼성전자 목표가 9만원으로 상향</p>
+              <p style="font-size:9px;color:#9CA3AF;margin-top:3px;">반도체 업황 회복 기대감, HBM 수주 확대 전망</p>
+            </div>
+            <div style="display:flex;align-items:center;gap:6px;">
+              <span style="font-size:9px;color:#0046FF;font-weight:600;">키움증권</span>
+              <span style="font-size:8px;color:#9CA3AF;">· 2026.03.18</span>
+            </div>
+          </div>
+          <div class="size-badge" style="background:#FFFBEB;color:#F59E0B;"><div class="dot" style="background:#F59E0B;"></div>2×1 · 와이드</div>
+        </div>
+
+      </div>
+    </div>
+  </main>
+
+  <!-- 채팅 패널 (368px) -->
+  <div class="cp">
+    <div class="cp-head">
+      <svg style="width:14px;height:14px;" fill="none" stroke="#0046FF" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/></svg>
+      <span style="font-size:13px;font-weight:600;">SOL AI</span>
+      <span style="width:6px;height:6px;border-radius:50%;background:#34D399;display:inline-block;margin-left:2px;"></span>
+    </div>
+    <div class="cp-msgs">
+      <div style="display:flex;gap:8px;"><div class="av"><svg style="width:11px;height:11px;" fill="none" stroke="white" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/></svg></div><div class="ai-bbl">안녕하세요! 오늘의 시장 동향이나 종목 분석을 도와드릴게요.</div></div>
+      <div style="display:flex;justify-content:flex-end;"><div class="me-bbl">SK하이닉스 지금 사도 돼?</div></div>
+      <div style="display:flex;gap:8px;"><div class="av"><svg style="width:11px;height:11px;" fill="none" stroke="white" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/></svg></div><div class="ai-bbl">현재 <strong style="color:#E8393E;">+1.96%</strong> 상승 중이에요. HBM 수요 증가로 목표주가 상향 리포트가 나왔습니다. 단기 모멘텀은 긍정적이나 분할 매수를 권장해요.</div></div>
+    </div>
+    <div class="cp-foot">
+      <input type="text" placeholder="AI에게 물어보세요..." style="flex:1;height:32px;padding:0 12px;border-radius:8px;background:#F4F6FA;font-size:12px;border:1px solid #E5E7EB;outline:none;"/>
+      <button style="width:32px;height:32px;display:flex;align-items:center;justify-content:center;border-radius:8px;background:#0046FF;border:none;cursor:pointer;"><svg style="width:13px;height:13px;" fill="none" stroke="white" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/></svg></button>
+    </div>
+  </div>
+</div>
+
+<!-- 범례 -->
+<div style="position:fixed;bottom:12px;left:72px;display:flex;gap:6px;z-index:50;flex-wrap:wrap;">
+  <div style="background:#EEF2FF;color:#0046FF;font-size:9px;font-weight:700;padding:3px 8px;border-radius:6px;border:1px solid #C7D7FF;">● 1×1 소형</div>
+  <div style="background:#FFFBEB;color:#F59E0B;font-size:9px;font-weight:700;padding:3px 8px;border-radius:6px;border:1px solid #FDE68A;">● 2×1 와이드</div>
+  <div style="background:#F3EEFF;color:#7C3AED;font-size:9px;font-weight:700;padding:3px 8px;border-radius:6px;border:1px solid #DDD6FE;">● 3×1 하프 와이드 (신규)</div>
+  <div style="background:#ECFDF5;color:#00A878;font-size:9px;font-weight:700;padding:3px 8px;border-radius:6px;border:1px solid #A7F3D0;">● 1×2 세로형 (신규)</div>
+  <div style="background:#EEF2FF;color:#0046FF;font-size:9px;font-weight:700;padding:3px 8px;border-radius:6px;border:1px solid #C7D7FF;">● 2×2 대형</div>
+  <div style="background:#F3EEFF;color:#7C3AED;font-size:9px;font-weight:700;padding:3px 8px;border-radius:6px;border:1px solid #DDD6FE;">● 3×2 하프 대형 (신규)</div>
+</div>
+
+</body>
+</html>

--- a/front-mvp/widget-sizes/01-balance.html
+++ b/front-mvp/widget-sizes/01-balance.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8"/>
+<title>계좌 잔고 — 사이즈 프리뷰</title>
+<link rel="stylesheet" href="_common.css"/>
+</head>
+<body>
+<div class="topbar">
+  <a href="../grid-b-6x4.html" class="nav-btn">← 목록</a>
+  <div style="flex:1;text-align:center;">
+    <span style="font-size:14px;font-weight:700;">계좌 잔고</span>
+    <span style="font-size:11px;color:#9CA3AF;margin-left:8px;">총 평가자산 · 평가손익 · 수익률</span>
+  </div>
+  <span style="font-size:11px;color:#9CA3AF;font-weight:600;">1 / 10</span>
+  <a href="02-index.html" class="nav-btn">다음 →</a>
+</div>
+
+<div class="grid-area">
+<div class="preview-grid">
+
+  <!-- 1×1 ✅ -->
+  <div class="card adopted cell-1x1">
+    <div class="size-tag">1×1</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;justify-content:space-between;">
+      <span class="lbl">계좌 잔고</span>
+      <div>
+        <div style="font-size:8px;color:#9CA3AF;margin-bottom:2px;">총 평가자산</div>
+        <div style="font-size:16px;font-weight:800;line-height:1.1;">84,320,000</div>
+        <div style="font-size:9px;font-weight:600;margin-top:3px;" class="up">▲ +2,152,000 (+2.61%)</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 2×1 ✅ -->
+  <div class="card adopted cell-2x1">
+    <div class="size-tag">2×1</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;gap:6px;overflow:hidden;">
+      <span class="lbl" style="flex-shrink:0;">계좌 잔고</span>
+      <!-- 총평가자산 그룹 -->
+      <div style="flex-shrink:0;">
+        <div style="font-size:8px;color:#9CA3AF;margin-bottom:1px;">총 평가자산</div>
+        <div style="font-size:18px;font-weight:800;line-height:1.1;">84,320,000</div>
+        <div style="font-size:9px;font-weight:600;margin-top:2px;" class="up">▲ +2,152,000원 (+2.61%)</div>
+      </div>
+      <div style="height:1px;background:#F3F4F6;flex-shrink:0;"></div>
+      <!-- 투자원금 / 평가손익 / 주문가능 가로배치 -->
+      <div style="display:flex;gap:8px;flex-shrink:0;">
+        <div style="flex:1;min-width:0;">
+          <div style="font-size:10px;color:#9CA3AF;margin-bottom:2px;">투자원금</div>
+          <div style="font-size:13px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">82,168,000</div>
+        </div>
+        <div style="flex:1;min-width:0;">
+          <div style="font-size:10px;color:#9CA3AF;margin-bottom:2px;">평가손익</div>
+          <div style="font-size:13px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;" class="up">+2,152,000</div>
+        </div>
+        <div style="flex:1;min-width:0;">
+          <div style="font-size:10px;color:#9CA3AF;margin-bottom:2px;">주문가능</div>
+          <div style="font-size:13px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">7,478만원</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 3×1 ✅ -->
+  <div class="card adopted cell-3x1">
+    <div class="size-tag">3×1</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;gap:16px;">
+      <div style="flex:1;display:flex;flex-direction:column;justify-content:space-between;">
+        <span class="lbl">계좌 잔고</span>
+        <div>
+          <div style="font-size:9px;color:#9CA3AF;">총 평가자산</div>
+          <div style="font-size:22px;font-weight:800;line-height:1.1;">84,320,000</div>
+          <div style="font-size:10px;font-weight:600;margin-top:2px;" class="up">▲ +2,152,000원 (+2.61%)</div>
+        </div>
+        <div style="display:flex;gap:10px;font-size:11px;">
+          <div><div style="color:#9CA3AF;">투자원금</div><div style="font-weight:600;">82,168,000</div></div>
+          <div><div style="color:#9CA3AF;">주문가능</div><div style="font-weight:600;">74,780,000</div></div>
+        </div>
+      </div>
+      <div style="border-left:1px solid #F3F4F6;padding-left:16px;flex:1;display:flex;flex-direction:column;justify-content:space-between;">
+        <div style="font-size:9px;color:#9CA3AF;">수익 추이 (30일)</div>
+        <div style="flex:1;display:flex;align-items:flex-end;gap:2px;min-height:0;margin:4px 0;">
+          <div class="bar" style="flex:1;background:#FECACA;height:30%;"></div>
+          <div class="bar" style="flex:1;background:#FCA5A5;height:38%;"></div>
+          <div class="bar" style="flex:1;background:#FCA5A5;height:35%;"></div>
+          <div class="bar" style="flex:1;background:#F87171;height:50%;"></div>
+          <div class="bar" style="flex:1;background:#F87171;height:55%;"></div>
+          <div class="bar" style="flex:1;background:#EF4444;height:65%;"></div>
+          <div class="bar" style="flex:1;background:#EF4444;height:70%;"></div>
+          <div class="bar" style="flex:1;background:#DC2626;height:80%;"></div>
+          <div class="bar" style="flex:1;background:#DC2626;height:85%;"></div>
+          <div class="bar" style="flex:1;background:#B91C1C;height:92%;"></div>
+        </div>
+        <div style="font-size:9px;color:#9CA3AF;text-align:right;">최고 +5.2%</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 1×2 미채택 -->
+  <div class="card not-adopted cell-1x2">
+    <div class="size-tag">1×2</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="flex:1;display:flex;flex-direction:column;justify-content:space-between;opacity:0.4;">
+      <span class="lbl">계좌 잔고</span>
+      <div>
+        <div style="font-size:9px;color:#9CA3AF;">총 평가자산</div>
+        <div style="font-size:16px;font-weight:800;line-height:1.1;">84,320,000</div>
+        <div style="font-size:9px;font-weight:600;" class="up">▲ +2.61%</div>
+      </div>
+      <div style="height:40%;display:flex;align-items:center;justify-content:center;border:1px dashed #E5E7EB;border-radius:8px;">
+        <span style="font-size:9px;color:#9CA3AF;">추가 정보 없음</span>
+      </div>
+    </div>
+    <div class="reject-reason">세로로 늘려도 표시할 추가 정보 없음</div>
+  </div>
+
+  <!-- 2×2 미채택 -->
+  <div class="card not-adopted cell-2x2">
+    <div class="size-tag">2×2</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="flex:1;display:flex;flex-direction:column;justify-content:space-between;opacity:0.4;">
+      <span class="lbl">계좌 잔고</span>
+      <div style="font-size:22px;font-weight:800;">84,320,000</div>
+      <div style="font-size:10px;" class="up">▲ +2,152,000 (+2.61%)</div>
+      <div style="flex:1;display:flex;align-items:center;justify-content:center;border:1px dashed #E5E7EB;border-radius:8px;margin-top:8px;">
+        <span style="font-size:9px;color:#9CA3AF;">포트폴리오 위젯과 정보 중복</span>
+      </div>
+    </div>
+    <div class="reject-reason">포트폴리오 위젯과 역할 중복 — 공간 낭비</div>
+  </div>
+
+  <!-- 3×2 미채택 -->
+  <div class="card not-adopted cell-3x2">
+    <div class="size-tag">3×2</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="flex:1;display:flex;align-items:center;justify-content:center;opacity:0.4;">
+      <div style="text-align:center;">
+        <div style="font-size:22px;font-weight:800;color:#9CA3AF;">84,320,000</div>
+        <div style="font-size:10px;color:#9CA3AF;margin-top:4px;">▲ +2.61%</div>
+      </div>
+    </div>
+    <div class="reject-reason">잔고 정보 특성상 대형 사이즈는 불필요</div>
+  </div>
+
+</div>
+</div>
+
+<div class="legend">
+  <div class="leg-item"><div class="leg-dot" style="background:#00A878;"></div><span>✅ 채택 — 해당 위젯에 권장</span></div>
+  <div class="leg-item"><div class="leg-dot" style="background:#D1D5DB;border:1px dashed #9CA3AF;"></div><span>— 미채택 — 이 위젯에는 불필요</span></div>
+</div>
+</body>
+</html>

--- a/front-mvp/widget-sizes/02-index.html
+++ b/front-mvp/widget-sizes/02-index.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8"/>
+<title>주요 지수 — 사이즈 프리뷰</title>
+<link rel="stylesheet" href="_common.css"/>
+</head>
+<body>
+<div class="topbar">
+  <a href="01-balance.html" class="nav-btn">← 이전</a>
+  <div style="flex:1;text-align:center;">
+    <span style="font-size:14px;font-weight:700;">주요 지수</span>
+    <span style="font-size:11px;color:#9CA3AF;margin-left:8px;">KOSPI · KOSDAQ · NASDAQ</span>
+  </div>
+  <span style="font-size:11px;color:#9CA3AF;font-weight:600;">2 / 10</span>
+  <a href="03-portfolio.html" class="nav-btn">다음 →</a>
+</div>
+
+<div class="grid-area">
+<div class="preview-grid">
+
+  <!-- 1×1 ✅ -->
+  <div class="card adopted cell-1x1">
+    <div class="size-tag">1×1</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;justify-content:space-between;">
+      <span class="lbl">주요 지수</span>
+      <div style="text-align:center;">
+        <div style="font-size:9px;color:#9CA3AF;">KOSPI</div>
+        <div style="font-size:18px;font-weight:800;line-height:1.1;">2,685</div>
+        <div style="font-size:9px;font-weight:600;" class="up">▲ +0.46%</div>
+      </div>
+      <div style="height:22px;width:100%;flex-shrink:0;">
+        <svg viewBox="0 0 100 30" preserveAspectRatio="none" style="width:100%;height:100%;display:block;">
+          <path d="M0,27 L25,21 L50,14 L75,8 L100,3 L100,30 L0,30 Z" fill="rgba(232,57,62,0.1)"/>
+          <polyline points="0,27 25,21 50,14 75,8 100,3" fill="none" stroke="#E8393E" stroke-width="1.5" vector-effect="non-scaling-stroke"/>
+        </svg>
+      </div>
+    </div>
+  </div>
+
+  <!-- 2×1 ✅ -->
+  <div class="card adopted cell-2x1">
+    <div class="size-tag">2×1</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:15px;flex:1;display:flex;">
+      <div style="flex:1;display:flex;flex-direction:column;align-items:center;padding:0 8px;border-right:1px solid #F3F4F6;">
+        <div style="flex:1;display:flex;flex-direction:column;justify-content:center;align-items:center;text-align:center;"><div style="font-size:9px;color:#9CA3AF;">KOSPI</div><div style="font-size:16px;font-weight:800;line-height:1.1;">2,685.42</div><div style="font-size:9px;" class="up">▲ +0.46%</div></div>
+        <div style="height:20px;width:100%;flex-shrink:0;">
+          <svg viewBox="0 0 100 30" preserveAspectRatio="none" style="width:100%;height:100%;display:block;">
+            <path d="M0,27 L33,18 L66,10 L100,3 L100,30 L0,30 Z" fill="rgba(232,57,62,0.1)"/>
+            <polyline points="0,27 33,18 66,10 100,3" fill="none" stroke="#E8393E" stroke-width="1.5" vector-effect="non-scaling-stroke"/>
+          </svg>
+        </div>
+      </div>
+      <div style="flex:1;display:flex;flex-direction:column;align-items:center;padding:0 8px;">
+        <div style="flex:1;display:flex;flex-direction:column;justify-content:center;align-items:center;text-align:center;"><div style="font-size:9px;color:#9CA3AF;">KOSDAQ</div><div style="font-size:16px;font-weight:800;line-height:1.1;">868.15</div><div style="font-size:9px;" class="down">▼ −0.21%</div></div>
+        <div style="height:20px;width:100%;flex-shrink:0;">
+          <svg viewBox="0 0 100 30" preserveAspectRatio="none" style="width:100%;height:100%;display:block;">
+            <path d="M0,3 L33,12 L66,20 L100,27 L100,30 L0,30 Z" fill="rgba(0,117,232,0.1)"/>
+            <polyline points="0,3 33,12 66,20 100,27" fill="none" stroke="#0075E8" stroke-width="1.5" vector-effect="non-scaling-stroke"/>
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 3×1 ✅ -->
+  <div class="card adopted cell-3x1">
+    <div class="size-tag">3×1</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;">
+      <div style="flex:1;display:flex;flex-direction:column;align-items:center;padding:0 10px;border-right:1px solid #F3F4F6;">
+        <div style="flex:1;display:flex;flex-direction:column;justify-content:center;align-items:center;text-align:center;"><div style="font-size:9px;color:#9CA3AF;">KOSPI</div><div style="font-size:17px;font-weight:800;line-height:1.1;">2,685.42</div><div style="font-size:9px;" class="up">▲ +12.35 (+0.46%)</div></div>
+        <div style="height:22px;width:100%;flex-shrink:0;">
+          <svg viewBox="0 0 100 30" preserveAspectRatio="none" style="width:100%;height:100%;display:block;">
+            <path d="M0,27 L25,21 L50,14 L75,8 L100,3 L100,30 L0,30 Z" fill="rgba(232,57,62,0.1)"/>
+            <polyline points="0,27 25,21 50,14 75,8 100,3" fill="none" stroke="#E8393E" stroke-width="1.5" vector-effect="non-scaling-stroke"/>
+          </svg>
+        </div>
+      </div>
+      <div style="flex:1;display:flex;flex-direction:column;align-items:center;padding:0 10px;border-right:1px solid #F3F4F6;">
+        <div style="flex:1;display:flex;flex-direction:column;justify-content:center;align-items:center;text-align:center;"><div style="font-size:9px;color:#9CA3AF;">KOSDAQ</div><div style="font-size:17px;font-weight:800;line-height:1.1;">868.15</div><div style="font-size:9px;" class="down">▼ −1.83 (−0.21%)</div></div>
+        <div style="height:22px;width:100%;flex-shrink:0;">
+          <svg viewBox="0 0 100 30" preserveAspectRatio="none" style="width:100%;height:100%;display:block;">
+            <path d="M0,3 L25,10 L50,17 L75,22 L100,27 L100,30 L0,30 Z" fill="rgba(0,117,232,0.1)"/>
+            <polyline points="0,3 25,10 50,17 75,22 100,27" fill="none" stroke="#0075E8" stroke-width="1.5" vector-effect="non-scaling-stroke"/>
+          </svg>
+        </div>
+      </div>
+      <div style="flex:1;display:flex;flex-direction:column;align-items:center;padding:0 10px;">
+        <div style="flex:1;display:flex;flex-direction:column;justify-content:center;align-items:center;text-align:center;"><div style="font-size:9px;color:#9CA3AF;">NASDAQ</div><div style="font-size:17px;font-weight:800;line-height:1.1;">16,274</div><div style="font-size:9px;" class="up">▲ +134 (+0.83%)</div></div>
+        <div style="height:22px;width:100%;flex-shrink:0;">
+          <svg viewBox="0 0 100 30" preserveAspectRatio="none" style="width:100%;height:100%;display:block;">
+            <path d="M0,27 L25,21 L50,14 L75,8 L100,3 L100,30 L0,30 Z" fill="rgba(232,57,62,0.1)"/>
+            <polyline points="0,27 25,21 50,14 75,8 100,3" fill="none" stroke="#E8393E" stroke-width="1.5" vector-effect="non-scaling-stroke"/>
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 1×2 미채택 -->
+  <div class="card not-adopted cell-1x2">
+    <div class="size-tag">1×2</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="flex:1;display:flex;flex-direction:column;gap:6px;opacity:0.4;margin-top:22px;">
+      <div style="text-align:center;padding:8px;border:1px solid #E5E7EB;border-radius:8px;"><div style="font-size:8px;color:#9CA3AF;">KOSPI</div><div style="font-size:14px;font-weight:800;">2,685</div><div style="font-size:8px;" class="up">▲ +0.46%</div></div>
+      <div style="text-align:center;padding:8px;border:1px solid #E5E7EB;border-radius:8px;"><div style="font-size:8px;color:#9CA3AF;">KOSDAQ</div><div style="font-size:14px;font-weight:800;">868</div><div style="font-size:8px;" class="down">▼ −0.21%</div></div>
+    </div>
+    <div class="reject-reason">지수는 수평 나열이 자연스러움 — 세로형 부적합</div>
+  </div>
+
+  <!-- 2×2 미채택 -->
+  <div class="card not-adopted cell-2x2">
+    <div class="size-tag">2×2</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="flex:1;display:flex;align-items:center;justify-content:center;opacity:0.4;">
+      <div style="text-align:center;color:#9CA3AF;font-size:10px;">3×1로 3개 지수 수평 표시 가능 — 정방형 불필요</div>
+    </div>
+    <div class="reject-reason">3×1로 동일한 정보 더 효율적으로 표시 가능</div>
+  </div>
+
+  <!-- 3×2 미채택 -->
+  <div class="card not-adopted cell-3x2">
+    <div class="size-tag">3×2</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="flex:1;display:flex;align-items:center;justify-content:center;opacity:0.4;">
+      <div style="display:flex;gap:10px;">
+        <div style="text-align:center;"><div style="font-size:9px;color:#9CA3AF;">KOSPI</div><div style="font-size:20px;font-weight:800;color:#9CA3AF;">2,685</div></div>
+        <div style="text-align:center;"><div style="font-size:9px;color:#9CA3AF;">KOSDAQ</div><div style="font-size:20px;font-weight:800;color:#9CA3AF;">868</div></div>
+        <div style="text-align:center;"><div style="font-size:9px;color:#9CA3AF;">NASDAQ</div><div style="font-size:20px;font-weight:800;color:#9CA3AF;">16,274</div></div>
+      </div>
+    </div>
+    <div class="reject-reason">3×1로 3개 지수 표시 충분 — 대형은 과함</div>
+  </div>
+
+</div>
+</div>
+<div class="legend">
+  <div class="leg-item"><div class="leg-dot" style="background:#00A878;"></div><span>✅ 채택</span></div>
+  <div class="leg-item"><div class="leg-dot" style="background:#D1D5DB;"></div><span>— 미채택</span></div>
+</div>
+</body>
+</html>

--- a/front-mvp/widget-sizes/03-portfolio.html
+++ b/front-mvp/widget-sizes/03-portfolio.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8"/>
+<title>포트폴리오 — 사이즈 프리뷰</title>
+<link rel="stylesheet" href="_common.css"/>
+</head>
+<body>
+<div class="topbar">
+  <a href="02-index.html" class="nav-btn">← 이전</a>
+  <div style="flex:1;text-align:center;">
+    <span style="font-size:14px;font-weight:700;">포트폴리오</span>
+    <span style="font-size:11px;color:#9CA3AF;margin-left:8px;">보유 종목 비중 파이차트 · 목록</span>
+  </div>
+  <span style="font-size:11px;color:#9CA3AF;font-weight:600;">3 / 10</span>
+  <a href="04-stock-chart.html" class="nav-btn">다음 →</a>
+</div>
+
+<div class="grid-area">
+<div class="preview-grid">
+
+  <!-- 1×1 ✅ — portfolio-sm -->
+  <div class="card adopted cell-1x1">
+    <div class="size-tag">1×1</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;">
+      <div style="margin-bottom:6px;flex-shrink:0;">
+        <span style="font-size:10px;font-weight:600;color:#9CA3AF;text-transform:uppercase;letter-spacing:.04em;">포트폴리오</span>
+      </div>
+      <div style="flex:1;display:flex;align-items:center;gap:10px;min-height:0;">
+        <div style="position:relative;width:52px;height:52px;flex-shrink:0;">
+          <div class="pie" style="width:52px;height:52px;"></div>
+          <div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;">
+            <div style="width:32px;height:32px;border-radius:50%;background:#fff;display:flex;align-items:center;justify-content:center;">
+              <span style="font-size:9px;font-weight:700;color:#E8393E;">+5.2%</span>
+            </div>
+          </div>
+        </div>
+        <div style="flex:1;display:flex;flex-direction:column;gap:4px;min-width:0;">
+          <div style="display:flex;align-items:center;gap:4px;">
+            <div style="width:6px;height:6px;border-radius:2px;background:#0046FF;flex-shrink:0;"></div>
+            <span style="font-size:10px;color:#6B7280;">삼성전자</span>
+          </div>
+          <div style="display:flex;align-items:center;gap:4px;">
+            <div style="width:6px;height:6px;border-radius:2px;background:#00A878;flex-shrink:0;"></div>
+            <span style="font-size:10px;color:#6B7280;">SK하이닉스</span>
+          </div>
+          <div style="display:flex;align-items:center;gap:4px;">
+            <div style="width:6px;height:6px;border-radius:2px;background:#FF9500;flex-shrink:0;"></div>
+            <span style="font-size:10px;color:#6B7280;">NAVER</span>
+          </div>
+          <div style="display:flex;align-items:center;gap:4px;">
+            <div style="width:6px;height:6px;border-radius:2px;background:#EF4444;flex-shrink:0;"></div>
+            <span style="font-size:10px;color:#6B7280;">기타</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 2×1 ✅ — portfolio-wide -->
+  <div class="card adopted cell-2x1">
+    <div class="size-tag">2×1</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;">
+      <div style="margin-bottom:8px;flex-shrink:0;">
+        <span style="font-size:10px;font-weight:600;color:#9CA3AF;text-transform:uppercase;letter-spacing:.04em;">포트폴리오</span>
+      </div>
+      <div style="flex:1;display:flex;flex-direction:column;justify-content:center;gap:8px;min-height:0;">
+          <div>
+            <div style="display:flex;justify-content:space-between;margin-bottom:2px;">
+              <span style="font-size:10px;color:#6B7280;">삼성전자</span>
+              <span style="font-size:10px;font-weight:600;">34%</span>
+            </div>
+            <div style="height:3px;background:#F3F4F6;border-radius:9999px;overflow:hidden;">
+              <div style="height:100%;border-radius:9999px;width:34%;background:#0046FF;"></div>
+            </div>
+          </div>
+          <div>
+            <div style="display:flex;justify-content:space-between;margin-bottom:2px;">
+              <span style="font-size:10px;color:#6B7280;">SK하이닉스</span>
+              <span style="font-size:10px;font-weight:600;">20%</span>
+            </div>
+            <div style="height:3px;background:#F3F4F6;border-radius:9999px;overflow:hidden;">
+              <div style="height:100%;border-radius:9999px;width:20%;background:#00A878;"></div>
+            </div>
+          </div>
+          <div>
+            <div style="display:flex;justify-content:space-between;margin-bottom:2px;">
+              <span style="font-size:10px;color:#6B7280;">NAVER</span>
+              <span style="font-size:10px;font-weight:600;">15%</span>
+            </div>
+            <div style="height:3px;background:#F3F4F6;border-radius:9999px;overflow:hidden;">
+              <div style="height:100%;border-radius:9999px;width:15%;background:#FF9500;"></div>
+            </div>
+          </div>
+          <div>
+            <div style="display:flex;justify-content:space-between;margin-bottom:2px;">
+              <span style="font-size:10px;color:#6B7280;">기타</span>
+              <span style="font-size:10px;font-weight:600;">31%</span>
+            </div>
+            <div style="height:3px;background:#F3F4F6;border-radius:9999px;overflow:hidden;">
+              <div style="height:100%;border-radius:9999px;width:31%;background:#EF4444;"></div>
+            </div>
+          </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 3×1 미채택 -->
+  <div class="card not-adopted cell-3x1">
+    <div class="size-tag">3×1</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;gap:12px;opacity:0.4;">
+      <div style="display:flex;align-items:center;justify-content:center;"><div class="pie" style="width:52px;height:52px;"></div></div>
+      <div style="flex:1;display:flex;flex-direction:column;justify-content:center;gap:5px;font-size:10px;">
+        <div style="display:flex;justify-content:space-between;"><span>삼성전자</span><span>34%</span></div>
+        <div style="display:flex;justify-content:space-between;"><span>SK하이닉스</span><span>20%</span></div>
+        <div style="display:flex;justify-content:space-between;"><span>NAVER</span><span>15%</span></div>
+      </div>
+      <div style="flex:1;border-left:1px solid #F3F4F6;padding-left:12px;display:flex;align-items:center;justify-content:center;">
+        <span style="font-size:9px;color:#9CA3AF;">추가 정보 없음</span>
+      </div>
+    </div>
+    <div class="reject-reason">2×1로 충분한 정보 표시 가능</div>
+  </div>
+
+  <!-- 1×2 미채택 -->
+  <div class="card not-adopted cell-1x2">
+    <div class="size-tag">1×2</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="flex:1;display:flex;align-items:center;justify-content:center;opacity:0.4;">
+      <div style="text-align:center;color:#9CA3AF;font-size:10px;">2×1로 동일한 정보 더 효율적으로 표시 가능</div>
+    </div>
+    <div class="reject-reason">세로형 — 2×1 가로형이 파이차트+목록 배치에 더 적합</div>
+  </div>
+
+  <!-- 2×2 ✅ — portfolio-2x2 -->
+  <div class="card adopted cell-2x2">
+    <div class="size-tag">2×2</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;">
+      <div style="margin-bottom:10px;flex-shrink:0;">
+        <span style="font-size:10px;font-weight:600;color:#9CA3AF;text-transform:uppercase;letter-spacing:.04em;">포트폴리오</span>
+      </div>
+      <div style="display:flex;align-items:center;gap:12px;flex-shrink:0;margin-bottom:12px;">
+        <div style="position:relative;width:68px;height:68px;flex-shrink:0;">
+          <div class="pie" style="width:68px;height:68px;"></div>
+          <div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;">
+            <div style="width:40px;height:40px;border-radius:50%;background:#fff;"></div>
+          </div>
+        </div>
+        <div>
+          <div style="font-size:9px;color:#9CA3AF;">총 수익률</div>
+          <div style="font-size:22px;font-weight:700;line-height:1.1;color:#E8393E;">+5.2%</div>
+          <div style="font-size:9px;color:#9CA3AF;margin-top:2px;">+4,280,000원</div>
+        </div>
+      </div>
+      <div style="flex:1;display:flex;flex-direction:column;gap:10px;min-height:0;">
+        <div>
+          <div style="display:flex;justify-content:space-between;margin-bottom:2px;">
+            <span style="font-size:10px;color:#6B7280;">삼성전자</span>
+            <span style="font-size:10px;font-weight:600;">34%</span>
+          </div>
+          <div style="height:4px;background:#F3F4F6;border-radius:9999px;overflow:hidden;">
+            <div style="height:100%;border-radius:9999px;width:34%;background:#0046FF;"></div>
+          </div>
+        </div>
+        <div>
+          <div style="display:flex;justify-content:space-between;margin-bottom:2px;">
+            <span style="font-size:10px;color:#6B7280;">SK하이닉스</span>
+            <span style="font-size:10px;font-weight:600;">20%</span>
+          </div>
+          <div style="height:4px;background:#F3F4F6;border-radius:9999px;overflow:hidden;">
+            <div style="height:100%;border-radius:9999px;width:20%;background:#00A878;"></div>
+          </div>
+        </div>
+        <div>
+          <div style="display:flex;justify-content:space-between;margin-bottom:2px;">
+            <span style="font-size:10px;color:#6B7280;">NAVER</span>
+            <span style="font-size:10px;font-weight:600;">15%</span>
+          </div>
+          <div style="height:4px;background:#F3F4F6;border-radius:9999px;overflow:hidden;">
+            <div style="height:100%;border-radius:9999px;width:15%;background:#FF9500;"></div>
+          </div>
+        </div>
+        <div>
+          <div style="display:flex;justify-content:space-between;margin-bottom:2px;">
+            <span style="font-size:10px;color:#6B7280;">기타</span>
+            <span style="font-size:10px;font-weight:600;">31%</span>
+          </div>
+          <div style="height:4px;background:#F3F4F6;border-radius:9999px;overflow:hidden;">
+            <div style="height:100%;border-radius:9999px;width:31%;background:#EF4444;"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 3×2 미채택 -->
+  <div class="card not-adopted cell-3x2">
+    <div class="size-tag">3×2</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="flex:1;display:flex;align-items:center;justify-content:center;opacity:0.4;gap:20px;">
+      <div class="pie" style="width:80px;height:80px;"></div>
+      <div style="display:flex;flex-direction:column;gap:6px;font-size:10px;color:#9CA3AF;">
+        <div>삼성전자 — 34%</div>
+        <div>SK하이닉스 — 20%</div>
+        <div>NAVER — 15%</div>
+      </div>
+    </div>
+    <div class="reject-reason">2×2로 충분한 상세 정보 표시 가능 — 공간 낭비</div>
+  </div>
+
+</div>
+</div>
+<div class="legend">
+  <div class="leg-item"><div class="leg-dot" style="background:#00A878;"></div><span>✅ 채택</span></div>
+  <div class="leg-item"><div class="leg-dot" style="background:#D1D5DB;"></div><span>— 미채택</span></div>
+</div>
+</body>
+</html>

--- a/front-mvp/widget-sizes/04-stock-chart.html
+++ b/front-mvp/widget-sizes/04-stock-chart.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8"/>
+<title>주가/차트 — 사이즈 프리뷰</title>
+<link rel="stylesheet" href="_common.css"/>
+</head>
+<body>
+<div class="topbar">
+  <a href="03-portfolio.html" class="nav-btn">← 이전</a>
+  <div style="flex:1;text-align:center;">
+    <span style="font-size:14px;font-weight:700;">주가 / 차트</span>
+    <span style="font-size:11px;color:#9CA3AF;margin-left:8px;">종목 현재가 · 차트 · 지표</span>
+  </div>
+  <span style="font-size:11px;color:#9CA3AF;font-weight:600;">4 / 10</span>
+  <a href="05-ranking.html" class="nav-btn">다음 →</a>
+</div>
+
+<div class="grid-area">
+<div class="preview-grid">
+
+  <!-- 1×1 ✅ -->
+  <div class="card adopted cell-1x1">
+    <div class="size-tag">1×1</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;justify-content:space-between;">
+      <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:700;">삼성전자</span><span style="font-size:8px;color:#9CA3AF;">005930</span></div>
+      <div style="flex:1;display:flex;align-items:flex-end;gap:1px;min-height:0;margin:4px 0;">
+        <div class="bar" style="flex:1;background:#FECACA;height:40%;"></div><div class="bar" style="flex:1;background:#FCA5A5;height:52%;"></div><div class="bar" style="flex:1;background:#F87171;height:60%;"></div><div class="bar" style="flex:1;background:#EF4444;height:72%;"></div><div class="bar" style="flex:1;background:#DC2626;height:82%;"></div>
+      </div>
+      <div><div style="font-size:16px;font-weight:800;line-height:1.1;">75,400</div><div style="font-size:9px;" class="up">▲ +1,200 (+1.62%)</div></div>
+    </div>
+  </div>
+
+  <!-- 2×1 ✅ -->
+  <div class="card adopted cell-2x1">
+    <div class="size-tag">2×1</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;gap:10px;">
+      <div style="min-width:90px;display:flex;flex-direction:column;justify-content:space-between;">
+        <div><div style="font-size:11px;font-weight:700;">삼성전자</div><div style="font-size:8px;color:#9CA3AF;">005930 · KOSPI</div></div>
+        <div><div style="font-size:18px;font-weight:800;line-height:1.1;">75,400</div><div style="font-size:9px;" class="up">▲ +1,200 (+1.62%)</div></div>
+      </div>
+      <div style="flex:1;display:flex;align-items:flex-end;gap:2px;">
+        <div class="bar" style="flex:1;background:#FECACA;height:35%;"></div><div class="bar" style="flex:1;background:#FCA5A5;height:48%;"></div><div class="bar" style="flex:1;background:#FCA5A5;height:42%;"></div><div class="bar" style="flex:1;background:#F87171;height:55%;"></div><div class="bar" style="flex:1;background:#F87171;height:60%;"></div><div class="bar" style="flex:1;background:#EF4444;height:70%;"></div><div class="bar" style="flex:1;background:#EF4444;height:78%;"></div><div class="bar" style="flex:1;background:#DC2626;height:88%;"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 3×1 미채택 -->
+  <div class="card not-adopted cell-3x1">
+    <div class="size-tag">3×1</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;gap:12px;opacity:0.4;">
+      <div style="min-width:100px;display:flex;flex-direction:column;justify-content:space-between;">
+        <div><div style="font-size:11px;font-weight:700;">삼성전자</div><div style="font-size:8px;color:#9CA3AF;">005930</div></div>
+        <div><div style="font-size:18px;font-weight:800;">75,400</div><div style="font-size:9px;" class="up">▲ +1.62%</div></div>
+      </div>
+      <div style="flex:1;display:flex;align-items:flex-end;gap:2px;">
+        <div class="bar" style="flex:1;background:#FECACA;height:35%;"></div><div class="bar" style="flex:1;background:#FCA5A5;height:48%;"></div><div class="bar" style="flex:1;background:#F87171;height:62%;"></div><div class="bar" style="flex:1;background:#EF4444;height:75%;"></div><div class="bar" style="flex:1;background:#DC2626;height:88%;"></div>
+      </div>
+    </div>
+    <div class="reject-reason">너비 대비 행 높이가 얕아 차트 가독성 낮음 — 2×1 권장</div>
+  </div>
+
+  <!-- 1×2 미채택 -->
+  <div class="card not-adopted cell-1x2">
+    <div class="size-tag">1×2</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;justify-content:space-between;opacity:0.4;">
+      <div><div style="font-size:10px;font-weight:700;">삼성전자</div><div style="font-size:8px;color:#9CA3AF;">005930</div></div>
+      <div style="flex:1;display:flex;align-items:flex-end;gap:1px;min-height:0;margin:6px 0;">
+        <div class="bar" style="flex:1;background:#FECACA;height:40%;"></div><div class="bar" style="flex:1;background:#F87171;height:65%;"></div><div class="bar" style="flex:1;background:#DC2626;height:88%;"></div>
+      </div>
+      <div><div style="font-size:16px;font-weight:800;">75,400</div><div style="font-size:9px;" class="up">▲ +1.62%</div></div>
+    </div>
+    <div class="reject-reason">너비가 좁아 차트 막대가 뭉개짐</div>
+  </div>
+
+  <!-- 2×2 ✅ -->
+  <div class="card adopted cell-2x2">
+    <div class="size-tag">2×2</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;gap:6px;">
+      <div style="display:flex;justify-content:space-between;flex-shrink:0;">
+        <div><div style="font-size:12px;font-weight:700;">삼성전자</div><div style="font-size:8px;color:#9CA3AF;">005930 · KOSPI</div></div>
+        <div style="text-align:right;"><div style="font-size:17px;font-weight:800;line-height:1.1;">75,400</div><div style="font-size:9px;" class="up">▲ +1,200 (+1.62%)</div></div>
+      </div>
+      <div style="background:#F9FAFB;border-radius:10px;flex:1;display:flex;align-items:flex-end;padding:8px;gap:2px;min-height:0;">
+        <div class="bar" style="flex:1;background:#FECACA;height:32%;"></div><div class="bar" style="flex:1;background:#FECACA;height:40%;"></div><div class="bar" style="flex:1;background:#FCA5A5;height:36%;"></div><div class="bar" style="flex:1;background:#FCA5A5;height:50%;"></div><div class="bar" style="flex:1;background:#F87171;height:55%;"></div><div class="bar" style="flex:1;background:#F87171;height:62%;"></div><div class="bar" style="flex:1;background:#EF4444;height:68%;"></div><div class="bar" style="flex:1;background:#EF4444;height:74%;"></div><div class="bar" style="flex:1;background:#DC2626;height:80%;"></div><div class="bar" style="flex:1;background:#DC2626;height:86%;"></div><div class="bar" style="flex:1;background:#B91C1C;height:92%;"></div>
+      </div>
+      <div style="display:flex;justify-content:space-between;flex-shrink:0;font-size:9px;">
+        <div style="text-align:center;"><div style="color:#9CA3AF;">시가</div><div style="font-weight:600;">74,200</div></div>
+        <div style="text-align:center;"><div style="color:#9CA3AF;">고가</div><div class="up" style="font-weight:600;">75,800</div></div>
+        <div style="text-align:center;"><div style="color:#9CA3AF;">저가</div><div class="down" style="font-weight:600;">73,900</div></div>
+        <div style="text-align:center;"><div style="color:#9CA3AF;">거래량</div><div style="font-weight:600;">12.4M</div></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 3×2 ✅ -->
+  <div class="card adopted cell-3x2">
+    <div class="size-tag">3×2</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;gap:6px;">
+      <div style="display:flex;justify-content:space-between;align-items:flex-start;flex-shrink:0;">
+        <div>
+          <div style="font-size:13px;font-weight:700;">삼성전자</div>
+          <div style="font-size:9px;color:#9CA3AF;">005930 · KOSPI · 반도체</div>
+        </div>
+        <div style="text-align:right;">
+          <div style="font-size:20px;font-weight:800;line-height:1.1;">75,400</div>
+          <div style="font-size:9px;" class="up">▲ +1,200 (+1.62%)</div>
+        </div>
+      </div>
+      <div style="display:flex;gap:6px;margin-bottom:2px;font-size:9px;">
+        <span style="padding:2px 6px;border-radius:4px;background:#EEF2FF;color:#0046FF;font-weight:600;">1일</span>
+        <span style="padding:2px 6px;border-radius:4px;color:#9CA3AF;">1주</span>
+        <span style="padding:2px 6px;border-radius:4px;color:#9CA3AF;">1달</span>
+        <span style="padding:2px 6px;border-radius:4px;color:#9CA3AF;">3달</span>
+      </div>
+      <div style="background:#F9FAFB;border-radius:10px;flex:1;display:flex;align-items:flex-end;padding:10px;gap:2px;min-height:0;">
+        <div class="bar" style="flex:1;background:#FECACA;height:28%;"></div><div class="bar" style="flex:1;background:#FECACA;height:35%;"></div><div class="bar" style="flex:1;background:#FCA5A5;height:32%;"></div><div class="bar" style="flex:1;background:#FCA5A5;height:44%;"></div><div class="bar" style="flex:1;background:#F87171;height:48%;"></div><div class="bar" style="flex:1;background:#F87171;height:54%;"></div><div class="bar" style="flex:1;background:#EF4444;height:58%;"></div><div class="bar" style="flex:1;background:#EF4444;height:65%;"></div><div class="bar" style="flex:1;background:#DC2626;height:70%;"></div><div class="bar" style="flex:1;background:#DC2626;height:76%;"></div><div class="bar" style="flex:1;background:#B91C1C;height:82%;"></div><div class="bar" style="flex:1;background:#B91C1C;height:88%;"></div><div class="bar" style="flex:1;background:#991B1B;height:92%;"></div><div class="bar" style="flex:1;background:#991B1B;height:96%;"></div>
+      </div>
+      <div style="display:flex;justify-content:space-between;flex-shrink:0;font-size:9px;">
+        <div style="text-align:center;"><div style="color:#9CA3AF;">시가</div><div style="font-weight:600;">74,200</div></div>
+        <div style="text-align:center;"><div style="color:#9CA3AF;">고가</div><div class="up" style="font-weight:600;">75,800</div></div>
+        <div style="text-align:center;"><div style="color:#9CA3AF;">저가</div><div class="down" style="font-weight:600;">73,900</div></div>
+        <div style="text-align:center;"><div style="color:#9CA3AF;">거래량</div><div style="font-weight:600;">12.4M</div></div>
+        <div style="text-align:center;"><div style="color:#9CA3AF;">시총</div><div style="font-weight:600;">450조</div></div>
+      </div>
+    </div>
+  </div>
+
+</div>
+</div>
+<div class="legend">
+  <div class="leg-item"><div class="leg-dot" style="background:#00A878;"></div><span>✅ 채택</span></div>
+  <div class="leg-item"><div class="leg-dot" style="background:#D1D5DB;"></div><span>— 미채택</span></div>
+</div>
+</body>
+</html>

--- a/front-mvp/widget-sizes/05-ranking.html
+++ b/front-mvp/widget-sizes/05-ranking.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8"/>
+<title>실시간 순위 — 사이즈 프리뷰</title>
+<link rel="stylesheet" href="_common.css"/>
+</head>
+<body>
+<div class="topbar">
+  <a href="04-stock-chart.html" class="nav-btn">← 이전</a>
+  <div style="flex:1;text-align:center;">
+    <span style="font-size:14px;font-weight:700;">실시간 순위</span>
+    <span style="font-size:11px;color:#9CA3AF;margin-left:8px;">거래대금 · 상승률 · 거래량</span>
+  </div>
+  <span style="font-size:11px;color:#9CA3AF;font-weight:600;">5 / 10</span>
+  <a href="06-watchlist.html" class="nav-btn">다음 →</a>
+</div>
+
+<div class="grid-area">
+<div class="preview-grid">
+
+  <!-- 1×1 미채택 -->
+  <div class="card not-adopted cell-1x1">
+    <div class="size-tag">1×1</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="flex:1;display:flex;flex-direction:column;gap:3px;overflow:hidden;opacity:0.4;margin-top:22px;">
+      <div style="display:flex;justify-content:space-between;font-size:9px;"><span>삼성전자</span><span class="up">+1.62%</span></div>
+      <div style="display:flex;justify-content:space-between;font-size:9px;"><span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:60px;">SK하이…</span><span class="up">+2.35%</span></div>
+      <div style="display:flex;justify-content:space-between;font-size:9px;"><span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:60px;">LG에너…</span><span class="down">−0.87%</span></div>
+    </div>
+    <div class="reject-reason">종목명 잘림 — 랭킹 목록 표시 불가</div>
+  </div>
+
+  <!-- 2×1 ✅ -->
+  <div class="card adopted cell-2x1">
+    <div class="size-tag">2×1</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;gap:3px;">
+      <div style="display:flex;gap:4px;margin-bottom:4px;">
+        <span class="tag" style="background:#EEF2FF;color:#0046FF;">거래대금</span>
+        <span class="tag" style="color:#9CA3AF;">상승률</span>
+        <span class="tag" style="color:#9CA3AF;">거래량</span>
+      </div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">1</span><span style="font-size:11px;font-weight:500;">삼성전자</span></div><span style="font-size:10px;font-weight:600;" class="up">+1.62%</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">2</span><span style="font-size:11px;font-weight:500;">SK하이닉스</span></div><span style="font-size:10px;font-weight:600;" class="up">+2.35%</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">3</span><span style="font-size:11px;font-weight:500;">LG에너지솔루션</span></div><span style="font-size:10px;font-weight:600;" class="down">−0.87%</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">4</span><span style="font-size:11px;font-weight:500;">POSCO홀딩스</span></div><span style="font-size:10px;font-weight:600;" class="up">+0.54%</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">5</span><span style="font-size:11px;font-weight:500;">현대차</span></div><span style="font-size:10px;font-weight:600;" class="down">−1.20%</span></div>
+    </div>
+  </div>
+
+  <!-- 3×1 미채택 -->
+  <div class="card not-adopted cell-3x1">
+    <div class="size-tag">3×1</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;gap:12px;opacity:0.4;">
+      <div style="flex:1;display:flex;flex-direction:column;gap:3px;">
+        <div style="display:flex;gap:4px;margin-bottom:4px;">
+          <span class="tag" style="background:#EEF2FF;color:#0046FF;">거래대금</span>
+          <span class="tag" style="color:#9CA3AF;">상승률</span>
+          <span class="tag" style="color:#9CA3AF;">거래량</span>
+        </div>
+        <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">1</span><span style="font-size:11px;font-weight:500;">삼성전자</span></div><span style="font-size:10px;font-weight:600;" class="up">+1.62%</span></div>
+        <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">2</span><span style="font-size:11px;font-weight:500;">SK하이닉스</span></div><span style="font-size:10px;font-weight:600;" class="up">+2.35%</span></div>
+        <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">3</span><span style="font-size:11px;font-weight:500;">LG에너지솔루션</span></div><span style="font-size:10px;font-weight:600;" class="down">−0.87%</span></div>
+        <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">4</span><span style="font-size:11px;font-weight:500;">POSCO홀딩스</span></div><span style="font-size:10px;font-weight:600;" class="up">+0.54%</span></div>
+        <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">5</span><span style="font-size:11px;font-weight:500;">현대차</span></div><span style="font-size:10px;font-weight:600;" class="down">−1.20%</span></div>
+      </div>
+      <div style="border-left:1px solid #F3F4F6;padding-left:12px;flex:1;display:flex;flex-direction:column;font-size:9px;">
+        <div style="color:#9CA3AF;font-weight:600;margin-bottom:7px;">거래대금 TOP</div>
+        <div style="display:flex;flex-direction:column;gap:4px;">
+          <div style="display:flex;justify-content:space-between;"><span>삼성전자</span><span style="color:#9CA3AF;">12.4조</span></div>
+          <div style="display:flex;justify-content:space-between;"><span>SK하이닉스</span><span style="color:#9CA3AF;">8.1조</span></div>
+          <div style="display:flex;justify-content:space-between;"><span>LG에너지</span><span style="color:#9CA3AF;">5.6조</span></div>
+          <div style="display:flex;justify-content:space-between;"><span>POSCO홀딩스</span><span style="color:#9CA3AF;">3.2조</span></div>
+          <div style="display:flex;justify-content:space-between;"><span>현대차</span><span style="color:#9CA3AF;">2.8조</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="reject-reason">2×1로 충분한 정보 표시 가능 — 가로 공간 낭비</div>
+  </div>
+
+  <!-- 1×2 미채택 -->
+  <div class="card not-adopted cell-1x2">
+    <div class="size-tag">1×2</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;gap:4px;overflow:hidden;opacity:0.4;">
+      <div style="display:flex;gap:3px;margin-bottom:3px;">
+        <span class="tag" style="background:#EEF2FF;color:#0046FF;font-size:7px;">거래대금</span>
+      </div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:4px;"><span style="font-size:9px;color:#9CA3AF;width:8px;">1</span><span style="font-size:10px;font-weight:500;">삼성전자</span></div><span style="font-size:9px;font-weight:600;" class="up">+1.62%</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:4px;"><span style="font-size:9px;color:#9CA3AF;width:8px;">2</span><span style="font-size:10px;font-weight:500;">SK하이닉스</span></div><span style="font-size:9px;font-weight:600;" class="up">+2.35%</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:4px;"><span style="font-size:9px;color:#9CA3AF;width:8px;">3</span><span style="font-size:10px;font-weight:500;">LG에너지</span></div><span style="font-size:9px;font-weight:600;" class="down">−0.87%</span></div>
+      <div style="height:1px;background:#F3F4F6;margin:2px 0;"></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:4px;"><span style="font-size:9px;color:#9CA3AF;width:8px;">4</span><span style="font-size:10px;font-weight:500;">POSCO홀딩스</span></div><span style="font-size:9px;font-weight:600;" class="up">+0.54%</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:4px;"><span style="font-size:9px;color:#9CA3AF;width:8px;">5</span><span style="font-size:10px;font-weight:500;">현대차</span></div><span style="font-size:9px;font-weight:600;" class="down">−1.20%</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:4px;"><span style="font-size:9px;color:#9CA3AF;width:8px;">6</span><span style="font-size:10px;font-weight:500;">카카오뱅크</span></div><span style="font-size:9px;font-weight:600;" class="up">+0.91%</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:4px;"><span style="font-size:9px;color:#9CA3AF;width:8px;">7</span><span style="font-size:10px;font-weight:500;">셀트리온</span></div><span style="font-size:9px;font-weight:600;" class="down">−0.33%</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:4px;"><span style="font-size:9px;color:#9CA3AF;width:8px;">8</span><span style="font-size:10px;font-weight:500;">현대모비스</span></div><span style="font-size:9px;font-weight:600;" class="up">+1.10%</span></div>
+    </div>
+    <div class="reject-reason">세로형 — 2×2로 더 많은 정보 표시 가능</div>
+  </div>
+
+  <!-- 2×2 ✅ -->
+  <div class="card adopted cell-2x2">
+    <div class="size-tag">2×2</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;gap:6px;">
+      <div style="display:flex;gap:4px;">
+        <span class="tag" style="background:#EEF2FF;color:#0046FF;padding:3px 8px;">거래대금</span>
+        <span class="tag" style="background:#F3F4F6;color:#6B7280;padding:3px 8px;">상승률</span>
+        <span class="tag" style="background:#F3F4F6;color:#6B7280;padding:3px 8px;">거래량</span>
+      </div>
+      <div style="flex:1;display:flex;gap:10px;min-height:0;">
+        <div style="flex:1;display:flex;flex-direction:column;gap:4px;overflow:hidden;">
+          <div style="font-size:8px;color:#9CA3AF;font-weight:600;">순위</div>
+          <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">1</span><span style="font-size:11px;font-weight:500;">삼성전자</span></div><span style="font-size:10px;font-weight:600;" class="up">+1.62%</span></div>
+          <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">2</span><span style="font-size:11px;font-weight:500;">SK하이닉스</span></div><span style="font-size:10px;font-weight:600;" class="up">+2.35%</span></div>
+          <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">3</span><span style="font-size:11px;font-weight:500;">LG에너지솔루션</span></div><span style="font-size:10px;font-weight:600;" class="down">−0.87%</span></div>
+          <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">4</span><span style="font-size:11px;font-weight:500;">POSCO홀딩스</span></div><span style="font-size:10px;font-weight:600;" class="up">+0.54%</span></div>
+          <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">5</span><span style="font-size:11px;font-weight:500;">현대차</span></div><span style="font-size:10px;font-weight:600;" class="down">−1.20%</span></div>
+          <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">6</span><span style="font-size:11px;font-weight:500;">카카오뱅크</span></div><span style="font-size:10px;font-weight:600;" class="up">+0.91%</span></div>
+          <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:6px;"><span style="font-size:9px;color:#9CA3AF;width:10px;">7</span><span style="font-size:11px;font-weight:500;">셀트리온</span></div><span style="font-size:10px;font-weight:600;" class="down">−0.33%</span></div>
+        </div>
+        <div style="border-left:1px solid #F3F4F6;padding-left:10px;min-width:80px;display:flex;flex-direction:column;gap:5px;font-size:9px;">
+          <div style="color:#9CA3AF;font-weight:600;margin-bottom:4px;">거래대금</div>
+          <div>12.4조</div><div>8.1조</div><div>5.6조</div><div>3.2조</div><div>2.8조</div><div>1.9조</div><div>1.4조</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 3×2 미채택 -->
+  <div class="card not-adopted cell-3x2">
+    <div class="size-tag">3×2</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="flex:1;display:flex;align-items:center;justify-content:center;opacity:0.4;">
+      <div style="text-align:center;color:#9CA3AF;">
+        <div style="font-size:11px;font-weight:600;margin-bottom:6px;">실시간 순위</div>
+        <div style="font-size:9px;">목록 내용은 2×2로 충분</div>
+      </div>
+    </div>
+    <div class="reject-reason">2×2로 충분한 순위 표시 가능 — 빈 공간 낭비</div>
+  </div>
+
+</div>
+</div>
+<div class="legend">
+  <div class="leg-item"><div class="leg-dot" style="background:#00A878;"></div><span>✅ 채택</span></div>
+  <div class="leg-item"><div class="leg-dot" style="background:#D1D5DB;"></div><span>— 미채택</span></div>
+</div>
+</body>
+</html>

--- a/front-mvp/widget-sizes/06-watchlist.html
+++ b/front-mvp/widget-sizes/06-watchlist.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8"/>
+<title>관심종목 — 사이즈 프리뷰</title>
+<link rel="stylesheet" href="_common.css"/>
+</head>
+<body>
+<div class="topbar">
+  <a href="05-ranking.html" class="nav-btn">← 이전</a>
+  <div style="flex:1;text-align:center;">
+    <span style="font-size:14px;font-weight:700;">관심종목</span>
+    <span style="font-size:11px;color:#9CA3AF;margin-left:8px;">등록된 관심 종목 리스트</span>
+  </div>
+  <span style="font-size:11px;color:#9CA3AF;font-weight:600;">6 / 10</span>
+  <a href="07-market-overview.html" class="nav-btn">다음 →</a>
+</div>
+
+<div class="grid-area">
+<div class="preview-grid">
+
+  <!-- 1×1 ✅ -->
+  <div class="card adopted cell-1x1">
+    <div class="size-tag">1×1</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;gap:4px;overflow:hidden;">
+      <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;">삼성전자</span><span style="font-size:9px;font-weight:600;" class="up">+1.62%</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;">SK하이닉스</span><span style="font-size:9px;font-weight:600;" class="up">+2.35%</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;">현대차</span><span style="font-size:9px;font-weight:600;" class="down">−0.43%</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;">LG에너지</span><span style="font-size:9px;font-weight:600;" class="up">+0.91%</span></div>
+    </div>
+  </div>
+
+  <!-- 2×1 ✅ -->
+  <div class="card adopted cell-2x1">
+    <div class="size-tag">2×1</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;gap:4px;overflow:hidden;">
+      <div style="display:flex;align-items:center;justify-content:space-between;font-size:8px;color:#9CA3AF;padding-bottom:2px;border-bottom:1px solid #F3F4F6;"><span>종목</span><span>현재가</span><span>등락</span><span>거래량</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;flex:2;">삼성전자</span><span style="font-size:10px;flex:2;text-align:right;">75,400</span><span style="font-size:10px;flex:1;text-align:right;" class="up">+1.62%</span><span style="font-size:9px;color:#9CA3AF;flex:1;text-align:right;">12.4M</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;flex:2;">SK하이닉스</span><span style="font-size:10px;flex:2;text-align:right;">182,000</span><span style="font-size:10px;flex:1;text-align:right;" class="up">+2.35%</span><span style="font-size:9px;color:#9CA3AF;flex:1;text-align:right;">8.1M</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;flex:2;">현대차</span><span style="font-size:10px;flex:2;text-align:right;">241,500</span><span style="font-size:10px;flex:1;text-align:right;" class="down">−0.43%</span><span style="font-size:9px;color:#9CA3AF;flex:1;text-align:right;">3.2M</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;flex:2;">LG에너지솔루션</span><span style="font-size:10px;flex:2;text-align:right;">398,000</span><span style="font-size:10px;flex:1;text-align:right;" class="up">+0.91%</span><span style="font-size:9px;color:#9CA3AF;flex:1;text-align:right;">2.1M</span></div>
+    </div>
+  </div>
+
+  <!-- 3×1 미채택 -->
+  <div class="card not-adopted cell-3x1">
+    <div class="size-tag">3×1</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;gap:4px;overflow:hidden;opacity:0.4;">
+      <div style="display:flex;align-items:center;justify-content:space-between;font-size:8px;color:#9CA3AF;padding-bottom:2px;border-bottom:1px solid #F3F4F6;"><span>종목</span><span>현재가</span><span>등락</span><span>거래량</span><span>시총</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;flex:2;">삼성전자</span><span style="font-size:10px;flex:2;text-align:right;">75,400</span><span style="font-size:10px;flex:1;text-align:right;" class="up">+1.62%</span><span style="font-size:9px;color:#9CA3AF;flex:1;text-align:right;">12.4M</span><span style="font-size:9px;color:#9CA3AF;flex:1;text-align:right;">450조</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;flex:2;">SK하이닉스</span><span style="font-size:10px;flex:2;text-align:right;">182,000</span><span style="font-size:10px;flex:1;text-align:right;" class="up">+2.35%</span><span style="font-size:9px;color:#9CA3AF;flex:1;text-align:right;">8.1M</span><span style="font-size:9px;color:#9CA3AF;flex:1;text-align:right;">132조</span></div>
+    </div>
+    <div class="reject-reason">2×1로 충분한 정보 표시 — 빈 공간 낭비</div>
+  </div>
+
+  <!-- 1×2 미채택 -->
+  <div class="card not-adopted cell-1x2">
+    <div class="size-tag">1×2</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;gap:4px;overflow:hidden;opacity:0.4;">
+      <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;">삼성전자</span><span style="font-size:9px;font-weight:600;" class="up">+1.62%</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;">SK하이닉스</span><span style="font-size:9px;font-weight:600;" class="up">+2.35%</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;">LG에너지솔루션</span><span style="font-size:9px;font-weight:600;" class="up">+0.91%</span></div>
+      <div style="height:1px;background:#F3F4F6;"></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;">현대차</span><span style="font-size:9px;font-weight:600;" class="down">−0.43%</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;">POSCO홀딩스</span><span style="font-size:9px;font-weight:600;" class="up">+0.54%</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;">카카오</span><span style="font-size:9px;font-weight:600;" class="down">−1.12%</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;">셀트리온</span><span style="font-size:9px;font-weight:600;" class="down">−0.33%</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;">기아차</span><span style="font-size:9px;font-weight:600;" class="up">+0.78%</span></div>
+    </div>
+    <div class="reject-reason">1×1로 종목명+등락률 표시 충분 — 세로 확장 불필요</div>
+  </div>
+
+  <!-- 2×2 미채택 -->
+  <div class="card not-adopted cell-2x2">
+    <div class="size-tag">2×2</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="flex:1;display:flex;flex-direction:column;gap:4px;overflow:hidden;opacity:0.4;margin-top:22px;">
+      <div style="display:flex;align-items:center;justify-content:space-between;font-size:8px;color:#9CA3AF;padding-bottom:2px;border-bottom:1px solid #F3F4F6;"><span>종목</span><span>현재가</span><span>등락</span><span>거래량</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;flex:2;">삼성전자</span><span style="font-size:10px;flex:2;text-align:right;">75,400</span><span style="font-size:10px;flex:1;text-align:right;" class="up">+1.62%</span><span style="font-size:9px;color:#9CA3AF;flex:1;text-align:right;">12.4M</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><span style="font-size:10px;font-weight:500;flex:2;">SK하이닉스</span><span style="font-size:10px;flex:2;text-align:right;">182,000</span><span style="font-size:10px;flex:1;text-align:right;" class="up">+2.35%</span><span style="font-size:9px;color:#9CA3AF;flex:1;text-align:right;">8.1M</span></div>
+      <div style="flex:1;display:flex;align-items:center;justify-content:center;border:1px dashed #E5E7EB;border-radius:8px;margin-top:6px;">
+        <span style="font-size:9px;color:#9CA3AF;">불필요하게 큰 공간</span>
+      </div>
+    </div>
+    <div class="reject-reason">목록형 위젯에 대형 사이즈 불필요 — 1×2 권장</div>
+  </div>
+
+  <!-- 3×2 미채택 -->
+  <div class="card not-adopted cell-3x2">
+    <div class="size-tag">3×2</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="flex:1;display:flex;align-items:center;justify-content:center;opacity:0.4;">
+      <div style="text-align:center;color:#9CA3AF;font-size:10px;">목록형에 과도하게 큰 공간</div>
+    </div>
+    <div class="reject-reason">관심종목 목록에 과도하게 큰 사이즈</div>
+  </div>
+
+</div>
+</div>
+<div class="legend">
+  <div class="leg-item"><div class="leg-dot" style="background:#00A878;"></div><span>✅ 채택</span></div>
+  <div class="leg-item"><div class="leg-dot" style="background:#D1D5DB;"></div><span>— 미채택</span></div>
+</div>
+</body>
+</html>

--- a/front-mvp/widget-sizes/07-market-overview.html
+++ b/front-mvp/widget-sizes/07-market-overview.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8"/>
+<title>오늘의 시황 — 사이즈 프리뷰</title>
+<link rel="stylesheet" href="_common.css"/>
+</head>
+<body>
+<div class="topbar">
+  <a href="06-watchlist.html" class="nav-btn">← 이전</a>
+  <div style="flex:1;text-align:center;">
+    <span style="font-size:14px;font-weight:700;">오늘의 시황</span>
+    <span style="font-size:11px;color:#9CA3AF;margin-left:8px;">주요 시황 뉴스 헤드라인</span>
+  </div>
+  <span style="font-size:11px;color:#9CA3AF;font-weight:600;">7 / 10</span>
+  <a href="07b-stock-news.html" class="nav-btn">다음 →</a>
+</div>
+
+<div class="grid-area">
+<div class="preview-grid">
+
+  <!-- 1×1 ✅ -->
+  <div class="card adopted cell-1x1">
+    <div class="size-tag">1×1</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;gap:5px;overflow:hidden;">
+      <span class="lbl">오늘의 시황</span>
+      <div style="display:flex;flex-direction:column;gap:4px;flex:1;overflow:hidden;">
+        <p style="font-size:10px;color:#374151;line-height:1.5;font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">美 CPI 예상치 하회, 나스닥 1% ↑</p>
+        <p style="font-size:10px;color:#6B7280;line-height:1.5;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">SK하이닉스 목표가 상향</p>
+        <p style="font-size:10px;color:#6B7280;line-height:1.5;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">원/달러 1,378원 마감</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- 2×1 ✅ -->
+  <div class="card adopted cell-2x1">
+    <div class="size-tag">2×1</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;gap:5px;overflow:hidden;">
+      <span class="lbl">오늘의 시황</span>
+      <div style="display:flex;flex-direction:column;gap:5px;flex:1;overflow:hidden;">
+        <div style="padding:6px 8px;border-radius:8px;background:#F9FAFB;border-left:3px solid #0046FF;flex-shrink:0;">
+          <p style="font-size:10px;color:#374151;font-weight:600;line-height:1.4;">美 CPI 예상치 하회, 나스닥 1% 상승</p>
+          <p style="font-size:9px;color:#9CA3AF;margin-top:2px;">연준 금리 인하 기대감 확산</p>
+        </div>
+        <div style="padding:6px 8px;border-radius:8px;background:#F9FAFB;border-left:3px solid #E5E7EB;flex-shrink:0;">
+          <p style="font-size:10px;color:#374151;font-weight:600;line-height:1.4;">SK하이닉스 목표가 상향 조정</p>
+          <p style="font-size:9px;color:#9CA3AF;margin-top:2px;">HBM 수요 증가 전망 — 키움증권</p>
+        </div>
+        <!-- <div style="padding:6px 8px;border-radius:8px;background:#F9FAFB;border-left:3px solid #E5E7EB;flex-shrink:0;">
+          <p style="font-size:10px;color:#374151;font-weight:600;line-height:1.4;">원/달러 환율 1,378원 하락 마감</p>
+        </div> -->
+      </div>
+    </div>
+  </div>
+
+  <!-- 3×1 미채택 -->
+  <div class="card not-adopted cell-3x1">
+    <div class="size-tag">3×1</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;gap:8px;opacity:0.4;">
+      <div style="flex:1;padding:6px 8px;border-radius:8px;background:#F9FAFB;border-left:3px solid #0046FF;"><p style="font-size:9px;color:#374151;font-weight:600;">美 CPI 예상치 하회</p><p style="font-size:8px;color:#9CA3AF;margin-top:2px;">연준 금리 인하 기대감</p></div>
+      <div style="flex:1;padding:6px 8px;border-radius:8px;background:#F9FAFB;border-left:3px solid #E5E7EB;"><p style="font-size:9px;color:#374151;font-weight:600;">SK하이닉스 목표가 상향</p><p style="font-size:8px;color:#9CA3AF;margin-top:2px;">키움증권</p></div>
+      <div style="flex:1;padding:6px 8px;border-radius:8px;background:#F9FAFB;border-left:3px solid #E5E7EB;"><p style="font-size:9px;color:#374151;font-weight:600;">환율 1,378원 마감</p><p style="font-size:8px;color:#9CA3AF;margin-top:2px;">달러 약세</p></div>
+    </div>
+    <div class="reject-reason">뉴스 3개를 수평 나열하면 읽기 불편 — 2×1 권장</div>
+  </div>
+
+  <!-- 1×2 미채택 -->
+  <div class="card not-adopted cell-1x2">
+    <div class="size-tag">1×2</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;gap:4px;overflow:hidden;opacity:0.4;">
+      <p style="font-size:9px;color:#374151;font-weight:600;line-height:1.4;">美 CPI 예상치 하회</p>
+      <p style="font-size:9px;color:#6B7280;line-height:1.4;">SK하이닉스 목표가 상향</p>
+      <p style="font-size:9px;color:#6B7280;line-height:1.4;">원/달러 1,378원</p>
+      <div style="flex:1;display:flex;align-items:center;justify-content:center;border:1px dashed #E5E7EB;border-radius:8px;margin-top:4px;">
+        <span style="font-size:8px;color:#9CA3AF;">추가 뉴스 없음</span>
+      </div>
+    </div>
+    <div class="reject-reason">뉴스는 세로 스크롤보다 카드형이 자연스러움</div>
+  </div>
+
+  <!-- 2×2 ✅ -->
+  <div class="card adopted cell-2x2">
+    <div class="size-tag">2×2</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;gap:5px;overflow:hidden;">
+      <span class="lbl">오늘의 시황</span>
+      <div style="display:flex;flex-direction:column;gap:6px;flex:1;overflow:hidden;">
+        <div style="padding:8px 10px;border-radius:10px;background:#F0F7FF;border-left:3px solid #0046FF;">
+          <p style="font-size:11px;color:#374151;font-weight:700;line-height:1.4;">美 CPI 예상치 하회, 나스닥 1% 상승</p>
+          <p style="font-size:9px;color:#6B7280;margin-top:3px;line-height:1.5;">연준 금리 인하 기대감이 확산되며 기술주 중심으로 매수세 유입. S&P500도 0.7% 상승 마감.</p>
+        </div>
+        <div style="padding:8px 10px;border-radius:10px;background:#F9FAFB;border-left:3px solid #EAECF0;">
+          <p style="font-size:11px;color:#374151;font-weight:700;line-height:1.4;">SK하이닉스 목표가 상향 조정</p>
+          <p style="font-size:9px;color:#6B7280;margin-top:3px;line-height:1.5;">HBM3E 수주 확대 및 AI 반도체 수요 급증으로 키움증권이 목표가를 20만원으로 상향.</p>
+        </div>
+        <div style="padding:8px 10px;border-radius:10px;background:#F9FAFB;border-left:3px solid #EAECF0;">
+          <p style="font-size:11px;color:#374151;font-weight:700;line-height:1.4;">원/달러 환율 1,378원 하락 마감</p>
+          <p style="font-size:9px;color:#6B7280;margin-top:3px;">달러 약세와 외국인 순매수로 원화 강세.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 3×2 미채택 -->
+  <div class="card not-adopted cell-3x2">
+    <div class="size-tag">3×2</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="flex:1;display:flex;align-items:center;justify-content:center;opacity:0.4;">
+      <div style="text-align:center;color:#9CA3AF;font-size:10px;">시황 뉴스 내용은 2×2로 충분</div>
+    </div>
+    <div class="reject-reason">텍스트 위주 콘텐츠는 넓은 공간 불필요</div>
+  </div>
+
+</div>
+</div>
+<div class="legend">
+  <div class="leg-item"><div class="leg-dot" style="background:#00A878;"></div><span>✅ 채택</span></div>
+  <div class="leg-item"><div class="leg-dot" style="background:#D1D5DB;"></div><span>— 미채택</span></div>
+</div>
+</body>
+</html>

--- a/front-mvp/widget-sizes/07b-stock-news.html
+++ b/front-mvp/widget-sizes/07b-stock-news.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8"/>
+<title>종목별 뉴스 — 사이즈 프리뷰</title>
+<link rel="stylesheet" href="_common.css"/>
+</head>
+<body>
+<div class="topbar">
+  <a href="07-market-overview.html" class="nav-btn">← 이전</a>
+  <div style="flex:1;text-align:center;">
+    <span style="font-size:14px;font-weight:700;">종목별 뉴스</span>
+    <span style="font-size:11px;color:#9CA3AF;margin-left:8px;">선택 종목 관련 뉴스 헤드라인</span>
+  </div>
+  <span style="font-size:11px;color:#9CA3AF;font-weight:600;">7b / 10</span>
+  <a href="08-exchange.html" class="nav-btn">다음 →</a>
+</div>
+
+<div class="grid-area">
+<div class="preview-grid">
+
+  <!-- 1×1 ✅ -->
+  <div class="card adopted cell-1x1">
+    <div class="size-tag">1×1</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;gap:5px;overflow:hidden;">
+      <div style="display:flex;align-items:center;justify-content:space-between;flex-shrink:0;">
+        <span class="lbl">종목별 뉴스</span>
+        <span style="font-size:9px;font-weight:600;color:#0046FF;background:#EEF2FF;padding:1px 5px;border-radius:3px;">삼성전자</span>
+      </div>
+      <div style="display:flex;flex-direction:column;gap:4px;flex:1;overflow:hidden;">
+        <p style="font-size:10px;color:#374151;line-height:1.5;font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">HBM 공급 본격화 — 엔비디아향 납품 재개</p>
+        <p style="font-size:10px;color:#6B7280;line-height:1.5;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">외국인 6거래일 연속 순매수</p>
+        <p style="font-size:10px;color:#6B7280;line-height:1.5;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">파운드리 2나노 시범 생산 개시</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- 2×1 ✅ -->
+  <div class="card adopted cell-2x1">
+    <div class="size-tag">2×1</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;gap:5px;overflow:hidden;">
+      <div style="display:flex;align-items:center;justify-content:space-between;flex-shrink:0;">
+        <span class="lbl">종목별 뉴스</span>
+        <span style="font-size:9px;font-weight:600;color:#0046FF;background:#EEF2FF;padding:1px 5px;border-radius:3px;">삼성전자 005930</span>
+      </div>
+      <div style="display:flex;flex-direction:column;gap:5px;flex:1;overflow:hidden;">
+        <div style="padding:6px 8px;border-radius:8px;background:#F9FAFB;border-left:3px solid #0046FF;flex-shrink:0;">
+          <p style="font-size:10px;color:#374151;font-weight:600;line-height:1.4;">HBM 공급 본격화 — 엔비디아향 납품 재개</p>
+          <p style="font-size:9px;color:#9CA3AF;margin-top:2px;">3분기 HBM3E 공급 계약 체결 확인</p>
+        </div>
+        <div style="padding:6px 8px;border-radius:8px;background:#F9FAFB;border-left:3px solid #E5E7EB;flex-shrink:0;">
+          <p style="font-size:10px;color:#374151;font-weight:600;line-height:1.4;">외국인 6거래일 연속 순매수</p>
+          <p style="font-size:9px;color:#9CA3AF;margin-top:2px;">누적 순매수 1.2조원 — 수급 개선</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 3×1 미채택 -->
+  <div class="card not-adopted cell-3x1">
+    <div class="size-tag">3×1</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;gap:8px;opacity:0.4;">
+      <div style="flex:1;padding:6px 8px;border-radius:8px;background:#F9FAFB;border-left:3px solid #0046FF;"><p style="font-size:9px;color:#374151;font-weight:600;">HBM 공급 본격화</p><p style="font-size:8px;color:#9CA3AF;margin-top:2px;">엔비디아향 납품 재개</p></div>
+      <div style="flex:1;padding:6px 8px;border-radius:8px;background:#F9FAFB;border-left:3px solid #E5E7EB;"><p style="font-size:9px;color:#374151;font-weight:600;">외국인 6일 연속 순매수</p><p style="font-size:8px;color:#9CA3AF;margin-top:2px;">누적 1.2조원</p></div>
+      <div style="flex:1;padding:6px 8px;border-radius:8px;background:#F9FAFB;border-left:3px solid #E5E7EB;"><p style="font-size:9px;color:#374151;font-weight:600;">파운드리 2나노 시범 생산</p><p style="font-size:8px;color:#9CA3AF;margin-top:2px;">하반기 양산 목표</p></div>
+    </div>
+    <div class="reject-reason">뉴스 3개를 수평 나열하면 읽기 불편 — 2×1 권장</div>
+  </div>
+
+  <!-- 1×2 미채택 -->
+  <div class="card not-adopted cell-1x2">
+    <div class="size-tag">1×2</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;gap:4px;overflow:hidden;opacity:0.4;">
+      <p style="font-size:9px;color:#374151;font-weight:600;line-height:1.4;">HBM 공급 본격화</p>
+      <p style="font-size:9px;color:#6B7280;line-height:1.4;">외국인 6거래일 연속 순매수</p>
+      <p style="font-size:9px;color:#6B7280;line-height:1.4;">파운드리 2나노 시범 생산</p>
+      <div style="flex:1;display:flex;align-items:center;justify-content:center;border:1px dashed #E5E7EB;border-radius:8px;margin-top:4px;">
+        <span style="font-size:8px;color:#9CA3AF;">추가 뉴스 없음</span>
+      </div>
+    </div>
+    <div class="reject-reason">뉴스는 세로 스크롤보다 카드형이 자연스러움</div>
+  </div>
+
+  <!-- 2×2 ✅ -->
+  <div class="card adopted cell-2x2">
+    <div class="size-tag">2×2</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;gap:5px;overflow:hidden;">
+      <div style="display:flex;align-items:center;justify-content:space-between;flex-shrink:0;">
+        <span class="lbl">종목별 뉴스</span>
+        <span style="font-size:9px;font-weight:600;color:#0046FF;background:#EEF2FF;padding:1px 5px;border-radius:3px;">삼성전자 005930</span>
+      </div>
+      <div style="display:flex;flex-direction:column;gap:6px;flex:1;overflow:hidden;">
+        <div style="padding:8px 10px;border-radius:10px;background:#F0F7FF;border-left:3px solid #0046FF;">
+          <p style="font-size:11px;color:#374151;font-weight:700;line-height:1.4;">HBM 공급 본격화 — 엔비디아향 납품 재개</p>
+          <p style="font-size:9px;color:#6B7280;margin-top:3px;line-height:1.5;">3분기 HBM3E 공급 계약 확인. AI 서버 수요 확대로 삼성전자 수혜 기대감 부각.</p>
+        </div>
+        <div style="padding:8px 10px;border-radius:10px;background:#F9FAFB;border-left:3px solid #EAECF0;">
+          <p style="font-size:11px;color:#374151;font-weight:700;line-height:1.4;">외국인 6거래일 연속 순매수</p>
+          <p style="font-size:9px;color:#6B7280;margin-top:3px;line-height:1.5;">누적 순매수 1.2조원. 반도체 업황 개선 기대에 외국인 수급 집중.</p>
+        </div>
+        <div style="padding:8px 10px;border-radius:10px;background:#F9FAFB;border-left:3px solid #EAECF0;">
+          <p style="font-size:11px;color:#374151;font-weight:700;line-height:1.4;">파운드리 2나노 시범 생산 개시</p>
+          <p style="font-size:9px;color:#6B7280;margin-top:3px;">하반기 양산 목표로 TSMC와 경쟁 본격화.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 3×2 미채택 -->
+  <div class="card not-adopted cell-3x2">
+    <div class="size-tag">3×2</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="flex:1;display:flex;align-items:center;justify-content:center;opacity:0.4;">
+      <div style="text-align:center;color:#9CA3AF;font-size:10px;">종목 뉴스 내용은 2×2로 충분</div>
+    </div>
+    <div class="reject-reason">텍스트 위주 콘텐츠는 넓은 공간 불필요</div>
+  </div>
+
+</div>
+</div>
+<div class="legend">
+  <div class="leg-item"><div class="leg-dot" style="background:#00A878;"></div><span>✅ 채택</span></div>
+  <div class="leg-item"><div class="leg-dot" style="background:#D1D5DB;"></div><span>— 미채택</span></div>
+</div>
+</body>
+</html>

--- a/front-mvp/widget-sizes/08-exchange.html
+++ b/front-mvp/widget-sizes/08-exchange.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8"/>
+<title>환율 — 사이즈 프리뷰</title>
+<link rel="stylesheet" href="_common.css"/>
+</head>
+<body>
+<div class="topbar">
+  <a href="07b-stock-news.html" class="nav-btn">← 이전</a>
+  <div style="flex:1;text-align:center;">
+    <span style="font-size:14px;font-weight:700;">환율</span>
+    <span style="font-size:11px;color:#9CA3AF;margin-left:8px;">USD · JPY · EUR 실시간 환율</span>
+  </div>
+  <span style="font-size:11px;color:#9CA3AF;font-weight:600;">8 / 10</span>
+  <a href="09-trade-history.html" class="nav-btn">다음 →</a>
+</div>
+
+<div class="grid-area">
+<div class="preview-grid">
+
+  <!-- 1×1 ✅ -->
+  <div class="card adopted cell-1x1">
+    <div class="size-tag">1×1</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;">
+      <span class="lbl" style="flex-shrink:0;">환율</span>
+      <div style="flex:1;display:flex;flex-direction:column;justify-content:center;">
+        <div style="font-size:9px;color:#9CA3AF;">USD / KRW</div>
+        <div style="font-size:18px;font-weight:800;line-height:1.1;">1,378.50</div>
+        <div style="font-size:9px;font-weight:600;margin-top:2px;" class="down">▼ −2.30 (−0.17%)</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 2×1 ✅ -->
+  <div class="card adopted cell-2x1">
+    <div class="size-tag">2×1</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;gap:0;">
+      <div style="flex:1.2;display:flex;flex-direction:column;justify-content:space-between;padding-right:12px;border-right:1px solid #F3F4F6;">
+        <div style="font-size:9px;color:#9CA3AF;">USD / KRW</div>
+        <div style="font-size:20px;font-weight:800;line-height:1.1;">1,378.50</div>
+        <div style="font-size:9px;" class="down">▼ −2.30 (−0.17%)</div>
+        <div style="height:18px;width:100%;flex-shrink:0;">
+          <svg viewBox="0 0 100 30" preserveAspectRatio="none" style="width:100%;height:100%;display:block;">
+            <path d="M0,3 L25,10 L50,17 L75,22 L100,27 L100,30 L0,30 Z" fill="rgba(0,117,232,0.1)"/>
+            <polyline points="0,3 25,10 50,17 75,22 100,27" fill="none" stroke="#0075E8" stroke-width="1.5" vector-effect="non-scaling-stroke"/>
+          </svg>
+        </div>
+      </div>
+      <div style="flex:1;padding-left:12px;display:flex;flex-direction:column;justify-content:space-between;">
+        <div style="font-size:9px;color:#9CA3AF;">JPY / KRW</div>
+        <div style="font-size:16px;font-weight:800;line-height:1.1;">9.18</div>
+        <div style="font-size:9px;" class="up">▲ +0.05 (+0.54%)</div>
+        <div style="height:18px;width:100%;flex-shrink:0;">
+          <svg viewBox="0 0 100 30" preserveAspectRatio="none" style="width:100%;height:100%;display:block;">
+            <path d="M0,27 L33,20 L66,12 L100,3 L100,30 L0,30 Z" fill="rgba(232,57,62,0.1)"/>
+            <polyline points="0,27 33,20 66,12 100,3" fill="none" stroke="#E8393E" stroke-width="1.5" vector-effect="non-scaling-stroke"/>
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 3×1 ✅ -->
+  <div class="card adopted cell-3x1">
+    <div class="size-tag">3×1</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;gap:0;">
+      <div style="flex:1.2;display:flex;flex-direction:column;justify-content:space-between;padding-right:12px;border-right:1px solid #F3F4F6;">
+        <div style="font-size:9px;color:#9CA3AF;">USD / KRW</div>
+        <div style="font-size:20px;font-weight:800;line-height:1.1;">1,378.50</div>
+        <div style="font-size:9px;" class="down">▼ −2.30 (−0.17%)</div>
+        <div style="height:18px;width:100%;flex-shrink:0;">
+          <svg viewBox="0 0 100 30" preserveAspectRatio="none" style="width:100%;height:100%;display:block;">
+            <path d="M0,3 L25,10 L50,17 L75,22 L100,27 L100,30 L0,30 Z" fill="rgba(0,117,232,0.1)"/>
+            <polyline points="0,3 25,10 50,17 75,22 100,27" fill="none" stroke="#0075E8" stroke-width="1.5" vector-effect="non-scaling-stroke"/>
+          </svg>
+        </div>
+      </div>
+      <div style="flex:1;padding:0 10px;border-right:1px solid #F3F4F6;display:flex;flex-direction:column;justify-content:space-between;">
+        <div style="font-size:9px;color:#9CA3AF;">JPY / KRW</div>
+        <div style="font-size:16px;font-weight:800;line-height:1.1;">9.18</div>
+        <div style="font-size:9px;" class="up">▲ +0.05 (+0.54%)</div>
+        <div style="height:18px;width:100%;flex-shrink:0;">
+          <svg viewBox="0 0 100 30" preserveAspectRatio="none" style="width:100%;height:100%;display:block;">
+            <path d="M0,27 L33,20 L66,12 L100,3 L100,30 L0,30 Z" fill="rgba(232,57,62,0.1)"/>
+            <polyline points="0,27 33,20 66,12 100,3" fill="none" stroke="#E8393E" stroke-width="1.5" vector-effect="non-scaling-stroke"/>
+          </svg>
+        </div>
+      </div>
+      <div style="flex:1;padding-left:10px;display:flex;flex-direction:column;justify-content:space-between;">
+        <div style="font-size:9px;color:#9CA3AF;">EUR / KRW</div>
+        <div style="font-size:16px;font-weight:800;line-height:1.1;">1,502.30</div>
+        <div style="font-size:9px;" class="down">▼ −3.20 (−0.21%)</div>
+        <div style="height:18px;width:100%;flex-shrink:0;">
+          <svg viewBox="0 0 100 30" preserveAspectRatio="none" style="width:100%;height:100%;display:block;">
+            <path d="M0,3 L33,12 L66,20 L100,27 L100,30 L0,30 Z" fill="rgba(0,117,232,0.1)"/>
+            <polyline points="0,3 33,12 66,20 100,27" fill="none" stroke="#0075E8" stroke-width="1.5" vector-effect="non-scaling-stroke"/>
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 1×2 미채택 -->
+  <div class="card not-adopted cell-1x2">
+    <div class="size-tag">1×2</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;gap:8px;opacity:0.4;">
+      <div><div style="font-size:9px;color:#9CA3AF;">USD / KRW</div><div style="font-size:16px;font-weight:800;">1,378.50</div><div style="font-size:9px;" class="down">▼ −0.17%</div></div>
+      <div><div style="font-size:9px;color:#9CA3AF;">JPY / KRW</div><div style="font-size:16px;font-weight:800;">9.18</div><div style="font-size:9px;" class="up">▲ +0.54%</div></div>
+    </div>
+    <div class="reject-reason">환율은 수평 나열이 자연스러움 — 3×1 권장</div>
+  </div>
+
+  <!-- 2×2 미채택 -->
+  <div class="card not-adopted cell-2x2">
+    <div class="size-tag">2×2</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="flex:1;display:flex;align-items:center;justify-content:center;opacity:0.4;">
+      <div style="text-align:center;color:#9CA3AF;font-size:10px;">3×1로 더 효율적인 표시 가능</div>
+    </div>
+    <div class="reject-reason">3×1로 동일한 정보 더 효율적으로 표시 가능</div>
+  </div>
+
+  <!-- 3×2 미채택 -->
+  <div class="card not-adopted cell-3x2">
+    <div class="size-tag">3×2</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="flex:1;display:flex;align-items:center;justify-content:center;opacity:0.4;">
+      <div style="text-align:center;color:#9CA3AF;font-size:10px;">환율 정보는 숫자 위주 — 대형 공간 불필요</div>
+    </div>
+    <div class="reject-reason">환율 특성상 대형 사이즈에 채울 콘텐츠 없음</div>
+  </div>
+
+</div>
+</div>
+<div class="legend">
+  <div class="leg-item"><div class="leg-dot" style="background:#00A878;"></div><span>✅ 채택</span></div>
+  <div class="leg-item"><div class="leg-dot" style="background:#D1D5DB;"></div><span>— 미채택</span></div>
+</div>
+</body>
+</html>

--- a/front-mvp/widget-sizes/09-trade-history.html
+++ b/front-mvp/widget-sizes/09-trade-history.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8"/>
+<title>거래내역 — 사이즈 프리뷰</title>
+<link rel="stylesheet" href="_common.css"/>
+</head>
+<body>
+<div class="topbar">
+  <a href="08-exchange.html" class="nav-btn">← 이전</a>
+  <div style="flex:1;text-align:center;">
+    <span style="font-size:14px;font-weight:700;">거래내역</span>
+    <span style="font-size:11px;color:#9CA3AF;margin-left:8px;">달력 · 목록 뷰</span>
+  </div>
+  <span style="font-size:11px;color:#9CA3AF;font-weight:600;">9 / 10</span>
+  <a href="10-report.html" class="nav-btn">다음 →</a>
+</div>
+
+<div class="grid-area">
+<div class="preview-grid">
+
+  <!-- 1×1 ✅ -->
+  <div class="card adopted cell-1x1">
+    <div class="size-tag">1×1</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;gap:4px;overflow:hidden;">
+      <span class="lbl">거래내역</span>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:3px;"><span class="tag up-bg">매수</span><span style="font-size:10px;">삼성전자</span></div><span style="font-size:9px;color:#9CA3AF;">10주</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:3px;"><span class="tag down-bg">매도</span><span style="font-size:10px;">SK하이닉스</span></div><span style="font-size:9px;color:#9CA3AF;">5주</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><div style="display:flex;align-items:center;gap:3px;"><span class="tag up-bg">매수</span><span style="font-size:10px;">LG에너지</span></div><span style="font-size:9px;color:#9CA3AF;">3주</span></div>
+    </div>
+  </div>
+
+  <!-- 2×1 ✅ -->
+  <div class="card adopted cell-2x1">
+    <div class="size-tag">2×1</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;gap:4px;overflow:hidden;">
+      <div style="display:flex;align-items:center;justify-content:space-between;font-size:8px;color:#9CA3AF;padding-bottom:3px;border-bottom:1px solid #F3F4F6;"><span>구분</span><span>종목</span><span>수량</span><span>체결가</span><span>체결금액</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;font-size:10px;"><span class="tag up-bg" style="flex-shrink:0;">매수</span><span style="flex:2;text-align:center;">삼성전자</span><span style="flex:1;text-align:center;">10주</span><span style="flex:1;text-align:right;">75,400</span><span style="flex:1;text-align:right;">754,000</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;font-size:10px;"><span class="tag down-bg" style="flex-shrink:0;">매도</span><span style="flex:2;text-align:center;">SK하이닉스</span><span style="flex:1;text-align:center;">5주</span><span style="flex:1;text-align:right;">182,000</span><span style="flex:1;text-align:right;">910,000</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;font-size:10px;"><span class="tag up-bg" style="flex-shrink:0;">매수</span><span style="flex:2;text-align:center;">LG에너지솔루션</span><span style="flex:1;text-align:center;">3주</span><span style="flex:1;text-align:right;">398,000</span><span style="flex:1;text-align:right;">1,194,000</span></div>
+    </div>
+  </div>
+
+  <!-- 3×1 미채택 -->
+  <div class="card not-adopted cell-3x1">
+    <div class="size-tag">3×1</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;gap:4px;overflow:hidden;opacity:0.4;">
+      <div style="display:flex;align-items:center;justify-content:space-between;font-size:8px;color:#9CA3AF;padding-bottom:3px;border-bottom:1px solid #F3F4F6;"><span>구분</span><span>종목</span><span>수량</span><span>체결가</span><span>체결금액</span><span>수익률</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;font-size:10px;"><span class="tag up-bg" style="flex-shrink:0;">매수</span><span style="flex:2;text-align:center;">삼성전자</span><span style="flex:1;text-align:center;">10주</span><span style="flex:1;text-align:right;">75,400</span><span style="flex:1;text-align:right;">754,000</span><span style="flex:1;text-align:right;" class="up">+1.62%</span></div>
+    </div>
+    <div class="reject-reason">행 높이가 낮아 날짜·상세 정보 표시 어려움 — 2×1 권장</div>
+  </div>
+
+  <!-- 1×2 미채택 -->
+  <div class="card not-adopted cell-1x2">
+    <div class="size-tag">1×2</div>
+    <div class="reject-tag">— 미채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;gap:4px;overflow:hidden;opacity:0.4;">
+      <div style="display:flex;align-items:center;justify-content:space-between;"><span class="tag up-bg">매수</span><span style="font-size:9px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:60px;">삼성전자</span><span style="font-size:8px;color:#9CA3AF;">10주</span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;"><span class="tag down-bg">매도</span><span style="font-size:9px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:60px;">SK하이닉스</span><span style="font-size:8px;color:#9CA3AF;">5주</span></div>
+    </div>
+    <div class="reject-reason">너비가 좁아 종목명·금액 동시 표시 어려움</div>
+  </div>
+
+  <!-- 2×2 ✅ (캘린더형) -->
+  <div class="card adopted cell-2x2">
+    <div class="size-tag">2×2</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;flex-direction:column;gap:4px;">
+      <div style="display:flex;align-items:center;justify-content:space-between;flex-shrink:0;margin-bottom:2px;">
+        <span class="lbl">거래내역</span>
+        <span style="font-size:9px;color:#9CA3AF;">2026년 3월</span>
+      </div>
+      <div style="display:grid;grid-template-columns:repeat(7,1fr);gap:2px;font-size:8px;color:#9CA3AF;text-align:center;margin-bottom:2px;">
+        <span>일</span><span>월</span><span>화</span><span>수</span><span>목</span><span>금</span><span>토</span>
+      </div>
+      <div style="display:grid;grid-template-columns:repeat(7,1fr);gap:2px;flex:1;min-height:0;">
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;visibility:hidden;">0</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;visibility:hidden;">0</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;visibility:hidden;">0</span></div>
+
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">1</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">2</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;">
+          <span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">3</span>
+          <div style="display:flex;align-items:center;gap:1px;width:100%;"><div style="width:2px;border-radius:999px;align-self:stretch;background:#0075E8;"></div><span style="font-size:7px;line-height:1.2;color:#111827;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;">삼성</span></div>
+          <div style="display:flex;align-items:center;gap:1px;width:100%;"><div style="width:2px;border-radius:999px;align-self:stretch;background:#E8393E;"></div><span style="font-size:7px;line-height:1.2;color:#111827;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;">SK하이</span></div>
+        </div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">4</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">5</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">6</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;">
+          <span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">7</span>
+            <div style="display:flex;align-items:center;gap:1px;width:100%;"><div style="width:2px;border-radius:999px;align-self:stretch;background:#0075E8;"></div><span style="font-size:7px;line-height:1.2;color:#111827;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;">현대차</span></div>
+        </div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">8</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">9</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">10</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">11</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;">
+          <span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">12</span>
+          <div style="display:flex;align-items:center;gap:1px;width:100%;"><div style="width:2px;border-radius:999px;align-self:stretch;background:#0075E8;"></div><span style="font-size:7px;line-height:1.2;color:#111827;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;">LG에너</span></div>
+          <div style="display:flex;align-items:center;gap:1px;width:100%;"><div style="width:2px;border-radius:999px;align-self:stretch;background:#E8393E;"></div><span style="font-size:7px;line-height:1.2;color:#111827;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;">NAVER</span></div>
+        </div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">13</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">14</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">15</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">16</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">17</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;">
+          <span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">18</span>
+          <div style="display:flex;align-items:center;gap:1px;width:100%;"><div style="width:2px;border-radius:999px;align-self:stretch;background:#0075E8;"></div><span style="font-size:7px;line-height:1.2;color:#111827;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;">삼성</span></div>
+          <div style="display:flex;align-items:center;gap:1px;width:100%;"><div style="width:2px;border-radius:999px;align-self:stretch;background:#E8393E;"></div><span style="font-size:7px;line-height:1.2;color:#111827;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;">SK</span></div>
+        </div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">19</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">20</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">21</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">22</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">23</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">24</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;">
+          <span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">25</span>
+          <div style="display:flex;align-items:center;gap:1px;width:100%;"><div style="width:2px;border-radius:999px;align-self:stretch;background:#E8393E;"></div><span style="font-size:7px;line-height:1.2;color:#111827;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;">포스코</span></div>
+        </div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">26</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">27</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">28</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">29</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">30</span></div>
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">31</span></div>
+
+        <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;visibility:hidden;">0</span></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 3×2 ✅ (캘린더 + 목록) -->
+  <div class="card adopted cell-3x2">
+    <div class="size-tag">3×2</div>
+    <div class="adopted-tag">✅ 채택</div>
+    <div style="margin-top:22px;flex:1;display:flex;gap:12px;">
+      <!-- 캘린더 -->
+      <div style="flex:1;display:flex;flex-direction:column;gap:4px;">
+        <div style="display:flex;align-items:center;justify-content:space-between;flex-shrink:0;">
+          <span class="lbl">거래내역</span>
+          <span style="font-size:9px;color:#9CA3AF;">2026년 3월</span>
+        </div>
+        <div style="display:grid;grid-template-columns:repeat(7,1fr);gap:2px;font-size:8px;color:#9CA3AF;text-align:center;margin-bottom:2px;">
+          <span>일</span><span>월</span><span>화</span><span>수</span><span>목</span><span>금</span><span>토</span>
+        </div>
+        <div style="display:grid;grid-template-columns:repeat(7,1fr);gap:2px;flex:1;min-height:0;">
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;visibility:hidden;">0</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;visibility:hidden;">0</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;visibility:hidden;">0</span></div>
+
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">1</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">2</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;">
+            <span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">3</span>
+            <div style="display:flex;align-items:center;gap:1px;width:100%;"><div style="width:2px;border-radius:999px;align-self:stretch;background:#0075E8;"></div><span style="font-size:7px;line-height:1.2;color:#111827;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;">삼성</span></div>
+            <div style="display:flex;align-items:center;gap:1px;width:100%;"><div style="width:2px;border-radius:999px;align-self:stretch;background:#E8393E;"></div><span style="font-size:7px;line-height:1.2;color:#111827;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;">SK하이</span></div>
+          </div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">4</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">5</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">6</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;">
+            <span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">7</span>
+            <div style="display:flex;align-items:center;gap:1px;width:100%;"><div style="width:2px;border-radius:999px;align-self:stretch;background:#0075E8;"></div><span style="font-size:7px;line-height:1.2;color:#111827;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;">현대차</span></div>
+          </div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">8</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">9</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">10</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">11</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;">
+            <span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">12</span>
+            <div style="display:flex;align-items:center;gap:1px;width:100%;"><div style="width:2px;border-radius:999px;align-self:stretch;background:#0075E8;"></div><span style="font-size:7px;line-height:1.2;color:#111827;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;">LG에너</span></div>
+            <div style="display:flex;align-items:center;gap:1px;width:100%;"><div style="width:2px;border-radius:999px;align-self:stretch;background:#E8393E;"></div><span style="font-size:7px;line-height:1.2;color:#111827;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;">NAVER</span></div>
+          </div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">13</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">14</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">15</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">16</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">17</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;">
+            <span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">18</span>
+            <div style="display:flex;align-items:center;gap:1px;width:100%;"><div style="width:2px;border-radius:999px;align-self:stretch;background:#0075E8;"></div><span style="font-size:7px;line-height:1.2;color:#111827;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;">삼성</span></div>
+            <div style="display:flex;align-items:center;gap:1px;width:100%;"><div style="width:2px;border-radius:999px;align-self:stretch;background:#E8393E;"></div><span style="font-size:7px;line-height:1.2;color:#111827;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;">SK</span></div>
+          </div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">19</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">20</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">21</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">22</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">23</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">24</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;">
+            <span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">25</span>
+            <div style="display:flex;align-items:center;gap:1px;width:100%;"><div style="width:2px;border-radius:999px;align-self:stretch;background:#E8393E;"></div><span style="font-size:7px;line-height:1.2;color:#111827;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;">포스코</span></div>
+          </div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">26</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">27</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">28</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">29</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">30</span></div>
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;color:#111827;margin-bottom:1px;">31</span></div>
+
+          <div style="display:flex;flex-direction:column;align-items:flex-start;padding:2px;border-radius:4px;"><span style="font-size:9px;line-height:1;visibility:hidden;">0</span></div>
+        </div>
+      </div>
+      <!-- 목록 -->
+      <div style="border-left:1px solid #F3F4F6;padding-left:12px;flex:1;display:flex;flex-direction:column;gap:5px;overflow:hidden;">
+        <div style="font-size:9px;color:#9CA3AF;font-weight:600;margin-bottom:2px;">거래 내역</div>
+        <div style="display:flex;align-items:center;justify-content:space-between;font-size:10px;"><div style="display:flex;align-items:center;gap:4px;"><span class="tag up-bg">매수</span><span>삼성전자</span></div><div style="text-align:right;"><div>75,400원</div><div style="font-size:8px;color:#9CA3AF;">10주 · 03.19</div></div></div>
+        <div style="display:flex;align-items:center;justify-content:space-between;font-size:10px;"><div style="display:flex;align-items:center;gap:4px;"><span class="tag down-bg">매도</span><span>SK하이닉스</span></div><div style="text-align:right;"><div>182,000원</div><div style="font-size:8px;color:#9CA3AF;">5주 · 03.18</div></div></div>
+        <div style="display:flex;align-items:center;justify-content:space-between;font-size:10px;"><div style="display:flex;align-items:center;gap:4px;"><span class="tag up-bg">매수</span><span>LG에너지</span></div><div style="text-align:right;"><div>398,000원</div><div style="font-size:8px;color:#9CA3AF;">3주 · 03.14</div></div></div>
+        <div style="display:flex;align-items:center;justify-content:space-between;font-size:10px;"><div style="display:flex;align-items:center;gap:4px;"><span class="tag down-bg">매도</span><span>POSCO홀딩스</span></div><div style="text-align:right;"><div>543,000원</div><div style="font-size:8px;color:#9CA3AF;">7주 · 03.12</div></div></div>
+        <div style="display:flex;align-items:center;justify-content:space-between;font-size:10px;"><div style="display:flex;align-items:center;gap:4px;"><span class="tag up-bg">매수</span><span>현대차</span></div><div style="text-align:right;"><div>241,500원</div><div style="font-size:8px;color:#9CA3AF;">4주 · 03.07</div></div></div>
+      </div>
+    </div>
+  </div>
+
+</div>
+</div>
+<div class="legend">
+  <div class="leg-item"><div class="leg-dot" style="background:#00A878;"></div><span>✅ 채택</span></div>
+  <div class="leg-item"><div class="leg-dot" style="background:#D1D5DB;"></div><span>— 미채택</span></div>
+</div>
+</body>
+</html>

--- a/front-mvp/widget-sizes/_common.css
+++ b/front-mvp/widget-sizes/_common.css
@@ -1,0 +1,43 @@
+/* 공통 스타일 — widget-sizes 프리뷰 페이지 */
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: 'Pretendard', -apple-system, sans-serif; background: #F4F6FA; height: 100vh; overflow: hidden; display: flex; flex-direction: column; color: #191F28; }
+
+.topbar { height: 52px; background: #fff; border-bottom: 1px solid #EAECF0; display: flex; align-items: center; padding: 0 16px; gap: 12px; flex-shrink: 0; }
+.nav-btn { padding: 4px 12px; border-radius: 8px; border: 1px solid #E5E7EB; background: #fff; font-size: 11px; font-weight: 500; color: #374151; cursor: pointer; text-decoration: none; display: inline-flex; align-items: center; gap: 4px; }
+.nav-btn:hover { border-color: #0046FF; color: #0046FF; }
+
+.grid-area { flex: 1; min-height: 0; padding: 10px; }
+.preview-grid { display: grid; grid-template-columns: repeat(6, 1fr); grid-template-rows: 1fr 2fr; gap: 8px; height: 100%; }
+
+/* grid 배치 */
+.cell-1x1 { grid-column: 1; grid-row: 1; }
+.cell-2x1 { grid-column: 2 / 4; grid-row: 1; }
+.cell-3x1 { grid-column: 4 / 7; grid-row: 1; }
+.cell-1x2 { grid-column: 1; grid-row: 2; }
+.cell-2x2 { grid-column: 2 / 4; grid-row: 2; }
+.cell-3x2 { grid-column: 4 / 7; grid-row: 2; }
+
+.card { background: #fff; border: 1px solid #EAECF0; border-radius: 14px; padding: 12px 14px; display: flex; flex-direction: column; overflow: hidden; position: relative; }
+.card.adopted { border: 2px solid #00A878; }
+.card.maybe { border: 2px solid #F59E0B; }
+.card.not-adopted { border: 1px dashed #D1D5DB; background: #F9FAFB; }
+
+.size-tag { position: absolute; top: 8px; left: 8px; font-size: 9px; font-weight: 700; padding: 2px 6px; border-radius: 4px; background: #F3F4F6; color: #6B7280; }
+.adopted-tag { position: absolute; top: 8px; right: 8px; font-size: 9px; font-weight: 700; padding: 2px 6px; border-radius: 4px; background: #ECFDF5; color: #00A878; }
+.maybe-tag { position: absolute; top: 8px; right: 8px; font-size: 9px; font-weight: 700; padding: 2px 6px; border-radius: 4px; background: #FFFBEB; color: #F59E0B; }
+.reject-tag { position: absolute; top: 8px; right: 8px; font-size: 9px; font-weight: 600; padding: 2px 6px; border-radius: 4px; background: #F3F4F6; color: #9CA3AF; }
+.reject-reason { position: absolute; bottom: 8px; left: 0; right: 0; text-align: center; font-size: 9px; color: #9CA3AF; padding: 0 8px; }
+
+.up { color: #E8393E; }
+.down { color: #0075E8; }
+.up-bg { background: #FFF0F1; color: #E8393E; }
+.down-bg { background: #EFF6FF; color: #0075E8; }
+.lbl { font-size: 9px; font-weight: 600; color: #9CA3AF; letter-spacing: .05em; text-transform: uppercase; }
+.bar { border-radius: 2px; align-self: flex-end; }
+.pie { border-radius: 50%; background: conic-gradient(#0046FF 0% 34%, #00A878 34% 54%, #FF9500 54% 69%, #EF4444 69% 81%, #8B5CF6 81% 100%); flex-shrink: 0; }
+.tag { font-size: 8px; font-weight: 600; padding: 1px 5px; border-radius: 3px; }
+
+.legend { height: 38px; display: flex; align-items: center; justify-content: center; gap: 20px; font-size: 10px; border-top: 1px solid #EAECF0; background: #fff; flex-shrink: 0; }
+.leg-item { display: flex; align-items: center; gap: 5px; }
+.leg-dot { width: 8px; height: 8px; border-radius: 50%; }


### PR DESCRIPTION
## 작업 내용

- 대시보드 위젯 10종의 채택 사이즈를 HTML 프로토타입으로 확정
- 각 사이즈별 채택/미채택 사유 기록 (`reject-reason`)
- 이후 `feat/dashboard-widget-variants` 구현 작업의 레퍼런스로 활용

Closes #35

## 확정된 채택 사이즈

| 위젯 | 채택 사이즈 |
|------|------------|
| 계좌 잔고 | 1×1, 2×1, 3×1 |
| 주요 지수 | 1×1, 2×1, 3×1 |
| 포트폴리오 | 1×1, 2×1, 2×2 |
| 주가/차트 | 1×1, 2×1, 2×2, 3×2 |
| 실시간 순위 | 2×1, 2×2 |
| 관심종목 | 1×1, 2×1 |
| 오늘의 시황 | 1×1, 2×1, 2×2 |
| 종목별 뉴스 (신규) | 1×1, 2×1, 2×2 |
| 환율 | 1×1, 2×1, 3×1 |
| 거래내역 | 1×1, 2×1, 2×2 |

**결정 사항**
- 증권사 리포트 위젯 — 구현 범위 제외 확정
- 종목별 뉴스 위젯 — 신규 추가 (오늘의 시황과 동일 구조, 선택 종목 기준)

## 확인 방법

- `front-mvp/widget-sizes/` 내 HTML 파일을 브라우저에서 열어 각 사이즈 확인
- 채택 사이즈가 위 표와 일치하는지 확인