### PR TITLE
fix(widget): 6×4 그리드 전환 후속 버그 수정

### DIFF
--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -1107,7 +1107,7 @@ export default function WidgetSizeList({ widgetType, onBack }) {
                   /* hover 추가 오버레이 */
                   <button
                     aria-label={`${variant.label} 추가`}
-                    onClick={() => { addWidget(widgetType.id, variant); onBack() }}
+                    onClick={() => { addWidget(widgetType.id, variant) }}
                     className="absolute inset-0 rounded-xl opacity-0 group-hover:opacity-100 bg-primary/10 border border-primary flex items-center justify-center transition-opacity duration-[150ms]"
                   >
                     <div className="w-7 h-7 rounded-full bg-primary flex items-center justify-center shadow-primary-btn">

--- a/src/components/widgets/EditHandle.jsx
+++ b/src/components/widgets/EditHandle.jsx
@@ -3,7 +3,7 @@ export default function EditHandle({ onDelete }) {
     <button
       aria-label="위젯 삭제"
       onClick={(e) => { e.stopPropagation(); onDelete?.() }}
-      className="absolute -top-2 -left-2 z-20 w-[22px] h-[22px] rounded-full bg-danger border-2 border-surface text-white text-[14px] font-bold leading-none flex items-center justify-center shadow-delete-btn hover:opacity-85 transition-opacity duration-[150ms]"
+      className="absolute top-1.5 left-1.5 z-20 w-[22px] h-[22px] rounded-full bg-danger border-2 border-surface text-white text-[14px] font-bold leading-none flex items-center justify-center shadow-delete-btn hover:opacity-85 transition-opacity duration-[150ms]"
     >
       −
     </button>

--- a/src/components/widgets/EditHandle.jsx
+++ b/src/components/widgets/EditHandle.jsx
@@ -3,7 +3,7 @@ export default function EditHandle({ onDelete }) {
     <button
       aria-label="위젯 삭제"
       onClick={(e) => { e.stopPropagation(); onDelete?.() }}
-      className="absolute top-1.5 left-1.5 z-20 w-[22px] h-[22px] rounded-full bg-danger border-2 border-surface text-white text-[14px] font-bold leading-none flex items-center justify-center shadow-delete-btn hover:opacity-85 transition-opacity duration-[150ms]"
+      className="absolute -top-2 -left-2 z-20 w-[22px] h-[22px] rounded-full bg-danger border-2 border-surface text-white text-[14px] font-bold leading-none flex items-center justify-center shadow-delete-btn hover:opacity-85 transition-opacity duration-[150ms]"
     >
       −
     </button>

--- a/src/components/widgets/WidgetCard.jsx
+++ b/src/components/widgets/WidgetCard.jsx
@@ -13,7 +13,7 @@ export default function WidgetCard({ children, colSpan = 1, rowSpan = 1, classNa
           ? 'animate-wiggle cursor-grab'
           : 'cursor-pointer transition-[transform] duration-[200ms] hover:-translate-y-px',
         colSpan === 3 ? 'col-span-3' : colSpan === 2 ? 'col-span-2' : 'col-span-1',
-        rowSpan === 3 ? 'row-span-3' : rowSpan === 2 ? 'row-span-2' : '',
+        rowSpan === 2 ? 'row-span-2' : '',
         className,
       )}
     >

--- a/src/components/widgets/WidgetCard.jsx
+++ b/src/components/widgets/WidgetCard.jsx
@@ -12,8 +12,8 @@ export default function WidgetCard({ children, colSpan = 1, rowSpan = 1, classNa
         isEditMode
           ? 'animate-wiggle cursor-grab'
           : 'cursor-pointer transition-[transform] duration-[200ms] hover:-translate-y-px',
-        colSpan === 2 ? 'col-span-2' : 'col-span-1',
-        rowSpan === 2 && 'row-span-2',
+        colSpan === 3 ? 'col-span-3' : colSpan === 2 ? 'col-span-2' : 'col-span-1',
+        rowSpan === 3 ? 'row-span-3' : rowSpan === 2 ? 'row-span-2' : '',
         className,
       )}
     >

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -3,7 +3,7 @@ import { Pencil } from 'lucide-react'
 import LiveDot from '@/components/ui/LiveDot'
 import useEditModeStore from '@/store/useEditModeStore'
 import useGridStore from '@/store/useGridStore'
-import useWidgetStore from '@/store/useWidgetStore'
+import useWidgetStore, { canFitInGrid } from '@/store/useWidgetStore'
 import { cn } from '@/lib/cn'
 import AddWidgetSlot from '@/components/widgets/AddWidgetSlot'
 import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry'
@@ -81,7 +81,7 @@ export default function HomePage() {
       {/* 스크롤 래퍼: 최솟값 이하로 줄어들면 스크롤 */}
       <div className={cn(
         'flex-1 min-h-0',
-        isEditMode ? 'overflow-hidden' : 'overflow-auto',
+        isEditMode ? 'overflow-visible' : 'overflow-auto',
       )}>
         {/* 위젯 그리드: 6열 × 4행, 뷰포트 채움 / 최솟값 이하면 고정 */}
         <div
@@ -106,7 +106,7 @@ export default function HomePage() {
               />
             )
           })}
-          {!isEditMode && <AddWidgetSlot />}
+          {!isEditMode && canFitInGrid(widgets, 1, 1) && <AddWidgetSlot />}
         </div>
       </div>
     </div>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -81,7 +81,7 @@ export default function HomePage() {
       {/* 스크롤 래퍼: 최솟값 이하로 줄어들면 스크롤 */}
       <div className={cn(
         'flex-1 min-h-0',
-        isEditMode ? 'overflow-visible' : 'overflow-auto',
+        isEditMode ? 'overflow-hidden' : 'overflow-auto',
       )}>
         {/* 위젯 그리드: 6열 × 4행, 뷰포트 채움 / 최솟값 이하면 고정 */}
         <div


### PR DESCRIPTION
Closes #45

## 작업 내용

- `WidgetCard`: col-span/row-span 3 이상 처리 누락 수정 — 3열 위젯이 1열로 배치되던 문제
- `WidgetSizeList`: 위젯 추가 후 `onBack()` 제거 — 추가 후 EditPanel 현재 위치 유지
- `HomePage`: 편집 모드 진입 시 위젯 height 증가 현상 수정 — 그리드가 꽉 찬 상태에서 `AddWidgetSlot`이 5번째 행을 생성하던 문제를 `canFitInGrid` 조건부 렌더링으로 해결

## 확인 방법

- [ ] 계좌잔고 3×1, 주가차트 3×2 추가 시 올바른 크기로 배치되는지 확인
- [ ] 위젯 추가 후 EditPanel 현재 화면 유지되는지 확인
- [ ] 위젯 편집 버튼 클릭 시 위젯 height 변화 없는지 확인