### PR TITLE
feat(home): 대시보드 그리드 6×4 전환 및 위젯 배치 동기화

### DIFF
--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -5,12 +5,13 @@ import useWidgetStore, { canFitInGrid } from '@/store/useWidgetStore'
 import { GRID_GAP, MIN_CELL_WIDTH, MIN_CELL_HEIGHT } from '@/lib/gridConstants'
 
 /* ── 너비 클래스 ─────────────────────────────────────────────
-   EditPanel 가로폭을 3등분하여 colSpan 비율을 정확히 반영.
-   colSpan=1 → w-1/3,  colSpan=2 → w-2/3,  colSpan=3 → w-full
+   EditPanel 가로폭을 6등분하여 colSpan 비율을 정확히 반영.
+   colSpan=1 → w-1/6,  colSpan=2 → w-1/3,  colSpan=3 → w-1/2,  colSpan≥4 → w-full
 ─────────────────────────────────────────────────────────── */
 function widthClass(colSpan) {
-  if (colSpan === 1) return 'w-1/3'
-  if (colSpan === 2) return 'w-2/3'
+  if (colSpan === 1) return 'w-1/6'
+  if (colSpan === 2) return 'w-1/3'
+  if (colSpan === 3) return 'w-1/2'
   return 'w-full'
 }
 
@@ -978,6 +979,65 @@ function PreviewContent({ type }) {
             ))}
           </div>
           </div>
+        </div>
+      )
+    }
+
+    /* 증권사 리포트 — 단일 1×1 */
+    case 'report-sm': {
+      const r = { title: '삼성전자 목표가 9만원으로 상향', firm: '키움증권', desc: '반도체 업황 회복 기대감' }
+      return (
+        <div className="flex flex-col h-full justify-between">
+          <div>
+            <p className="text-[10px] font-bold text-foreground leading-snug">{r.title}</p>
+            <p className="text-[8px] text-foreground-disabled mt-1">{r.desc}</p>
+          </div>
+          <div className="flex items-center gap-1">
+            <span className="text-[9px] text-primary font-semibold">{r.firm}</span>
+          </div>
+        </div>
+      )
+    }
+
+    /* 증권사 리포트 — 목록형 2×1 */
+    case 'report-wide': {
+      const reports = [
+        { title: '삼성전자 목표가 상향', firm: '키움증권' },
+        { title: 'SK하이닉스 HBM 수요 긍정적', firm: '삼성증권' },
+        { title: 'LG에너지 실적 전망 하향', firm: 'NH투자' },
+      ]
+      return (
+        <div className="flex flex-col gap-1.5 h-full">
+          {reports.map(({ title, firm }) => (
+            <div key={title} className="flex items-start justify-between gap-2">
+              <p className="text-[9px] text-foreground leading-snug truncate">{title}</p>
+              <span className="text-[8px] text-primary shrink-0">{firm}</span>
+            </div>
+          ))}
+        </div>
+      )
+    }
+
+    /* 증권사 리포트 — 상세 2×2 */
+    case 'report-2x2': {
+      const reports = [
+        { title: '삼성전자 목표가 상향', firm: '키움증권', desc: '반도체 업황 회복 기대감' },
+        { title: 'SK하이닉스 HBM 수요 긍정적', firm: '삼성증권', desc: 'AI 서버 수요 지속 증가' },
+        { title: 'LG에너지 실적 전망 하향', firm: 'NH투자', desc: 'EV 시장 성장 둔화 우려' },
+      ]
+      return (
+        <div className="flex flex-col gap-2 h-full">
+          {reports.map(({ title, firm, desc }) => (
+            <div key={title} className="border-b border-stroke last:border-0 pb-2 last:pb-0">
+              <div className="flex items-start justify-between gap-1">
+                <span className="text-[10px] font-semibold text-foreground leading-snug">{title}</span>
+              </div>
+              <div className="flex items-center gap-1 mt-0.5">
+                <span className="text-[8px] text-primary">{firm}</span>
+                <span className="text-[8px] text-foreground-disabled">· {desc}</span>
+              </div>
+            </div>
+          ))}
         </div>
       )
     }

--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -5,13 +5,13 @@ import useWidgetStore, { canFitInGrid } from '@/store/useWidgetStore'
 import { GRID_GAP, MIN_CELL_WIDTH, MIN_CELL_HEIGHT } from '@/lib/gridConstants'
 
 /* ── 너비 클래스 ─────────────────────────────────────────────
-   EditPanel 가로폭을 6등분하여 colSpan 비율을 정확히 반영.
-   colSpan=1 → w-1/6,  colSpan=2 → w-1/3,  colSpan=3 → w-1/2,  colSpan≥4 → w-full
+   EditPanel 가로폭을 3등분하여 colSpan 비율을 반영.
+   6열 그리드 기준: 1열=소형(1/3), 2열=와이드(2/3), 3열=하프(full)
+   colSpan=1 → w-1/3,  colSpan=2 → w-2/3,  colSpan≥3 → w-full
 ─────────────────────────────────────────────────────────── */
 function widthClass(colSpan) {
-  if (colSpan === 1) return 'w-1/6'
-  if (colSpan === 2) return 'w-1/3'
-  if (colSpan === 3) return 'w-1/2'
+  if (colSpan === 1) return 'w-1/3'
+  if (colSpan === 2) return 'w-2/3'
   return 'w-full'
 }
 

--- a/src/components/widgets/widgetRegistry.js
+++ b/src/components/widgets/widgetRegistry.js
@@ -8,6 +8,7 @@ import MarketOverviewWidget from './MarketOverviewWidget'
 import StockNewsWidget from './StockNewsWidget'
 import ExchangeWidget from './ExchangeWidget'
 import TradeHistoryWidget from './TradeHistoryWidget'
+import ReportWidget from './ReportWidget'
 
 export const WIDGET_REGISTRY = {
   'balance':         BalanceWidget,
@@ -20,4 +21,5 @@ export const WIDGET_REGISTRY = {
   'stock-news':      StockNewsWidget,
   'exchange':        ExchangeWidget,
   'trade-history':   TradeHistoryWidget,
+  'report':          ReportWidget,
 }

--- a/src/lib/gridConstants.js
+++ b/src/lib/gridConstants.js
@@ -1,10 +1,10 @@
-export const GRID_COLS = 4
-export const GRID_ROWS = 3
+export const GRID_COLS = 6
+export const GRID_ROWS = 4
 export const GRID_GAP = 10
 
 // 위젯 내부 콘텐츠가 overflow 나지 않는 최소 셀 크기
-export const MIN_CELL_WIDTH = 160
-export const MIN_CELL_HEIGHT = 150
+export const MIN_CELL_WIDTH = 140
+export const MIN_CELL_HEIGHT = 130
 
 export const MIN_GRID_WIDTH = MIN_CELL_WIDTH * GRID_COLS + GRID_GAP * (GRID_COLS - 1)
 export const MIN_GRID_HEIGHT = MIN_CELL_HEIGHT * GRID_ROWS + GRID_GAP * (GRID_ROWS - 1)

--- a/src/mocks/widgets.js
+++ b/src/mocks/widgets.js
@@ -115,6 +115,17 @@ export const WIDGET_TYPES = [
       { id: 'trade-3x2',  label: '캘린더+목록', colSpan: 3, rowSpan: 2, preview: 'trade-3x2'  },
     ],
   },
+  {
+    id: 'report',
+    name: '증권사 리포트',
+    category: '기타',
+    description: '증권사 분석 리포트 헤드라인',
+    variants: [
+      { id: 'report-sm',   label: '단일',  colSpan: 1, rowSpan: 1, preview: 'report-sm' },
+      { id: 'report-wide', label: '목록형', colSpan: 2, rowSpan: 1, preview: 'report-wide' },
+      { id: 'report-2x2',  label: '상세',  colSpan: 2, rowSpan: 2, preview: 'report-2x2' },
+    ],
+  },
 ]
 
 export const WIDGET_CATEGORIES = ['전체', ...new Set(WIDGET_TYPES.map((w) => w.category))]

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -83,10 +83,10 @@ export default function HomePage() {
         'flex-1 min-h-0',
         isEditMode ? 'overflow-visible' : 'overflow-auto',
       )}>
-        {/* 위젯 그리드: 4열 × 3행, 뷰포트 채움 / 최솟값 이하면 고정 */}
+        {/* 위젯 그리드: 6열 × 4행, 뷰포트 채움 / 최솟값 이하면 고정 */}
         <div
           ref={gridRef}
-          className="grid grid-cols-4 grid-rows-3 gap-[10px] w-full h-full"
+          className="grid grid-cols-6 grid-rows-4 gap-[10px] w-full h-full"
           style={{
             minWidth: `${MIN_GRID_WIDTH}px`,
             minHeight: `${MIN_GRID_HEIGHT}px`,

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -31,16 +31,22 @@ export function canFitInGrid(widgets, colSpan, rowSpan) {
   return _tryPlace(grid, colSpan, rowSpan)
 }
 
+// 6열 × 4행 (24셀) 기본 레이아웃
+// Row 1:   index-3x1(3) + balance-sm(1) + portfolio-sm(1) + exchange-sm(1)       = 6
+// Row 2–3: stock-3x2(3×2) + ranking-lg(2×2) + watchlist-sm(1) + market-sm(1)    = 6×2
+// Row 4:   trade-wide(2) + stock-news-wide(2) + report-wide(2)                   = 6
 const INITIAL_WIDGETS = [
-  { instanceId: 'w1', widgetTypeId: 'balance',         variantId: 'balance-sm',   colSpan: 1, rowSpan: 1 },
-  { instanceId: 'w2', widgetTypeId: 'index',           variantId: 'index-wide',   colSpan: 2, rowSpan: 1 },
-  { instanceId: 'w3', widgetTypeId: 'portfolio',       variantId: 'portfolio-sm', colSpan: 1, rowSpan: 1 },
-  { instanceId: 'w4', widgetTypeId: 'stock-chart',     variantId: 'stock-sm',     colSpan: 1, rowSpan: 1, config: { stockId: 'samsung'  } },
-  { instanceId: 'w5', widgetTypeId: 'ranking',         variantId: 'ranking-wide', colSpan: 2, rowSpan: 1 },
-  { instanceId: 'w6', widgetTypeId: 'watchlist',       variantId: 'watchlist-sm', colSpan: 1, rowSpan: 1 },
-  { instanceId: 'w7', widgetTypeId: 'market-overview', variantId: 'market-sm',    colSpan: 1, rowSpan: 1 },
-  { instanceId: 'w8', widgetTypeId: 'exchange',        variantId: 'exchange-sm',  colSpan: 1, rowSpan: 1 },
-  { instanceId: 'w9', widgetTypeId: 'stock-chart',     variantId: 'stock-sm',     colSpan: 1, rowSpan: 1, config: { stockId: 'skhynix' } },
+  { instanceId: 'w1',  widgetTypeId: 'index',           variantId: 'index-3x1',      colSpan: 3, rowSpan: 1 },
+  { instanceId: 'w2',  widgetTypeId: 'balance',         variantId: 'balance-sm',     colSpan: 1, rowSpan: 1 },
+  { instanceId: 'w3',  widgetTypeId: 'portfolio',       variantId: 'portfolio-sm',   colSpan: 1, rowSpan: 1 },
+  { instanceId: 'w4',  widgetTypeId: 'exchange',        variantId: 'exchange-sm',    colSpan: 1, rowSpan: 1 },
+  { instanceId: 'w5',  widgetTypeId: 'stock-chart',     variantId: 'stock-3x2',      colSpan: 3, rowSpan: 2, config: { stockId: 'samsung' } },
+  { instanceId: 'w6',  widgetTypeId: 'ranking',         variantId: 'ranking-lg',     colSpan: 2, rowSpan: 2 },
+  { instanceId: 'w7',  widgetTypeId: 'watchlist',       variantId: 'watchlist-sm',   colSpan: 1, rowSpan: 1 },
+  { instanceId: 'w8',  widgetTypeId: 'market-overview', variantId: 'market-sm',      colSpan: 1, rowSpan: 1 },
+  { instanceId: 'w9',  widgetTypeId: 'trade-history',   variantId: 'trade-wide',     colSpan: 2, rowSpan: 1 },
+  { instanceId: 'w10', widgetTypeId: 'stock-news',      variantId: 'stock-news-wide', colSpan: 2, rowSpan: 1 },
+  { instanceId: 'w11', widgetTypeId: 'report',          variantId: 'report-wide',    colSpan: 2, rowSpan: 1 },
 ]
 
 const useWidgetStore = create((set) => ({


### PR DESCRIPTION
Closes #42

## 작업 내용

- `gridConstants.js`: GRID_COLS 4→6, GRID_ROWS 3→4, MIN_CELL 크기 조정 (140×130)
- `HomePage.jsx`: `grid-cols-6 grid-rows-4` 클래스 반영
- `useWidgetStore.js`: INITIAL_WIDGETS 6×4 레이아웃 재설계 (24셀 완전 채움)
- `WidgetSizeList.jsx`: EditPanel 프리뷰 너비 3등분 기준 유지 + report 프리뷰 케이스 추가
- `widgetRegistry.js`: `ReportWidget` 등록 누락 추가
- `mocks/widgets.js`: `report` 위젯 타입 및 variant 정의 추가

## INITIAL_WIDGETS 레이아웃 (24셀)

| 행 | 위젯 배치 |
|---|---|
| 1행 | index-3x1 (3) + balance-sm (1) + portfolio-sm (1) + exchange-sm (1) |
| 2–3행 | stock-3x2 (3×2) + ranking-lg (2×2) + watchlist-sm (1) + market-sm (1) |
| 4행 | trade-wide (2) + stock-news-wide (2) + report-wide (2) |

## 확인 방법

- [ ] 홈 대시보드 6×4 그리드 정상 렌더링
- [ ] EditPanel 위젯 프리뷰 크기 3등분 기준으로 정상 표시
- [ ] `canFitInGrid` 로직이 6×4 기준으로 정상 동작
- [ ] report 위젯 추가 가능 여부 확인