### PR TITLE
fix(auth): 새로고침 후 로그인 상태 유지 및 플래시 제거

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,10 +7,13 @@ import LoginModal from '@/components/auth/LoginModal'
 export default function App() {
   const showLoginModal = useAuthStore((s) => s.showLoginModal)
   const closeLoginModal = useAuthStore((s) => s.closeLoginModal)
+  const isRestoring = useAuthStore((s) => s.isRestoring)
 
   useEffect(() => {
     useAuthStore.getState().restoreAuth()
   }, [])
+
+  if (isRestoring) return null
 
   return (
     <>

--- a/src/components/layout/ChatPanel.jsx
+++ b/src/components/layout/ChatPanel.jsx
@@ -72,14 +72,20 @@ function ChatMessages() {
 }
 
 export default function ChatPanel() {
-  const { isAuthenticated } = useAuthStore()
+  const { isAuthenticated, isRestoring } = useAuthStore()
   const { isEditMode } = useEditModeStore()
 
   if (isEditMode) return <EditPanel />
 
   return (
     <aside className="w-chat-panel flex flex-col bg-surface border-l border-stroke shrink-0">
-      {isAuthenticated ? (
+      {isRestoring ? (
+        <>
+          <ChatHeader />
+          <ChatMessages />
+          <ChatInput />
+        </>
+      ) : isAuthenticated ? (
         <>
           <ChatHeader />
           <ChatMessages />

--- a/src/components/widgets/BalanceWidget.jsx
+++ b/src/components/widgets/BalanceWidget.jsx
@@ -5,7 +5,7 @@ import WidgetCard from './WidgetCard'
 import { BALANCE } from '@/mocks/home'
 
 export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, rowSpan = 1, onDelete }) {
-  const { isAuthenticated } = useAuthStore()
+  const { isAuthenticated, isRestoring } = useAuthStore()
 
   return (
     <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
@@ -97,7 +97,7 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
         </div>
       )}
 
-      {!isAuthenticated && <LockedOverlay message="계좌 정보를 보려면" />}
+      {!isRestoring && !isAuthenticated && <LockedOverlay message="계좌 정보를 보려면" />}
     </WidgetCard>
   )
 }

--- a/src/components/widgets/ExchangeWidget.jsx
+++ b/src/components/widgets/ExchangeWidget.jsx
@@ -28,7 +28,7 @@ function ExchangeRow({ flag, pair, rate, change }) {
 }
 
 export default function ExchangeWidget({ variant = 'exchange-sm', colSpan = 1, rowSpan = 1, onDelete }) {
-  const { isAuthenticated } = useAuthStore()
+  const { isAuthenticated, isRestoring } = useAuthStore()
   const usd = EXCHANGE[0]
 
   if (variant === 'exchange-wide') {
@@ -55,7 +55,7 @@ export default function ExchangeWidget({ variant = 'exchange-sm', colSpan = 1, r
             )
           })}
         </div>
-        {!isAuthenticated && <LockedOverlay message="환율 정보를 보려면" />}
+        {!isRestoring && !isAuthenticated && <LockedOverlay message="환율 정보를 보려면" />}
       </WidgetCard>
     )
   }
@@ -104,7 +104,7 @@ export default function ExchangeWidget({ variant = 'exchange-sm', colSpan = 1, r
         >
           환전하기 →
         </button>
-        {!isAuthenticated && <LockedOverlay message="환율 정보를 보려면" />}
+        {!isRestoring && !isAuthenticated && <LockedOverlay message="환율 정보를 보려면" />}
       </WidgetCard>
     )
   }
@@ -125,7 +125,7 @@ export default function ExchangeWidget({ variant = 'exchange-sm', colSpan = 1, r
           환전하기 →
         </button>
       </div>
-      {!isAuthenticated && <LockedOverlay message="환율 정보를 보려면" />}
+      {!isRestoring && !isAuthenticated && <LockedOverlay message="환율 정보를 보려면" />}
     </WidgetCard>
   )
 }

--- a/src/components/widgets/PortfolioWidget.jsx
+++ b/src/components/widgets/PortfolioWidget.jsx
@@ -22,7 +22,7 @@ function PieDonut({ size = 52, innerSize = 32 }) {
 }
 
 export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1, rowSpan = 1, onDelete }) {
-  const { isAuthenticated } = useAuthStore()
+  const { isAuthenticated, isRestoring } = useAuthStore()
 
   return (
     <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
@@ -93,7 +93,7 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
         </div>
       )}
 
-      {!isAuthenticated && <LockedOverlay message="포트폴리오를 보려면" />}
+      {!isRestoring && !isAuthenticated && <LockedOverlay message="포트폴리오를 보려면" />}
     </WidgetCard>
   )
 }

--- a/src/store/useAuthStore.js
+++ b/src/store/useAuthStore.js
@@ -5,11 +5,13 @@ const useAuthStore = create((set, get) => ({
   user: null,           // { userId, email, name }
   accessToken: null,
   showLoginModal: false,
+  isRestoring: true,    // 앱 초기화 중 상태 복원 여부
 
   // 로그인 성공 시 호출
   setAuth: ({ accessToken, user, autoLogin }) => {
     const storage = autoLogin ? localStorage : sessionStorage
     storage.setItem('accessToken', accessToken)
+    storage.setItem('user', JSON.stringify(user))
     set({ isAuthenticated: true, user, accessToken })
   },
 
@@ -18,13 +20,19 @@ const useAuthStore = create((set, get) => ({
     const accessToken =
       localStorage.getItem('accessToken') ?? sessionStorage.getItem('accessToken')
     if (accessToken) {
-      set({ isAuthenticated: true, accessToken })
+      const userStr = localStorage.getItem('user') ?? sessionStorage.getItem('user')
+      const user = userStr ? JSON.parse(userStr) : null
+      set({ isAuthenticated: true, user, accessToken, isRestoring: false })
+    } else {
+      set({ isRestoring: false })
     }
   },
 
   logout: () => {
     localStorage.removeItem('accessToken')
+    localStorage.removeItem('user')
     sessionStorage.removeItem('accessToken')
+    sessionStorage.removeItem('user')
     set({ isAuthenticated: false, user: null, accessToken: null })
   },
 


### PR DESCRIPTION
## 연관된 이슈

-

## 작업 내용

로그인 상태 관리 문제를 완벽히 해결했습니다.

### 변경사항
- useAuthStore: user 정보 저장/복원 추가
  - 로그인 시 accessToken + user를 함께 저장 (localStorage/sessionStorage)
  - 앱 초기화 시 두 정보 모두 복원
  - logout 시 두 정보 모두 제거

- App.jsx: isRestoring 플래그로 전체 UI 제어
  - 상태 복원 완료 전까지 전체 UI 렌더링 차단
  - 모든 화면의 플래시 문제 일괄 해결

### 해결된 문제
- 새로고침 후 로그인 상태 유지 (이전: 상태만 유지, user는 null)
- 위젯 깜빡임 제거 (BalanceWidget, ExchangeWidget, PortfolioWidget)
- 채팅창 깜빡임 제거 (ChatPanel)
- 모든 로그인 필요 화면에서 순간적인 "로그인 필요" 메시지 제거

## 체크리스트

- [x] 코드가 정상적으로 빌드되는지 확인했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항

- App.jsx에서 isRestoring 중 return null로 처리하는 방식이 적절한지 확인 부탁드립니다.
- 혹시 더 나은 UI/UX 방식이 있으면 제안해주세요 (스켈레톤 로더 등)