### PR TITLE
feat(account): 계정 설정 패널 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.1.2",
     "@radix-ui/react-primitive": "^2.0.1",
+    "@tanstack/react-query": "^5.91.2",
     "clsx": "^2.1.1",
     "lucide-react": "^0.577.0",
     "react": "^19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@radix-ui/react-primitive':
         specifier: ^2.0.1
         version: 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tanstack/react-query':
+        specifier: ^5.91.2
+        version: 5.91.2(react@19.2.4)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -790,6 +793,14 @@ packages:
     resolution: {integrity: sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
+
+  '@tanstack/query-core@5.91.2':
+    resolution: {integrity: sha512-Uz2pTgPC1mhqrrSGg18RKCWT/pkduAYtxbcyIyKBhw7dTWjXZIzqmpzO2lBkyWr4hlImQgpu1m1pei3UnkFRWw==}
+
+  '@tanstack/react-query@5.91.2':
+    resolution: {integrity: sha512-GClLPzbM57iFXv+FlvOUL56XVe00PxuTaVEyj1zAObhRiKF008J5vedmaq7O6ehs+VmPHe8+PUQhMuEyv8d9wQ==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -2245,6 +2256,13 @@ snapshots:
       '@tailwindcss/oxide': 4.2.1
       tailwindcss: 4.2.1
       vite: 8.0.0(jiti@2.6.1)
+
+  '@tanstack/query-core@5.91.2': {}
+
+  '@tanstack/react-query@5.91.2(react@19.2.4)':
+    dependencies:
+      '@tanstack/query-core': 5.91.2
+      react: 19.2.4
 
   '@tybys/wasm-util@0.10.1':
     dependencies:

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,18 @@
 import { useEffect } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { RouterProvider } from 'react-router-dom'
 import { router } from './router'
 import useAuthStore from '@/store/useAuthStore'
 import LoginModal from '@/components/auth/LoginModal'
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60 * 5, // 5분
+      retry: 1,
+    },
+  },
+})
 
 export default function App() {
   const showLoginModal = useAuthStore((s) => s.showLoginModal)
@@ -16,9 +26,9 @@ export default function App() {
   if (isRestoring) return null
 
   return (
-    <>
+    <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
       {showLoginModal && <LoginModal onClose={closeLoginModal} />}
-    </>
+    </QueryClientProvider>
   )
 }

--- a/src/api/account.js
+++ b/src/api/account.js
@@ -1,0 +1,39 @@
+import { useQuery } from '@tanstack/react-query'
+import useAuthStore from '@/store/useAuthStore'
+
+const BASE = '/api/accounts'
+
+async function get(path, options = {}) {
+  const { headers: optionHeaders, ...restOptions } = options
+  const headers = { ...optionHeaders }
+
+  const accessToken = useAuthStore.getState().accessToken
+  if (accessToken) {
+    headers['Authorization'] = `Bearer ${accessToken}`
+  }
+
+  const res = await fetch(`${BASE}${path}`, {
+    headers,
+    credentials: 'include',
+    ...restOptions,
+  })
+  const data = await res.json()
+  if (!res.ok) throw data
+  return data
+}
+
+export const accountApi = {
+  getMyAccount: () => get('/me'),
+}
+
+// React Query Hook
+export const useMyAccount = () => {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
+
+  return useQuery({
+    queryKey: ['account', 'me'],
+    queryFn: () => accountApi.getMyAccount(),
+    enabled: isAuthenticated, // 인증되었을 때만 호출
+    staleTime: 1000 * 60 * 10, // 10분
+  })
+}

--- a/src/api/user.js
+++ b/src/api/user.js
@@ -1,7 +1,6 @@
-import { useQuery } from '@tanstack/react-query'
 import useAuthStore from '@/store/useAuthStore'
 
-const BASE = '/api/accounts'
+const BASE = '/api/users'
 
 async function request(path, method = 'GET', body = null, options = {}) {
   const { headers: optionHeaders, ...restOptions } = options
@@ -28,21 +27,8 @@ async function request(path, method = 'GET', body = null, options = {}) {
   return data
 }
 
-export const accountApi = {
-  getMyAccount: () => request('/me', 'GET'),
-  changePin: (currentPin, newPin) => request('/me/pin', 'PATCH', { currentPin, newPin }),
-  reset: (accountPin) => request('/reset', 'POST', { accountPin }),
-  closeAccount: (accountPin) => request('', 'DELETE', { accountPin }),
-}
-
-// React Query Hook
-export const useMyAccount = () => {
-  const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
-
-  return useQuery({
-    queryKey: ['account', 'me'],
-    queryFn: () => accountApi.getMyAccount(),
-    enabled: isAuthenticated,
-    staleTime: 1000 * 60 * 10,
-  })
+export const userApi = {
+  getProfile: () => request('/me', 'GET'),
+  changePassword: (currentPassword, newPassword) =>
+    request('/me/password', 'PATCH', { currentPassword, newPassword, newPasswordConfirm: newPassword }),
 }

--- a/src/components/auth/LoginModal.jsx
+++ b/src/components/auth/LoginModal.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { Activity, X, Check } from 'lucide-react'
 import { Input, PasswordInput } from '@/components/ui/Input'
 import { authApi } from '@/api/auth'
@@ -6,6 +7,7 @@ import { router } from '@/router'
 import useAuthStore from '@/store/useAuthStore'
 
 export default function LoginModal({ onClose }) {
+  const queryClient = useQueryClient()
   const setAuth = useAuthStore((s) => s.setAuth)
 
   const [email, setEmail] = useState('')
@@ -25,6 +27,8 @@ export default function LoginModal({ onClose }) {
         user:        res.user,
         autoLogin,
       })
+      // 계좌 정보 쿼리 유효화 (다음 호출 시 새로 fetch)
+      queryClient.invalidateQueries({ queryKey: ['account', 'me'] })
       onClose()
     } catch (err) {
       setError(err?.message ?? '이메일 또는 비밀번호를 확인해 주세요.')

--- a/src/components/layout/AccountSettingsPanel.jsx
+++ b/src/components/layout/AccountSettingsPanel.jsx
@@ -1,0 +1,96 @@
+import { X, Lock, RotateCcw, Trash2, Key } from 'lucide-react'
+import useAuthStore from '@/store/useAuthStore'
+import useRightPanelStore from '@/store/useRightPanelStore'
+import { useMyAccount } from '@/api/account'
+
+function Header() {
+  const setChatMode = useRightPanelStore((s) => s.setChatMode)
+  return (
+    <div className="h-chat-header flex items-center justify-between px-4 border-b border-stroke shrink-0">
+      <span className="text-[13px] font-semibold text-foreground">계좌 설정</span>
+      <button
+        onClick={() => setChatMode()}
+        aria-label="닫기"
+        className="p-1 text-foreground-tertiary hover:text-foreground transition-colors"
+      >
+        <X className="w-4 h-4" />
+      </button>
+    </div>
+  )
+}
+
+function AccountInfo() {
+  const { user } = useAuthStore()
+  const { data: accountInfo } = useMyAccount()
+
+  return (
+    <div className="px-4 py-4 border-b border-stroke-subtle bg-surface-subtle shrink-0">
+      <div className="text-[12px] font-semibold text-foreground mb-1">
+        {user?.name}
+      </div>
+      <div className="text-[11px] text-foreground-secondary">
+        {accountInfo?.accountNumber}
+      </div>
+      <div className="text-[10px] text-foreground-disabled mt-2">
+        상태: {accountInfo?.accountStatus}
+      </div>
+    </div>
+  )
+}
+
+function MenuItem({ icon: Icon, label, onClick, isWarning = false }) {
+  return (
+    <button
+      onClick={onClick}
+      className={`w-full flex items-center gap-3 px-4 py-3 text-[12px] hover:bg-surface-muted transition-colors text-left border-b border-stroke-subtle last:border-b-0 ${isWarning ? 'text-up' : 'text-foreground'}`}
+    >
+      <Icon className="w-4 h-4 shrink-0" strokeWidth={2} style={{ color: isWarning ? 'currentColor' : '' }} />
+      <span>{label}</span>
+    </button>
+  )
+}
+
+function MenuContent() {
+  const handleMenuClick = (label) => {
+    console.log(label)
+    // TODO: 각 메뉴 항목에 대한 동작 구현
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto flex flex-col">
+      <div className="flex-1 flex flex-col">
+        <MenuItem
+          icon={Lock}
+          label="계좌 비밀번호 변경"
+          onClick={() => handleMenuClick('계좌 비밀번호 변경')}
+        />
+        <MenuItem
+          icon={RotateCcw}
+          label="리셋"
+          onClick={() => handleMenuClick('리셋')}
+        />
+        <MenuItem
+          icon={Trash2}
+          label="계좌 해지 신청"
+          onClick={() => handleMenuClick('계좌 해지 신청')}
+          isWarning
+        />
+        <MenuItem
+          icon={Key}
+          label="계정 비밀번호 변경"
+          onClick={() => handleMenuClick('계정 비밀번호 변경')}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default function AccountSettingsPanel() {
+  return (
+    <>
+      <Header />
+      <AccountInfo />
+      <MenuContent />
+    </>
+  )
+}

--- a/src/components/layout/AccountSettingsPanel.jsx
+++ b/src/components/layout/AccountSettingsPanel.jsx
@@ -1,96 +1,593 @@
-import { X, Lock, RotateCcw, Trash2, Key } from 'lucide-react'
-import useAuthStore from '@/store/useAuthStore'
+import { useState } from 'react'
+import { X, Lock, RotateCcw, Trash2, Key, LogOut } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
 import useRightPanelStore from '@/store/useRightPanelStore'
-import { useMyAccount } from '@/api/account'
+import useAuthStore from '@/store/useAuthStore'
+import { PasswordInput } from '@/components/ui/Input'
+import { userApi } from '@/api/user'
+import { accountApi } from '@/api/account'
+import { authApi } from '@/api/auth'
+import { changePasswordSchema, changePinSchema, resetAccountSchema, closeAccountSchema } from '@/lib/validationSchemas'
+import AccountPinKeypad from '@/components/signup/AccountPinKeypad'
+import DecoyCursorOverlay from '@/components/signup/DecoyCursorOverlay'
 
 function Header() {
+  const navigate = useNavigate()
   const setChatMode = useRightPanelStore((s) => s.setChatMode)
+  const logout = useAuthStore((s) => s.logout)
+
+  const handleLogout = async () => {
+    try {
+      await authApi.logout()
+    } catch (err) {
+      console.error('로그아웃 에러:', err)
+    }
+    logout()
+    navigate('/')
+  }
+
   return (
     <div className="h-chat-header flex items-center justify-between px-4 border-b border-stroke shrink-0">
-      <span className="text-[13px] font-semibold text-foreground">계좌 설정</span>
+      <span className="text-[13px] font-semibold text-foreground">계정 설정</span>
+      <div className="flex items-center gap-2">
+        <button
+          onClick={handleLogout}
+          aria-label="로그아웃"
+          className="p-1 text-foreground-tertiary hover:text-up transition-colors"
+          title="로그아웃"
+        >
+          <LogOut className="w-4 h-4" strokeWidth={2} />
+        </button>
+        <button
+          onClick={() => setChatMode()}
+          aria-label="닫기"
+          className="p-1 text-foreground-tertiary hover:text-foreground transition-colors"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function MenuTabs({ selectedMenuItem, onSelectMenuItem }) {
+  return (
+    <div className="flex border-b border-stroke shrink-0 overflow-x-auto">
       <button
-        onClick={() => setChatMode()}
-        aria-label="닫기"
-        className="p-1 text-foreground-tertiary hover:text-foreground transition-colors"
+        onClick={() => onSelectMenuItem('change-account-password')}
+        className={`px-4 py-2 text-[12px] font-medium border-b-2 transition-colors whitespace-nowrap ${
+          selectedMenuItem === 'change-account-password'
+            ? 'text-primary border-b-primary'
+            : 'text-foreground-secondary border-b-transparent hover:text-foreground'
+        }`}
       >
-        <X className="w-4 h-4" />
+        계정 비밀번호
+      </button>
+      <button
+        onClick={() => onSelectMenuItem('change-account-pin')}
+        className={`px-4 py-2 text-[12px] font-medium border-b-2 transition-colors whitespace-nowrap ${
+          selectedMenuItem === 'change-account-pin'
+            ? 'text-primary border-b-primary'
+            : 'text-foreground-secondary border-b-transparent hover:text-foreground'
+        }`}
+      >
+        계좌 비밀번호
+      </button>
+      <button
+        onClick={() => onSelectMenuItem('reset')}
+        className={`px-4 py-2 text-[12px] font-medium border-b-2 transition-colors whitespace-nowrap ${
+          selectedMenuItem === 'reset'
+            ? 'text-primary border-b-primary'
+            : 'text-foreground-secondary border-b-transparent hover:text-foreground'
+        }`}
+      >
+        리셋
+      </button>
+      <button
+        onClick={() => onSelectMenuItem('close-account')}
+        className={`px-4 py-2 text-[12px] font-medium border-b-2 transition-colors whitespace-nowrap ${
+          selectedMenuItem === 'close-account'
+            ? 'text-up border-b-up'
+            : 'text-foreground-secondary border-b-transparent hover:text-up'
+        }`}
+      >
+        계좌 해지
       </button>
     </div>
   )
 }
 
-function AccountInfo() {
-  const { user } = useAuthStore()
-  const { data: accountInfo } = useMyAccount()
+function ChangePasswordForm({ onSuccess }) {
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setError('')
+
+    const validation = changePasswordSchema.safeParse({
+      currentPassword,
+      newPassword,
+      confirmPassword,
+    })
+
+    if (!validation.success) {
+      const fieldError = validation.error.errors[0]
+      setError(fieldError.message)
+      return
+    }
+
+    setIsLoading(true)
+    try {
+      await userApi.changePassword(currentPassword, newPassword)
+      onSuccess('비밀번호가 변경되었습니다.')
+      setCurrentPassword('')
+      setNewPassword('')
+      setConfirmPassword('')
+    } catch (err) {
+      setError(err?.message ?? '비밀번호 변경에 실패했습니다.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
 
   return (
-    <div className="px-4 py-4 border-b border-stroke-subtle bg-surface-subtle shrink-0">
-      <div className="text-[12px] font-semibold text-foreground mb-1">
-        {user?.name}
+    <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+      <div>
+        <label className="text-[11px] font-semibold text-foreground-secondary block mb-1.5">
+          현재 비밀번호
+        </label>
+        <PasswordInput
+          value={currentPassword}
+          onChange={(e) => setCurrentPassword(e.target.value)}
+          placeholder="현재 비밀번호"
+        />
       </div>
-      <div className="text-[11px] text-foreground-secondary">
-        {accountInfo?.accountNumber}
+
+      <div>
+        <label className="text-[11px] font-semibold text-foreground-secondary block mb-1.5">
+          새 비밀번호
+        </label>
+        <PasswordInput
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+          placeholder="새 비밀번호"
+        />
       </div>
-      <div className="text-[10px] text-foreground-disabled mt-2">
-        상태: {accountInfo?.accountStatus}
+
+      <div>
+        <label className="text-[11px] font-semibold text-foreground-secondary block mb-1.5">
+          비밀번호 확인
+        </label>
+        <PasswordInput
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          placeholder="비밀번호 확인"
+        />
       </div>
+
+      {error && <p className="text-[11px] text-up">{error}</p>}
+
+      <button
+        type="submit"
+        disabled={isLoading}
+        className="px-4 py-2 rounded-lg bg-primary text-white text-[12px] font-medium hover:bg-primary-hover transition-colors disabled:opacity-60 mt-2"
+      >
+        {isLoading ? '변경 중...' : '변경'}
+      </button>
+    </form>
+  )
+}
+
+function PinDots({ value, active }) {
+  return (
+    <div className="flex justify-center gap-2.5">
+      {Array.from({ length: 4 }, (_, index) => {
+        const filled = index < value.length
+
+        return (
+          <div
+            key={index}
+            className={[
+              'flex h-11 w-11 items-center justify-center rounded-2xl border transition-colors',
+              active ? 'border-primary bg-primary-light' : 'border-stroke-input bg-surface-subtle',
+            ].join(' ')}
+          >
+            <div
+              className={[
+                'h-2.5 w-2.5 rounded-full transition-colors',
+                filled ? 'bg-primary' : active ? 'bg-primary/20' : 'bg-stroke-input',
+              ].join(' ')}
+            />
+          </div>
+        )
+      })}
     </div>
   )
 }
 
-function MenuItem({ icon: Icon, label, onClick, isWarning = false }) {
+function PinField({ label, value, active, error, onClick }) {
   return (
-    <button
-      onClick={onClick}
-      className={`w-full flex items-center gap-3 px-4 py-3 text-[12px] hover:bg-surface-muted transition-colors text-left border-b border-stroke-subtle last:border-b-0 ${isWarning ? 'text-up' : 'text-foreground'}`}
-    >
-      <Icon className="w-4 h-4 shrink-0" strokeWidth={2} style={{ color: isWarning ? 'currentColor' : '' }} />
-      <span>{label}</span>
-    </button>
+    <div>
+      <label className="text-[11px] font-semibold text-foreground-secondary block mb-1.5">
+        {label}
+      </label>
+      <button
+        type="button"
+        onClick={onClick}
+        className={[
+          'flex w-full justify-center bg-transparent py-1 text-center transition-opacity duration-[150ms] focus:outline-none',
+          active ? 'opacity-100' : 'opacity-95 hover:opacity-100',
+        ].join(' ')}
+        data-pin-interactive="true"
+      >
+        <PinDots value={value} active={active} />
+      </button>
+
+      {error && <p className="mt-2 text-[11px] text-up">{error}</p>}
+    </div>
   )
 }
 
-function MenuContent() {
-  const handleMenuClick = (label) => {
-    console.log(label)
-    // TODO: 각 메뉴 항목에 대한 동작 구현
+function ChangePinForm({ onSuccess }) {
+  const [currentPin, setCurrentPin] = useState('')
+  const [newPin, setNewPin] = useState('')
+  const [confirmPin, setConfirmPin] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [activePinField, setActivePinField] = useState(null)
+  const [isKeyboardOpen, setIsKeyboardOpen] = useState(false)
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setError('')
+
+    const validation = changePinSchema.safeParse({
+      currentPin,
+      newPin,
+      confirmPin,
+    })
+
+    if (!validation.success) {
+      const fieldError = validation.error.errors[0]
+      setError(fieldError.message)
+      return
+    }
+
+    setIsLoading(true)
+    try {
+      await accountApi.changePin(currentPin, newPin)
+      onSuccess('계좌 비밀번호가 변경되었습니다.')
+      setCurrentPin('')
+      setNewPin('')
+      setConfirmPin('')
+    } catch (err) {
+      setError(err?.message ?? '계좌 비밀번호 변경에 실패했습니다.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  function handlePinChange(nextValue) {
+    const sanitizedValue = nextValue.replace(/\D/g, '').slice(0, 4)
+
+    if (activePinField === 'currentPin') {
+      setCurrentPin(sanitizedValue)
+      return
+    }
+    if (activePinField === 'newPin') {
+      setNewPin(sanitizedValue)
+      return
+    }
+    if (activePinField === 'confirmPin') {
+      setConfirmPin(sanitizedValue)
+      return
+    }
+  }
+
+  function handlePinDone() {
+    setIsKeyboardOpen(false)
+  }
+
+  function openKeyboard(fieldName) {
+    setActivePinField(fieldName)
+    setIsKeyboardOpen(true)
   }
 
   return (
-    <div className="flex-1 overflow-y-auto flex flex-col">
-      <div className="flex-1 flex flex-col">
-        <MenuItem
-          icon={Lock}
-          label="계좌 비밀번호 변경"
-          onClick={() => handleMenuClick('계좌 비밀번호 변경')}
+    <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+      <div>
+        <PinField
+          label="현재 비밀번호 (4자리)"
+          value={currentPin}
+          active={activePinField === 'currentPin' && isKeyboardOpen}
+          error={undefined}
+          onClick={() => openKeyboard('currentPin')}
         />
-        <MenuItem
-          icon={RotateCcw}
-          label="리셋"
-          onClick={() => handleMenuClick('리셋')}
+        {activePinField === 'currentPin' && (
+          <AccountPinKeypad
+            variant="desktop"
+            isOpen={isKeyboardOpen}
+            value={currentPin}
+            onChange={handlePinChange}
+            onDone={handlePinDone}
+            onClose={() => setIsKeyboardOpen(false)}
+          />
+        )}
+      </div>
+
+      <div>
+        <PinField
+          label="새 비밀번호 (4자리)"
+          value={newPin}
+          active={activePinField === 'newPin' && isKeyboardOpen}
+          error={undefined}
+          onClick={() => openKeyboard('newPin')}
         />
-        <MenuItem
-          icon={Trash2}
-          label="계좌 해지 신청"
-          onClick={() => handleMenuClick('계좌 해지 신청')}
-          isWarning
+        {activePinField === 'newPin' && (
+          <AccountPinKeypad
+            variant="desktop"
+            isOpen={isKeyboardOpen}
+            value={newPin}
+            onChange={handlePinChange}
+            onDone={handlePinDone}
+            onClose={() => setIsKeyboardOpen(false)}
+          />
+        )}
+      </div>
+
+      <div>
+        <PinField
+          label="비밀번호 확인 (4자리)"
+          value={confirmPin}
+          active={activePinField === 'confirmPin' && isKeyboardOpen}
+          error={undefined}
+          onClick={() => openKeyboard('confirmPin')}
         />
-        <MenuItem
-          icon={Key}
-          label="계정 비밀번호 변경"
-          onClick={() => handleMenuClick('계정 비밀번호 변경')}
+        {activePinField === 'confirmPin' && (
+          <AccountPinKeypad
+            variant="desktop"
+            isOpen={isKeyboardOpen}
+            value={confirmPin}
+            onChange={handlePinChange}
+            onDone={handlePinDone}
+            onClose={() => setIsKeyboardOpen(false)}
+          />
+        )}
+      </div>
+
+      {error && <p className="text-[11px] text-up">{error}</p>}
+
+      <button
+        type="submit"
+        disabled={isLoading}
+        className="px-4 py-2 rounded-lg bg-primary text-white text-[12px] font-medium hover:bg-primary-hover transition-colors disabled:opacity-60 mt-2"
+      >
+        {isLoading ? '변경 중...' : '변경'}
+      </button>
+    </form>
+  )
+}
+
+function ResetForm({ onSuccess }) {
+  const [accountPin, setAccountPin] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [isKeyboardOpen, setIsKeyboardOpen] = useState(false)
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setError('')
+
+    const validation = resetAccountSchema.safeParse({
+      accountPin,
+    })
+
+    if (!validation.success) {
+      const fieldError = validation.error.errors[0]
+      setError(fieldError.message)
+      return
+    }
+
+    setIsLoading(true)
+    try {
+      await accountApi.reset(accountPin)
+      onSuccess('계좌가 리셋되었습니다. 새 라운드가 시작됩니다.')
+      setAccountPin('')
+    } catch (err) {
+      setError(err?.message ?? '리셋에 실패했습니다.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  function handlePinChange(nextValue) {
+    const sanitizedValue = nextValue.replace(/\D/g, '').slice(0, 4)
+    setAccountPin(sanitizedValue)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+      <div className="p-3 bg-up-bg rounded-lg">
+        <p className="text-[11px] text-up leading-relaxed">
+          리셋하면 현재 라운드가 종료되고 새로운 라운드가 시작됩니다. 이 작업은 되돌릴 수 없습니다.
+        </p>
+      </div>
+
+      <div>
+        <PinField
+          label="계좌 비밀번호 (4자리)"
+          value={accountPin}
+          active={isKeyboardOpen}
+          error={undefined}
+          onClick={() => setIsKeyboardOpen(true)}
+        />
+        <AccountPinKeypad
+          variant="desktop"
+          isOpen={isKeyboardOpen}
+          value={accountPin}
+          onChange={handlePinChange}
+          onDone={() => setIsKeyboardOpen(false)}
+          onClose={() => setIsKeyboardOpen(false)}
         />
       </div>
+
+      {error && <p className="text-[11px] text-up">{error}</p>}
+
+      <button
+        type="submit"
+        disabled={isLoading}
+        className="px-4 py-2 rounded-lg bg-primary text-white text-[12px] font-medium hover:bg-primary-hover transition-colors disabled:opacity-60 mt-2"
+      >
+        {isLoading ? '진행 중...' : '리셋'}
+      </button>
+    </form>
+  )
+}
+
+function CloseAccountForm({ onSuccess }) {
+  const [accountPin, setAccountPin] = useState('')
+  const [agreed, setAgreed] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [isKeyboardOpen, setIsKeyboardOpen] = useState(false)
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setError('')
+
+    const validation = closeAccountSchema.safeParse({
+      accountPin,
+      agreed,
+    })
+
+    if (!validation.success) {
+      const fieldError = validation.error.errors[0]
+      setError(fieldError.message)
+      return
+    }
+
+    setIsLoading(true)
+    try {
+      await accountApi.closeAccount(accountPin)
+      onSuccess('계좌가 해지되었습니다.')
+      setAccountPin('')
+    } catch (err) {
+      setError(err?.message ?? '계좌 해지에 실패했습니다.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  function handlePinChange(nextValue) {
+    const sanitizedValue = nextValue.replace(/\D/g, '').slice(0, 4)
+    setAccountPin(sanitizedValue)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+      <div className="p-3 bg-up-bg rounded-lg">
+        <p className="text-[11px] text-up leading-relaxed">
+          계좌를 해지하면 모든 데이터가 삭제되며 되돌릴 수 없습니다.
+        </p>
+      </div>
+
+      <div>
+        <PinField
+          label="계좌 비밀번호 (4자리)"
+          value={accountPin}
+          active={isKeyboardOpen}
+          error={undefined}
+          onClick={() => setIsKeyboardOpen(true)}
+        />
+        <AccountPinKeypad
+          variant="desktop"
+          isOpen={isKeyboardOpen}
+          value={accountPin}
+          onChange={handlePinChange}
+          onDone={() => setIsKeyboardOpen(false)}
+          onClose={() => setIsKeyboardOpen(false)}
+        />
+      </div>
+
+      <label className="flex items-center gap-2 cursor-pointer select-none">
+        <input
+          type="checkbox"
+          checked={agreed}
+          onChange={(e) => setAgreed(e.target.checked)}
+          className="w-4 h-4 accent-primary rounded cursor-pointer"
+        />
+        <span className="text-[11px] text-foreground-secondary">
+          계좌 해지에 동의합니다.
+        </span>
+      </label>
+
+      {error && <p className="text-[11px] text-up">{error}</p>}
+
+      <button
+        type="submit"
+        disabled={isLoading || !agreed}
+        className="px-4 py-2 rounded-lg bg-up text-white text-[12px] font-medium hover:bg-[#d03239] transition-colors disabled:opacity-60 mt-2"
+      >
+        {isLoading ? '처리 중...' : '해지'}
+      </button>
+    </form>
+  )
+}
+
+function ContentArea({ selectedMenuItem, onSuccess }) {
+  return (
+    <div className="flex-1 flex flex-col p-4 overflow-y-auto">
+      {selectedMenuItem === 'change-account-password' && (
+        <ChangePasswordForm onSuccess={onSuccess} />
+      )}
+
+      {selectedMenuItem === 'change-account-pin' && (
+        <ChangePinForm onSuccess={onSuccess} />
+      )}
+
+      {selectedMenuItem === 'reset' && (
+        <ResetForm onSuccess={onSuccess} />
+      )}
+
+      {selectedMenuItem === 'close-account' && (
+        <CloseAccountForm onSuccess={onSuccess} />
+      )}
+
+      {!selectedMenuItem && (
+        <div className="flex items-center justify-center h-full text-foreground-disabled">
+          <p className="text-[12px]">항목을 선택해주세요.</p>
+        </div>
+      )}
     </div>
   )
 }
 
 export default function AccountSettingsPanel() {
+  const [selectedMenuItem, setSelectedMenuItem] = useState('change-account-password')
+  const [successMessage, setSuccessMessage] = useState('')
+
+  const handleSuccess = (message) => {
+    setSuccessMessage(message)
+    setTimeout(() => setSuccessMessage(''), 3000)
+  }
+
   return (
-    <>
+    <div className="flex flex-col h-full">
       <Header />
-      <AccountInfo />
-      <MenuContent />
-    </>
+
+      {successMessage && (
+        <div className="px-4 py-2 bg-live/10 border-b border-live text-[11px] text-live">
+          {successMessage}
+        </div>
+      )}
+
+      <MenuTabs selectedMenuItem={selectedMenuItem} onSelectMenuItem={setSelectedMenuItem} />
+
+      <ContentArea selectedMenuItem={selectedMenuItem} onSuccess={handleSuccess} />
+    </div>
   )
 }

--- a/src/components/layout/AccountSettingsPanel.jsx
+++ b/src/components/layout/AccountSettingsPanel.jsx
@@ -530,7 +530,7 @@ function CloseAccountForm({ onSuccess }) {
       <button
         type="submit"
         disabled={isLoading || !agreed}
-        className="px-4 py-2 rounded-lg bg-up text-white text-[12px] font-medium hover:bg-[#d03239] transition-colors disabled:opacity-60 mt-2"
+        className="px-4 py-2 rounded-lg bg-up text-white text-[12px] font-medium hover:opacity-90 transition-colors disabled:opacity-60 mt-2"
       >
         {isLoading ? '처리 중...' : '해지'}
       </button>

--- a/src/components/layout/AppHeader.jsx
+++ b/src/components/layout/AppHeader.jsx
@@ -1,8 +1,9 @@
-import { Activity, LayoutGrid, LogOut } from 'lucide-react'
+import { Activity, LayoutGrid } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import NavTabs from './NavTabs'
 import useAuthStore from '@/store/useAuthStore'
-import { authApi } from '@/api/auth'
+import { useMyAccount } from '@/api/account'
+import useChatPanelStore from '@/store/useChatPanelStore'
 import useEditModeStore from '@/store/useEditModeStore'
 import useWidgetStore from '@/store/useWidgetStore'
 
@@ -22,43 +23,25 @@ function Logo() {
 }
 
 function UserArea() {
-  const navigate = useNavigate()
-  const { isAuthenticated, user, logout } = useAuthStore()
-
-  async function handleLogout() {
-    try {
-      await authApi.logout()
-    } finally {
-      logout()
-      navigate('/')
-    }
-  }
+  const { isAuthenticated, user } = useAuthStore()
+  const { data: accountInfo } = useMyAccount()
+  const setAccountSettingsMode = useChatPanelStore((s) => s.setAccountSettingsMode)
 
   if (isAuthenticated && user) {
     return (
-      <div className="flex items-center gap-2 pl-2 border-l border-stroke">
-        <div className="flex items-center gap-1.5">
-          <div className="w-7 h-7 rounded-full bg-primary text-white text-[11px] font-bold flex items-center justify-center">
-            {user.name?.[0] ?? '김'}
+      <button
+        onClick={() => setAccountSettingsMode()}
+        className="pl-2 pr-3 py-2 border-l border-stroke flex items-center gap-2 hover:bg-surface-muted rounded-lg transition-colors"
+      >
+        <div className="text-right">
+          <div className="text-[12px] font-bold leading-none text-foreground">
+            {user.name}
           </div>
-          <div className="hidden sm:block">
-            <div className="text-[11px] font-semibold leading-none text-foreground">
-              {user.name ?? '김SOL'}
-            </div>
-            <div className="text-[9px] text-foreground-disabled mt-0.5">
-              주문가능 {user.availableAmount ?? '7,478만원'}
-            </div>
+          <div className="text-[10px] text-foreground-disabled mt-0.5">
+            {accountInfo?.accountNumber ?? '-'}
           </div>
         </div>
-        <button
-          onClick={handleLogout}
-          aria-label="로그아웃"
-          className="p-2 text-foreground-tertiary hover:text-foreground hover:bg-surface-muted rounded-lg transition-colors"
-          title="로그아웃"
-        >
-          <LogOut className="w-5 h-5" strokeWidth={2} />
-        </button>
-      </div>
+      </button>
     )
   }
 

--- a/src/components/layout/AppHeader.jsx
+++ b/src/components/layout/AppHeader.jsx
@@ -23,43 +23,46 @@ function Logo() {
 }
 
 function UserArea() {
+  const navigate = useNavigate()
   const { isAuthenticated, user } = useAuthStore()
   const { data: accountInfo } = useMyAccount()
   const setAccountSettingsMode = useRightPanelStore((s) => s.setAccountSettingsMode)
 
-  if (isAuthenticated && user) {
+  if (!isAuthenticated || !user) {
     return (
-      <button
-        onClick={() => setAccountSettingsMode()}
-        className="pl-2 pr-3 py-2 border-l border-stroke flex items-center gap-2 hover:bg-surface-muted rounded-lg transition-colors"
-      >
-        <div className="text-right">
-          <div className="text-[12px] font-bold leading-none text-foreground">
-            {user.name}
-          </div>
-          <div className="text-[10px] text-foreground-disabled mt-0.5">
-            {accountInfo?.accountNumber ?? '-'}
-          </div>
-        </div>
-      </button>
+      <div className="flex items-center gap-2">
+        <button
+          onClick={() => navigate('/login')}
+          className="flex items-center px-4 py-1.5 rounded-xl bg-primary text-white text-[12px] font-semibold hover:bg-primary-hover transition-colors duration-[150ms] shadow-primary-btn"
+        >
+          로그인
+        </button>
+        <button
+          onClick={() => navigate('/signup')}
+          className="flex items-center px-4 py-1.5 rounded-xl border border-primary text-primary text-[12px] font-semibold hover:bg-primary-light transition-colors duration-[150ms]"
+        >
+          회원가입
+        </button>
+      </div>
     )
   }
 
+  const accountNumber = accountInfo?.accountNumber ?? '-'
+
   return (
-    <div className="flex items-center gap-2">
-      <button
-        onClick={() => navigate('/login')}
-        className="flex items-center px-4 py-1.5 rounded-xl bg-primary text-white text-[12px] font-semibold hover:bg-primary-hover transition-colors duration-[150ms] shadow-primary-btn"
-      >
-        로그인
-      </button>
-      <button
-        onClick={() => navigate('/signup')}
-        className="flex items-center px-4 py-1.5 rounded-xl border border-primary text-primary text-[12px] font-semibold hover:bg-primary-light transition-colors duration-[150ms]"
-      >
-        회원가입
-      </button>
-    </div>
+    <button
+      onClick={() => setAccountSettingsMode()}
+      className="pl-2 pr-3 py-2 border-l border-stroke flex items-center gap-2 hover:bg-surface-muted rounded-lg transition-colors"
+    >
+      <div className="text-right">
+        <div className="text-[13px] font-bold leading-none text-foreground">
+          {user.name}
+        </div>
+        <div className="text-[12px] text-foreground-secondary mt-1">
+          {accountNumber}
+        </div>
+      </div>
+    </button>
   )
 }
 

--- a/src/components/layout/AppHeader.jsx
+++ b/src/components/layout/AppHeader.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import NavTabs from './NavTabs'
 import useAuthStore from '@/store/useAuthStore'
 import { useMyAccount } from '@/api/account'
-import useChatPanelStore from '@/store/useChatPanelStore'
+import useRightPanelStore from '@/store/useRightPanelStore'
 import useEditModeStore from '@/store/useEditModeStore'
 import useWidgetStore from '@/store/useWidgetStore'
 
@@ -25,7 +25,7 @@ function Logo() {
 function UserArea() {
   const { isAuthenticated, user } = useAuthStore()
   const { data: accountInfo } = useMyAccount()
-  const setAccountSettingsMode = useChatPanelStore((s) => s.setAccountSettingsMode)
+  const setAccountSettingsMode = useRightPanelStore((s) => s.setAccountSettingsMode)
 
   if (isAuthenticated && user) {
     return (

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -1,6 +1,6 @@
 import { Outlet } from 'react-router-dom'
 import AppHeader from './AppHeader'
-import ChatPanel from './ChatPanel'
+import RightPanel from './RightPanel'
 
 export default function AppShell() {
   return (
@@ -10,7 +10,7 @@ export default function AppShell() {
         <main className="flex-1 overflow-hidden bg-background">
           <Outlet />
         </main>
-        <ChatPanel />
+        <RightPanel />
       </div>
     </div>
   )

--- a/src/components/layout/ChatPanel.jsx
+++ b/src/components/layout/ChatPanel.jsx
@@ -1,8 +1,10 @@
-import { MessageSquare, Send, Lock } from 'lucide-react'
+import { MessageSquare, Send, Lock, X, RotateCcw, Trash2, Key } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import LiveDot from '@/components/ui/LiveDot'
 import useAuthStore from '@/store/useAuthStore'
 import useEditModeStore from '@/store/useEditModeStore'
+import useChatPanelStore from '@/store/useChatPanelStore'
+import { useMyAccount } from '@/api/account'
 import EditPanel from './EditPanel'
 
 function LoginPrompt() {
@@ -71,15 +73,97 @@ function ChatMessages() {
   )
 }
 
+function AccountSettingsHeader() {
+  const setChatMode = useChatPanelStore((s) => s.setChatMode)
+  return (
+    <div className="h-chat-header flex items-center justify-between px-4 border-b border-stroke shrink-0">
+      <span className="text-[13px] font-semibold text-foreground">계좌 설정</span>
+      <button
+        onClick={() => setChatMode()}
+        aria-label="닫기"
+        className="p-1 text-foreground-tertiary hover:text-foreground transition-colors"
+      >
+        <X className="w-4 h-4" />
+      </button>
+    </div>
+  )
+}
+
+function AccountSettingsContent() {
+  const setChatMode = useChatPanelStore((s) => s.setChatMode)
+  const { user } = useAuthStore()
+  const { data: accountInfo } = useMyAccount()
+
+  const handleMenuClick = (label) => {
+    console.log(label)
+    // TODO: 각 메뉴 항목에 대한 동작 구현
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto flex flex-col">
+      {/* 계좌 정보 */}
+      <div className="px-4 py-4 border-b border-stroke-subtle bg-surface-subtle shrink-0">
+        <div className="text-[12px] font-semibold text-foreground mb-1">
+          {user?.name}
+        </div>
+        <div className="text-[11px] text-foreground-secondary">
+          {accountInfo?.accountNumber}
+        </div>
+        <div className="text-[10px] text-foreground-disabled mt-2">
+          상태: {accountInfo?.accountStatus}
+        </div>
+      </div>
+
+      {/* 메뉴 */}
+      <div className="flex-1 flex flex-col">
+        <button
+          onClick={() => handleMenuClick('계좌 비밀번호 변경')}
+          className="flex items-center gap-3 px-4 py-3 text-[12px] text-foreground hover:bg-surface-muted transition-colors text-left border-b border-stroke-subtle"
+        >
+          <Lock className="w-4 h-4 text-foreground-tertiary shrink-0" strokeWidth={2} />
+          <span>계좌 비밀번호 변경</span>
+        </button>
+        <button
+          onClick={() => handleMenuClick('리셋')}
+          className="flex items-center gap-3 px-4 py-3 text-[12px] text-foreground hover:bg-surface-muted transition-colors text-left border-b border-stroke-subtle"
+        >
+          <RotateCcw className="w-4 h-4 text-foreground-tertiary shrink-0" strokeWidth={2} />
+          <span>리셋</span>
+        </button>
+        <button
+          onClick={() => handleMenuClick('계좌 해지 신청')}
+          className="flex items-center gap-3 px-4 py-3 text-[12px] text-up hover:bg-up-bg transition-colors text-left border-b border-stroke-subtle"
+        >
+          <Trash2 className="w-4 h-4 shrink-0" strokeWidth={2} />
+          <span>계좌 해지 신청</span>
+        </button>
+        <button
+          onClick={() => handleMenuClick('계정 비밀번호 변경')}
+          className="flex items-center gap-3 px-4 py-3 text-[12px] text-foreground hover:bg-surface-muted transition-colors text-left"
+        >
+          <Key className="w-4 h-4 text-foreground-tertiary shrink-0" strokeWidth={2} />
+          <span>계정 비밀번호 변경</span>
+        </button>
+      </div>
+    </div>
+  )
+}
+
 export default function ChatPanel() {
   const { isAuthenticated, isRestoring } = useAuthStore()
   const { isEditMode } = useEditModeStore()
+  const mode = useChatPanelStore((s) => s.mode)
 
   if (isEditMode) return <EditPanel />
 
   return (
     <aside className="w-chat-panel flex flex-col bg-surface border-l border-stroke shrink-0">
-      {isRestoring ? (
+      {mode === 'account-settings' ? (
+        <>
+          <AccountSettingsHeader />
+          <AccountSettingsContent />
+        </>
+      ) : isRestoring ? (
         <>
           <ChatHeader />
           <ChatMessages />

--- a/src/components/layout/ChatPanel.jsx
+++ b/src/components/layout/ChatPanel.jsx
@@ -1,10 +1,8 @@
-import { MessageSquare, Send, Lock, X, RotateCcw, Trash2, Key } from 'lucide-react'
+import { MessageSquare, Send, Lock } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import LiveDot from '@/components/ui/LiveDot'
 import useAuthStore from '@/store/useAuthStore'
 import useEditModeStore from '@/store/useEditModeStore'
-import useChatPanelStore from '@/store/useChatPanelStore'
-import { useMyAccount } from '@/api/account'
 import EditPanel from './EditPanel'
 
 function LoginPrompt() {
@@ -73,114 +71,25 @@ function ChatMessages() {
   )
 }
 
-function AccountSettingsHeader() {
-  const setChatMode = useChatPanelStore((s) => s.setChatMode)
-  return (
-    <div className="h-chat-header flex items-center justify-between px-4 border-b border-stroke shrink-0">
-      <span className="text-[13px] font-semibold text-foreground">계좌 설정</span>
-      <button
-        onClick={() => setChatMode()}
-        aria-label="닫기"
-        className="p-1 text-foreground-tertiary hover:text-foreground transition-colors"
-      >
-        <X className="w-4 h-4" />
-      </button>
-    </div>
-  )
-}
-
-function AccountSettingsContent() {
-  const setChatMode = useChatPanelStore((s) => s.setChatMode)
-  const { user } = useAuthStore()
-  const { data: accountInfo } = useMyAccount()
-
-  const handleMenuClick = (label) => {
-    console.log(label)
-    // TODO: 각 메뉴 항목에 대한 동작 구현
-  }
-
-  return (
-    <div className="flex-1 overflow-y-auto flex flex-col">
-      {/* 계좌 정보 */}
-      <div className="px-4 py-4 border-b border-stroke-subtle bg-surface-subtle shrink-0">
-        <div className="text-[12px] font-semibold text-foreground mb-1">
-          {user?.name}
-        </div>
-        <div className="text-[11px] text-foreground-secondary">
-          {accountInfo?.accountNumber}
-        </div>
-        <div className="text-[10px] text-foreground-disabled mt-2">
-          상태: {accountInfo?.accountStatus}
-        </div>
-      </div>
-
-      {/* 메뉴 */}
-      <div className="flex-1 flex flex-col">
-        <button
-          onClick={() => handleMenuClick('계좌 비밀번호 변경')}
-          className="flex items-center gap-3 px-4 py-3 text-[12px] text-foreground hover:bg-surface-muted transition-colors text-left border-b border-stroke-subtle"
-        >
-          <Lock className="w-4 h-4 text-foreground-tertiary shrink-0" strokeWidth={2} />
-          <span>계좌 비밀번호 변경</span>
-        </button>
-        <button
-          onClick={() => handleMenuClick('리셋')}
-          className="flex items-center gap-3 px-4 py-3 text-[12px] text-foreground hover:bg-surface-muted transition-colors text-left border-b border-stroke-subtle"
-        >
-          <RotateCcw className="w-4 h-4 text-foreground-tertiary shrink-0" strokeWidth={2} />
-          <span>리셋</span>
-        </button>
-        <button
-          onClick={() => handleMenuClick('계좌 해지 신청')}
-          className="flex items-center gap-3 px-4 py-3 text-[12px] text-up hover:bg-up-bg transition-colors text-left border-b border-stroke-subtle"
-        >
-          <Trash2 className="w-4 h-4 shrink-0" strokeWidth={2} />
-          <span>계좌 해지 신청</span>
-        </button>
-        <button
-          onClick={() => handleMenuClick('계정 비밀번호 변경')}
-          className="flex items-center gap-3 px-4 py-3 text-[12px] text-foreground hover:bg-surface-muted transition-colors text-left"
-        >
-          <Key className="w-4 h-4 text-foreground-tertiary shrink-0" strokeWidth={2} />
-          <span>계정 비밀번호 변경</span>
-        </button>
-      </div>
-    </div>
-  )
-}
-
 export default function ChatPanel() {
   const { isAuthenticated, isRestoring } = useAuthStore()
-  const { isEditMode } = useEditModeStore()
-  const mode = useChatPanelStore((s) => s.mode)
-
-  if (isEditMode) return <EditPanel />
 
   return (
-    <aside className="w-chat-panel flex flex-col bg-surface border-l border-stroke shrink-0">
-      {mode === 'account-settings' ? (
+    <>
+      <ChatHeader />
+      {isRestoring ? (
         <>
-          <AccountSettingsHeader />
-          <AccountSettingsContent />
-        </>
-      ) : isRestoring ? (
-        <>
-          <ChatHeader />
           <ChatMessages />
           <ChatInput />
         </>
       ) : isAuthenticated ? (
         <>
-          <ChatHeader />
           <ChatMessages />
           <ChatInput />
         </>
       ) : (
-        <>
-          <ChatHeader />
-          <LoginPrompt />
-        </>
+        <LoginPrompt />
       )}
-    </aside>
+    </>
   )
 }

--- a/src/components/layout/RightPanel.jsx
+++ b/src/components/layout/RightPanel.jsx
@@ -1,0 +1,22 @@
+import useEditModeStore from '@/store/useEditModeStore'
+import useRightPanelStore from '@/store/useRightPanelStore'
+import EditPanel from './EditPanel'
+import ChatPanel from './ChatPanel'
+import AccountSettingsPanel from './AccountSettingsPanel'
+
+export default function RightPanel() {
+  const { isEditMode } = useEditModeStore()
+  const mode = useRightPanelStore((s) => s.mode)
+
+  if (isEditMode) return <EditPanel />
+
+  return (
+    <aside className="w-chat-panel flex flex-col bg-surface border-l border-stroke shrink-0">
+      {mode === 'account-settings' ? (
+        <AccountSettingsPanel />
+      ) : (
+        <ChatPanel />
+      )}
+    </aside>
+  )
+}

--- a/src/lib/validationSchemas.js
+++ b/src/lib/validationSchemas.js
@@ -1,0 +1,52 @@
+import { z } from 'zod'
+
+// Password schema - must be 8+ chars with letters, numbers, and special characters
+export const passwordSchema = z
+  .string()
+  .min(8, '비밀번호는 8자 이상이어야 합니다.')
+  .regex(/^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/, '비밀번호는 8자 이상, 영문+숫자+특수문자를 포함해야 합니다.')
+
+// PIN schema - exactly 4 digits
+export const pinSchema = z
+  .string()
+  .length(4, 'PIN은 4자리 숫자여야 합니다.')
+  .regex(/^\d+$/, 'PIN은 숫자만 입력 가능합니다.')
+
+// Change password form schema
+export const changePasswordSchema = z.object({
+  currentPassword: z.string().min(1, '현재 비밀번호를 입력해주세요.'),
+  newPassword: passwordSchema,
+  confirmPassword: z.string().min(1, '비밀번호 확인을 입력해주세요.'),
+}).refine(
+  (data) => data.newPassword === data.confirmPassword,
+  {
+    message: '새 비밀번호가 일치하지 않습니다.',
+    path: ['confirmPassword'],
+  }
+)
+
+// Change PIN form schema
+export const changePinSchema = z.object({
+  currentPin: pinSchema,
+  newPin: pinSchema,
+  confirmPin: z.string().length(4, 'PIN은 4자리 숫자여야 합니다.'),
+}).refine(
+  (data) => data.newPin === data.confirmPin,
+  {
+    message: '새 PIN이 일치하지 않습니다.',
+    path: ['confirmPin'],
+  }
+)
+
+// Reset account form schema
+export const resetAccountSchema = z.object({
+  accountPin: pinSchema,
+})
+
+// Close account form schema
+export const closeAccountSchema = z.object({
+  accountPin: pinSchema,
+  agreed: z.boolean().refine((val) => val === true, {
+    message: '약관에 동의해주세요.',
+  }),
+})

--- a/src/store/useChatPanelStore.js
+++ b/src/store/useChatPanelStore.js
@@ -1,0 +1,10 @@
+import { create } from 'zustand'
+
+const useChatPanelStore = create((set) => ({
+  mode: 'chat', // 'chat' | 'account-settings'
+
+  setChatMode: () => set({ mode: 'chat' }),
+  setAccountSettingsMode: () => set({ mode: 'account-settings' }),
+}))
+
+export default useChatPanelStore

--- a/src/store/useRightPanelStore.js
+++ b/src/store/useRightPanelStore.js
@@ -1,10 +1,10 @@
 import { create } from 'zustand'
 
-const useChatPanelStore = create((set) => ({
+const useRightPanelStore = create((set) => ({
   mode: 'chat', // 'chat' | 'account-settings'
 
   setChatMode: () => set({ mode: 'chat' }),
   setAccountSettingsMode: () => set({ mode: 'account-settings' }),
 }))
 
-export default useChatPanelStore
+export default useRightPanelStore


### PR DESCRIPTION
## 요약
계정 설정 패널 전체 기능 구현 및 백엔드 연동 완료

## 주요 변경사항
- 계정 비밀번호 변경 (패스워드 검증)
- 계좌 비밀번호 변경 (4자리 숫자, 가상 키보드)
- 계좌 리셋 (새 라운드 시작)
- 계좌 해지 (계정 폐쇄)
- Zod 검증 스키마 추가 (백엔드와 동일)
- 로그아웃 기능 추가
- 계좌번호 헤더 표시

## 테스트 항목
- [ ] 계정 비밀번호 변경 성공/실패
- [ ] 계좌 비밀번호 변경 성공/실패
- [ ] 리셋 기능 작동 확인
- [ ] 계좌 해지 기능 작동 확인
- [ ] 로그아웃 정상 작동
- [ ] 계좌번호 정상 표시