### PR TITLE
feat(dnd): 대시보드 위젯 drag&drop 순서 변경 및 EditPanel drag-to-add

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-accordion": "^1.2.2",
     "@radix-ui/react-dialog": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.71.2(react@19.2.4))
@@ -159,6 +168,28 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/core@1.9.0':
     resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
@@ -1699,6 +1730,31 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
 
   '@emnapi/core@1.9.0':
     dependencies:

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -11,7 +11,7 @@ import {
 import AppHeader from './AppHeader'
 import RightPanel from './RightPanel'
 import useWidgetStore, { canFitInGrid, canReorderWidgets, findInsertIndex } from '@/store/useWidgetStore'
-
+import useEditModeStore from '@/store/useEditModeStore'
 import useGridStore from '@/store/useGridStore'
 import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry'
 import { GRID_GAP, GRID_COLS, GRID_ROWS, gridElementRef } from '@/lib/gridConstants'
@@ -27,8 +27,8 @@ export default function AppShell() {
     clearPhantom,
     phantomWidget,
     setIsDraggingNewWidget,
-    setIsDraggingExistingWidget,
   } = useWidgetStore()
+  const { resyncWiggle } = useEditModeStore()
   const { cellWidth, cellHeight } = useGridStore()
   const preDragOrder = useRef(null)
   const lastOverId = useRef(null)
@@ -49,7 +49,6 @@ export default function AppShell() {
     const type = active.data.current?.type
     setActiveDrag({ id: active.id, data: active.data.current })
     if (type === 'existing-widget') {
-      setIsDraggingExistingWidget(true)
       preDragOrder.current = [...widgets]
       lastOverId.current = null
     } else if (type === 'new-widget') {
@@ -112,7 +111,7 @@ export default function AppShell() {
     lastOverId.current = null
     clearPhantom()
     setIsDraggingNewWidget(false)
-    setIsDraggingExistingWidget(false)
+    resyncWiggle()
 
     const type = active.data.current?.type
 
@@ -143,7 +142,7 @@ export default function AppShell() {
   function handleDragCancel() {
     clearPhantom()
     setIsDraggingNewWidget(false)
-    setIsDraggingExistingWidget(false)
+    resyncWiggle()
     if (preDragOrder.current) {
       setWidgetsOrder(preDragOrder.current)
     }

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { Outlet } from 'react-router-dom'
 import {
   DndContext,
@@ -10,11 +10,11 @@ import {
 } from '@dnd-kit/core'
 import AppHeader from './AppHeader'
 import RightPanel from './RightPanel'
-import useWidgetStore, { canFitInGrid, canReorderWidgets } from '@/store/useWidgetStore'
+import useWidgetStore, { canFitInGrid, canReorderWidgets, findInsertIndex } from '@/store/useWidgetStore'
 
 import useGridStore from '@/store/useGridStore'
 import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry'
-import { GRID_GAP } from '@/lib/gridConstants'
+import { GRID_GAP, GRID_COLS, GRID_ROWS, gridElementRef } from '@/lib/gridConstants'
 
 export default function AppShell() {
   const [activeDrag, setActiveDrag] = useState(null)
@@ -31,6 +31,14 @@ export default function AppShell() {
   const { cellWidth, cellHeight } = useGridStore()
   const preDragOrder = useRef(null)
   const lastOverId = useRef(null)
+  const pointerPos = useRef({ x: 0, y: 0 })
+
+  // 포인터 좌표를 실시간으로 추적 (handleDragMove에서 사용)
+  useEffect(() => {
+    const onMove = (e) => { pointerPos.current = { x: e.clientX, y: e.clientY } }
+    window.addEventListener('pointermove', onMove)
+    return () => window.removeEventListener('pointermove', onMove)
+  }, [])
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -47,6 +55,34 @@ export default function AppShell() {
     }
   }
 
+  /* new-widget 드래그 중 포인터 좌표 → grid cell → insertIndex 계산.
+     onDragOver보다 높은 빈도로 발생해 더 정확한 위치를 반영한다. */
+  function handleDragMove({ active }) {
+    if (active.data.current?.type !== 'new-widget') return
+    const el = gridElementRef.current
+    if (!el || !cellWidth || !cellHeight) return
+
+    const { variant } = active.data.current
+    if (!canFitInGrid(widgets, variant.colSpan, variant.rowSpan)) {
+      clearPhantom()
+      return
+    }
+
+    const rect = el.getBoundingClientRect()
+    const { x, y } = pointerPos.current
+
+    // 그리드 영역 밖이면 phantom 제거
+    if (x < rect.left || x > rect.right || y < rect.top || y > rect.bottom) {
+      clearPhantom()
+      return
+    }
+
+    const col = Math.max(0, Math.min(Math.floor((x - rect.left) / (cellWidth + GRID_GAP)), GRID_COLS - 1))
+    const row = Math.max(0, Math.min(Math.floor((y - rect.top) / (cellHeight + GRID_GAP)), GRID_ROWS - 1))
+    const insertIndex = findInsertIndex(widgets, row, col)
+    setPhantom({ insertIndex, colSpan: variant.colSpan, rowSpan: variant.rowSpan })
+  }
+
   function handleDragOver({ active, over }) {
     const type = active.data.current?.type
 
@@ -59,20 +95,12 @@ export default function AppShell() {
     if (over.id === lastOverId.current) return
     lastOverId.current = over.id
 
+    // existing-widget 재정렬만 처리 (new-widget phantom은 handleDragMove에서 처리)
     if (type === 'existing-widget') {
       if (active.id === over.id) return
       if (canReorderWidgets(widgets, active.id, over.id)) {
         reorderWidgets(active.id, over.id)
       }
-    } else if (type === 'new-widget') {
-      const { variant } = active.data.current
-      if (!canFitInGrid(widgets, variant.colSpan, variant.rowSpan)) {
-        clearPhantom()
-        return
-      }
-      const overIndex = widgets.findIndex((w) => w.instanceId === over.id)
-      const insertIndex = overIndex !== -1 ? overIndex : widgets.length
-      setPhantom({ insertIndex, colSpan: variant.colSpan, rowSpan: variant.rowSpan })
     }
   }
 
@@ -96,7 +124,10 @@ export default function AppShell() {
     preDragOrder.current = null
 
     if (type === 'new-widget') {
-      const isOverDashboard = widgets.some((w) => w.instanceId === over.id)
+      // 'dashboard-grid' droppable 또는 개별 위젯 위에 drop된 경우 모두 허용
+      const isOverDashboard =
+        over.id === 'dashboard-grid' ||
+        widgets.some((w) => w.instanceId === over.id)
       if (isOverDashboard) {
         const { widgetTypeId, variant } = active.data.current
         const insertIndex = savedPhantom?.insertIndex ?? widgets.length
@@ -155,6 +186,7 @@ export default function AppShell() {
       sensors={sensors}
       collisionDetection={closestCenter}
       onDragStart={handleDragStart}
+      onDragMove={handleDragMove}
       onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -1,17 +1,86 @@
+import { useState } from 'react'
 import { Outlet } from 'react-router-dom'
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+} from '@dnd-kit/core'
 import AppHeader from './AppHeader'
 import RightPanel from './RightPanel'
+import useWidgetStore from '@/store/useWidgetStore'
+import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry'
 
 export default function AppShell() {
-  return (
-    <div className="flex flex-col h-screen overflow-hidden">
-      <AppHeader />
-      <div className="flex flex-1 overflow-hidden">
-        <main className="flex-1 overflow-hidden bg-background">
-          <Outlet />
-        </main>
-        <RightPanel />
+  const [activeDrag, setActiveDrag] = useState(null)
+  const { widgets, reorderWidgets, addWidget } = useWidgetStore()
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  )
+
+  function handleDragStart({ active }) {
+    setActiveDrag({ id: active.id, data: active.data.current })
+  }
+
+  function handleDragEnd({ active, over }) {
+    setActiveDrag(null)
+    if (!over) return
+    const { type } = active.data.current ?? {}
+
+    if (type === 'existing-widget' && active.id !== over.id) {
+      reorderWidgets(active.id, over.id)
+    } else if (type === 'new-widget') {
+      // 대시보드 grid 위 또는 grid 내 어느 위젯 위에 드롭해도 추가
+      const isOverDashboard =
+        over.id === 'dashboard' || widgets.some((w) => w.instanceId === over.id)
+      if (isOverDashboard) {
+        const { widgetTypeId, variant } = active.data.current
+        addWidget(widgetTypeId, variant)
+      }
+    }
+  }
+
+  // DragOverlay: existing-widget 드래그 시 위젯 미리보기
+  let overlayContent = null
+  if (activeDrag?.data?.type === 'existing-widget') {
+    const w = widgets.find((w) => w.instanceId === activeDrag.id)
+    const Comp = w ? WIDGET_REGISTRY[w.widgetTypeId] : null
+    if (Comp && w) {
+      overlayContent = (
+        <div className="opacity-90 rotate-1 scale-105 shadow-widget-edit rounded-2xl cursor-grabbing">
+          <Comp variant={w.variantId} colSpan={w.colSpan} rowSpan={w.rowSpan} config={w.config} />
+        </div>
+      )
+    }
+  } else if (activeDrag?.data?.type === 'new-widget') {
+    const { variant } = activeDrag.data
+    overlayContent = (
+      <div className="opacity-90 rotate-1 scale-105 rounded-2xl bg-surface border-2 border-primary shadow-widget-edit cursor-grabbing flex items-center justify-center px-3 py-2">
+        <span className="text-[11px] text-primary font-semibold">{variant?.label}</span>
       </div>
-    </div>
+    )
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
+      <div className="flex flex-col h-screen overflow-hidden">
+        <AppHeader />
+        <div className="flex flex-1 overflow-hidden">
+          <main className="flex-1 overflow-hidden bg-background">
+            <Outlet />
+          </main>
+          <RightPanel />
+        </div>
+      </div>
+      <DragOverlay>{overlayContent}</DragOverlay>
+    </DndContext>
   )
 }

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -124,14 +124,14 @@ export default function AppShell() {
     preDragOrder.current = null
 
     if (type === 'new-widget') {
-      // 'dashboard-grid' droppable 또는 개별 위젯 위에 drop된 경우 모두 허용
+      // savedPhantom이 있어야만 대시보드 위에 유효하게 hover했다고 판단
+      // phantom 없으면 EditPanel 영역에서 drop한 것으로 간주해 추가하지 않음
       const isOverDashboard =
-        over.id === 'dashboard-grid' ||
-        widgets.some((w) => w.instanceId === over.id)
+        savedPhantom != null &&
+        (over.id === 'dashboard-grid' || widgets.some((w) => w.instanceId === over.id))
       if (isOverDashboard) {
         const { widgetTypeId, variant } = active.data.current
-        const insertIndex = savedPhantom?.insertIndex ?? widgets.length
-        addWidgetAt(widgetTypeId, variant, insertIndex)
+        addWidgetAt(widgetTypeId, variant, savedPhantom.insertIndex)
       }
     }
     // existing-widget: onDragOver에서 이미 reorder 완료

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -48,11 +48,16 @@ export default function AppShell() {
   }
 
   function handleDragOver({ active, over }) {
-    if (!over) return
+    const type = active.data.current?.type
+
+    if (!over) {
+      lastOverId.current = null
+      if (type === 'new-widget') clearPhantom()
+      return
+    }
+
     if (over.id === lastOverId.current) return
     lastOverId.current = over.id
-
-    const type = active.data.current?.type
 
     if (type === 'existing-widget') {
       if (active.id === over.id) return

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef } from 'react'
 import { Outlet } from 'react-router-dom'
 import {
   DndContext,
@@ -34,12 +34,9 @@ export default function AppShell() {
   const lastOverId = useRef(null)
   const pointerPos = useRef({ x: 0, y: 0 })
 
-  // 포인터 좌표를 실시간으로 추적 (handleDragMove에서 사용)
-  useEffect(() => {
-    const onMove = (e) => { pointerPos.current = { x: e.clientX, y: e.clientY } }
-    window.addEventListener('pointermove', onMove)
-    return () => window.removeEventListener('pointermove', onMove)
-  }, [])
+  // 포인터 좌표를 drag 중에만 추적 (handleDragMove에서 사용)
+  // 동일 참조로 등록·해제할 수 있도록 useRef에 저장
+  const onPointerMove = useRef((e) => { pointerPos.current = { x: e.clientX, y: e.clientY } }).current
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -48,6 +45,7 @@ export default function AppShell() {
   function handleDragStart({ active }) {
     const type = active.data.current?.type
     setActiveDrag({ id: active.id, data: active.data.current })
+    window.addEventListener('pointermove', onPointerMove)
     if (type === 'existing-widget') {
       preDragOrder.current = [...widgets]
       lastOverId.current = null
@@ -106,6 +104,7 @@ export default function AppShell() {
   }
 
   function handleDragEnd({ active, over }) {
+    window.removeEventListener('pointermove', onPointerMove)
     const savedPhantom = phantomWidget
     setActiveDrag(null)
     lastOverId.current = null
@@ -140,6 +139,7 @@ export default function AppShell() {
   }
 
   function handleDragCancel() {
+    window.removeEventListener('pointermove', onPointerMove)
     clearPhantom()
     setIsDraggingNewWidget(false)
     resyncWiggle()

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -27,6 +27,7 @@ export default function AppShell() {
     clearPhantom,
     phantomWidget,
     setIsDraggingNewWidget,
+    setIsDraggingExistingWidget,
   } = useWidgetStore()
   const { cellWidth, cellHeight } = useGridStore()
   const preDragOrder = useRef(null)
@@ -48,6 +49,7 @@ export default function AppShell() {
     const type = active.data.current?.type
     setActiveDrag({ id: active.id, data: active.data.current })
     if (type === 'existing-widget') {
+      setIsDraggingExistingWidget(true)
       preDragOrder.current = [...widgets]
       lastOverId.current = null
     } else if (type === 'new-widget') {
@@ -110,6 +112,7 @@ export default function AppShell() {
     lastOverId.current = null
     clearPhantom()
     setIsDraggingNewWidget(false)
+    setIsDraggingExistingWidget(false)
 
     const type = active.data.current?.type
 
@@ -140,6 +143,7 @@ export default function AppShell() {
   function handleDragCancel() {
     clearPhantom()
     setIsDraggingNewWidget(false)
+    setIsDraggingExistingWidget(false)
     if (preDragOrder.current) {
       setWidgetsOrder(preDragOrder.current)
     }

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -11,6 +11,7 @@ import {
 import AppHeader from './AppHeader'
 import RightPanel from './RightPanel'
 import useWidgetStore, { canFitInGrid, canReorderWidgets } from '@/store/useWidgetStore'
+
 import useGridStore from '@/store/useGridStore'
 import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry'
 import { GRID_GAP } from '@/lib/gridConstants'
@@ -25,6 +26,7 @@ export default function AppShell() {
     setPhantom,
     clearPhantom,
     phantomWidget,
+    setIsDraggingNewWidget,
   } = useWidgetStore()
   const { cellWidth, cellHeight } = useGridStore()
   const preDragOrder = useRef(null)
@@ -35,10 +37,13 @@ export default function AppShell() {
   )
 
   function handleDragStart({ active }) {
+    const type = active.data.current?.type
     setActiveDrag({ id: active.id, data: active.data.current })
-    if (active.data.current?.type === 'existing-widget') {
+    if (type === 'existing-widget') {
       preDragOrder.current = [...widgets]
       lastOverId.current = null
+    } else if (type === 'new-widget') {
+      setIsDraggingNewWidget(true)
     }
   }
 
@@ -71,6 +76,7 @@ export default function AppShell() {
     setActiveDrag(null)
     lastOverId.current = null
     clearPhantom()
+    setIsDraggingNewWidget(false)
 
     const type = active.data.current?.type
 
@@ -85,8 +91,7 @@ export default function AppShell() {
     preDragOrder.current = null
 
     if (type === 'new-widget') {
-      const isOverDashboard =
-        over.id === 'dashboard' || widgets.some((w) => w.instanceId === over.id)
+      const isOverDashboard = widgets.some((w) => w.instanceId === over.id)
       if (isOverDashboard) {
         const { widgetTypeId, variant } = active.data.current
         const insertIndex = savedPhantom?.insertIndex ?? widgets.length
@@ -98,6 +103,7 @@ export default function AppShell() {
 
   function handleDragCancel() {
     clearPhantom()
+    setIsDraggingNewWidget(false)
     if (preDragOrder.current) {
       setWidgetsOrder(preDragOrder.current)
     }

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { Outlet } from 'react-router-dom'
 import {
   DndContext,
@@ -10,12 +10,25 @@ import {
 } from '@dnd-kit/core'
 import AppHeader from './AppHeader'
 import RightPanel from './RightPanel'
-import useWidgetStore from '@/store/useWidgetStore'
+import useWidgetStore, { canFitInGrid, canReorderWidgets } from '@/store/useWidgetStore'
+import useGridStore from '@/store/useGridStore'
 import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry'
+import { GRID_GAP } from '@/lib/gridConstants'
 
 export default function AppShell() {
   const [activeDrag, setActiveDrag] = useState(null)
-  const { widgets, reorderWidgets, addWidget } = useWidgetStore()
+  const {
+    widgets,
+    reorderWidgets,
+    addWidgetAt,
+    setWidgetsOrder,
+    setPhantom,
+    clearPhantom,
+    phantomWidget,
+  } = useWidgetStore()
+  const { cellWidth, cellHeight } = useGridStore()
+  const preDragOrder = useRef(null)
+  const lastOverId = useRef(null)
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -23,45 +36,107 @@ export default function AppShell() {
 
   function handleDragStart({ active }) {
     setActiveDrag({ id: active.id, data: active.data.current })
+    if (active.data.current?.type === 'existing-widget') {
+      preDragOrder.current = [...widgets]
+      lastOverId.current = null
+    }
+  }
+
+  function handleDragOver({ active, over }) {
+    if (!over) return
+    if (over.id === lastOverId.current) return
+    lastOverId.current = over.id
+
+    const type = active.data.current?.type
+
+    if (type === 'existing-widget') {
+      if (active.id === over.id) return
+      if (canReorderWidgets(widgets, active.id, over.id)) {
+        reorderWidgets(active.id, over.id)
+      }
+    } else if (type === 'new-widget') {
+      const { variant } = active.data.current
+      if (!canFitInGrid(widgets, variant.colSpan, variant.rowSpan)) {
+        clearPhantom()
+        return
+      }
+      const overIndex = widgets.findIndex((w) => w.instanceId === over.id)
+      const insertIndex = overIndex !== -1 ? overIndex : widgets.length
+      setPhantom({ insertIndex, colSpan: variant.colSpan, rowSpan: variant.rowSpan })
+    }
   }
 
   function handleDragEnd({ active, over }) {
+    const savedPhantom = phantomWidget
     setActiveDrag(null)
-    if (!over) return
-    const { type } = active.data.current ?? {}
+    lastOverId.current = null
+    clearPhantom()
 
-    if (type === 'existing-widget' && active.id !== over.id) {
-      reorderWidgets(active.id, over.id)
-    } else if (type === 'new-widget') {
-      // 대시보드 grid 위 또는 grid 내 어느 위젯 위에 드롭해도 추가
+    const type = active.data.current?.type
+
+    if (!over) {
+      if (type === 'existing-widget' && preDragOrder.current) {
+        setWidgetsOrder(preDragOrder.current)
+      }
+      preDragOrder.current = null
+      return
+    }
+
+    preDragOrder.current = null
+
+    if (type === 'new-widget') {
       const isOverDashboard =
         over.id === 'dashboard' || widgets.some((w) => w.instanceId === over.id)
       if (isOverDashboard) {
         const { widgetTypeId, variant } = active.data.current
-        addWidget(widgetTypeId, variant)
+        const insertIndex = savedPhantom?.insertIndex ?? widgets.length
+        addWidgetAt(widgetTypeId, variant, insertIndex)
       }
     }
+    // existing-widget: onDragOver에서 이미 reorder 완료
   }
 
-  // DragOverlay: existing-widget 드래그 시 위젯 미리보기
-  let overlayContent = null
-  if (activeDrag?.data?.type === 'existing-widget') {
-    const w = widgets.find((w) => w.instanceId === activeDrag.id)
-    const Comp = w ? WIDGET_REGISTRY[w.widgetTypeId] : null
-    if (Comp && w) {
-      overlayContent = (
-        <div className="opacity-90 rotate-1 scale-105 shadow-widget-edit rounded-2xl cursor-grabbing">
-          <Comp variant={w.variantId} colSpan={w.colSpan} rowSpan={w.rowSpan} config={w.config} />
-        </div>
-      )
+  function handleDragCancel() {
+    clearPhantom()
+    if (preDragOrder.current) {
+      setWidgetsOrder(preDragOrder.current)
     }
-  } else if (activeDrag?.data?.type === 'new-widget') {
-    const { variant } = activeDrag.data
-    overlayContent = (
-      <div className="opacity-90 rotate-1 scale-105 rounded-2xl bg-surface border-2 border-primary shadow-widget-edit cursor-grabbing flex items-center justify-center px-3 py-2">
-        <span className="text-[11px] text-primary font-semibold">{variant?.label}</span>
-      </div>
-    )
+    preDragOrder.current = null
+    lastOverId.current = null
+    setActiveDrag(null)
+  }
+
+  // ── DragOverlay 렌더링 ────────────────────────────────────
+  let overlayContent = null
+
+  if (activeDrag && cellWidth && cellHeight) {
+    const type = activeDrag.data?.type
+
+    if (type === 'existing-widget') {
+      const w = widgets.find((w) => w.instanceId === activeDrag.id)
+      const Comp = w ? WIDGET_REGISTRY[w.widgetTypeId] : null
+      if (Comp && w) {
+        const ow = w.colSpan * cellWidth + (w.colSpan - 1) * GRID_GAP
+        const oh = w.rowSpan * cellHeight + (w.rowSpan - 1) * GRID_GAP
+        overlayContent = (
+          <div className="opacity-90 shadow-widget-edit cursor-grabbing" style={{ width: ow, height: oh }}>
+            <Comp variant={w.variantId} colSpan={w.colSpan} rowSpan={w.rowSpan} config={w.config} />
+          </div>
+        )
+      }
+    } else if (type === 'new-widget') {
+      const { widgetTypeId, variant } = activeDrag.data
+      const Comp = WIDGET_REGISTRY[widgetTypeId]
+      if (Comp) {
+        const ow = variant.colSpan * cellWidth + (variant.colSpan - 1) * GRID_GAP
+        const oh = variant.rowSpan * cellHeight + (variant.rowSpan - 1) * GRID_GAP
+        overlayContent = (
+          <div className="opacity-90 shadow-widget-edit cursor-grabbing" style={{ width: ow, height: oh }}>
+            <Comp variant={variant.id} colSpan={variant.colSpan} rowSpan={variant.rowSpan} />
+          </div>
+        )
+      }
+    }
   }
 
   return (
@@ -69,7 +144,9 @@ export default function AppShell() {
       sensors={sensors}
       collisionDetection={closestCenter}
       onDragStart={handleDragStart}
+      onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
     >
       <div className="flex flex-col h-screen overflow-hidden">
         <AppHeader />

--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, Plus } from 'lucide-react'
+import { ChevronLeft } from 'lucide-react'
 import { useDraggable } from '@dnd-kit/core'
 import { cn } from '@/lib/cn'
 import useGridStore from '@/store/useGridStore'
@@ -1027,7 +1027,6 @@ function VariantPreview({ variant }) {
 
 /* ── DraggableVariantItem ───────────────────────────────── */
 function DraggableVariantItem({ variant, widgetType, canAdd }) {
-  const { addWidget } = useWidgetStore()
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: `new-widget-${variant.id}`,
     disabled: !canAdd,
@@ -1048,20 +1047,15 @@ function DraggableVariantItem({ variant, widgetType, canAdd }) {
     >
       <VariantPreview variant={variant} />
       {canAdd ? (
-        /* hover 추가 오버레이 */
-        <button
-          aria-label={`${variant.label} 추가`}
-          onPointerDown={(e) => e.stopPropagation()}
-          onClick={() => addWidget(widgetType.id, variant)}
-          className="absolute inset-0 rounded-xl opacity-0 group-hover:opacity-100 bg-primary/10 border border-primary flex items-center justify-center transition-opacity duration-[150ms] cursor-pointer"
-        >
-          <div className="w-7 h-7 rounded-full bg-primary flex items-center justify-center shadow-primary-btn">
-            <Plus className="w-3.5 h-3.5 text-white" />
-          </div>
-        </button>
+        /* hover 드래그 힌트 오버레이 — pointer-events-none으로 drag 이벤트 차단 안 함 */
+        <div className="absolute inset-0 rounded-xl opacity-0 group-hover:opacity-100 bg-primary/10 border border-primary flex items-center justify-center transition-opacity duration-[150ms] pointer-events-none">
+          <span className="text-[10px] text-primary font-semibold bg-primary/10 px-2 py-0.5 rounded-full">
+            드래그하여 추가
+          </span>
+        </div>
       ) : (
         /* 공간 부족 오버레이 — 항상 표시 */
-        <div className="absolute inset-0 rounded-xl bg-background/60 border border-stroke flex items-center justify-center">
+        <div className="absolute inset-0 rounded-xl bg-background/60 border border-stroke flex items-center justify-center pointer-events-none">
           <span className="text-[10px] text-foreground-disabled font-medium">공간 부족</span>
         </div>
       )}
@@ -1107,7 +1101,7 @@ export default function WidgetSizeList({ widgetType, onBack }) {
           })}
         </div>
         <p className="text-[10px] text-foreground-disabled mt-4 text-center">
-          클릭하거나 대시보드로 드래그하여 추가
+          대시보드로 드래그하여 추가
         </p>
       </div>
     </>

--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -1,4 +1,5 @@
 import { ChevronLeft, Plus } from 'lucide-react'
+import { useDraggable } from '@dnd-kit/core'
 import { cn } from '@/lib/cn'
 import useGridStore from '@/store/useGridStore'
 import useWidgetStore, { canFitInGrid } from '@/store/useWidgetStore'
@@ -1024,9 +1025,53 @@ function VariantPreview({ variant }) {
   )
 }
 
+/* ── DraggableVariantItem ───────────────────────────────── */
+function DraggableVariantItem({ variant, widgetType, canAdd }) {
+  const { addWidget } = useWidgetStore()
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `new-widget-${variant.id}`,
+    disabled: !canAdd,
+    data: { type: 'new-widget', widgetTypeId: widgetType.id, variant },
+  })
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn(
+        'relative group',
+        widthClass(variant.colSpan),
+        canAdd ? 'cursor-grab' : 'cursor-default',
+        isDragging && 'opacity-40',
+      )}
+      {...attributes}
+      {...listeners}
+    >
+      <VariantPreview variant={variant} />
+      {canAdd ? (
+        /* hover 추가 오버레이 */
+        <button
+          aria-label={`${variant.label} 추가`}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={() => addWidget(widgetType.id, variant)}
+          className="absolute inset-0 rounded-xl opacity-0 group-hover:opacity-100 bg-primary/10 border border-primary flex items-center justify-center transition-opacity duration-[150ms] cursor-pointer"
+        >
+          <div className="w-7 h-7 rounded-full bg-primary flex items-center justify-center shadow-primary-btn">
+            <Plus className="w-3.5 h-3.5 text-white" />
+          </div>
+        </button>
+      ) : (
+        /* 공간 부족 오버레이 — 항상 표시 */
+        <div className="absolute inset-0 rounded-xl bg-background/60 border border-stroke flex items-center justify-center">
+          <span className="text-[10px] text-foreground-disabled font-medium">공간 부족</span>
+        </div>
+      )}
+    </div>
+  )
+}
+
 /* ── WidgetSizeList ─────────────────────────────────────── */
 export default function WidgetSizeList({ widgetType, onBack }) {
-  const { widgets, addWidget } = useWidgetStore()
+  const { widgets } = useWidgetStore()
 
   return (
     <>
@@ -1052,34 +1097,17 @@ export default function WidgetSizeList({ widgetType, onBack }) {
           {widgetType.variants.map((variant) => {
             const canAdd = canFitInGrid(widgets, variant.colSpan, variant.rowSpan)
             return (
-              <div
+              <DraggableVariantItem
                 key={variant.id}
-                className={cn('relative group', widthClass(variant.colSpan))}
-              >
-                <VariantPreview variant={variant} />
-                {canAdd ? (
-                  /* hover 추가 오버레이 */
-                  <button
-                    aria-label={`${variant.label} 추가`}
-                    onClick={() => { addWidget(widgetType.id, variant) }}
-                    className="absolute inset-0 rounded-xl opacity-0 group-hover:opacity-100 bg-primary/10 border border-primary flex items-center justify-center transition-opacity duration-[150ms]"
-                  >
-                    <div className="w-7 h-7 rounded-full bg-primary flex items-center justify-center shadow-primary-btn">
-                      <Plus className="w-3.5 h-3.5 text-white" />
-                    </div>
-                  </button>
-                ) : (
-                  /* 공간 부족 오버레이 — 항상 표시 */
-                  <div className="absolute inset-0 rounded-xl bg-background/60 border border-stroke flex items-center justify-center">
-                    <span className="text-[10px] text-foreground-disabled font-medium">공간 부족</span>
-                  </div>
-                )}
-              </div>
+                variant={variant}
+                widgetType={widgetType}
+                canAdd={canAdd}
+              />
             )
           })}
         </div>
         <p className="text-[10px] text-foreground-disabled mt-4 text-center">
-          클릭하여 대시보드에 추가
+          클릭하거나 대시보드로 드래그하여 추가
         </p>
       </div>
     </>

--- a/src/components/widgets/BalanceWidget.jsx
+++ b/src/components/widgets/BalanceWidget.jsx
@@ -1,4 +1,3 @@
-import LiveDot from '@/components/ui/LiveDot'
 import LockedOverlay from '@/components/ui/LockedOverlay'
 import useAuthStore from '@/store/useAuthStore'
 import WidgetCard from './WidgetCard'
@@ -9,9 +8,8 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
 
   return (
     <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-      <div className="flex items-center justify-between mb-2 shrink-0">
+      <div className="mb-2 shrink-0">
         <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">계좌 잔고</span>
-        <LiveDot />
       </div>
 
       {variant === 'balance-lg' ? (

--- a/src/components/widgets/ExchangeWidget.jsx
+++ b/src/components/widgets/ExchangeWidget.jsx
@@ -1,4 +1,3 @@
-import LiveDot from '@/components/ui/LiveDot'
 import LockedOverlay from '@/components/ui/LockedOverlay'
 import useAuthStore from '@/store/useAuthStore'
 import WidgetCard from './WidgetCard'
@@ -50,9 +49,8 @@ export default function ExchangeWidget({ variant = 'exchange-sm', colSpan = 1, r
     ]
     return (
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-        <div className="flex items-center justify-between mb-1 shrink-0">
+        <div className="mb-1 shrink-0">
           <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
-          <LiveDot />
         </div>
         <div className="flex flex-1 min-h-0 divide-x divide-stroke">
           {cols3x1.map(({ pair, rate, change, rateSize, flex, pr, pl }, i) => {
@@ -91,9 +89,8 @@ export default function ExchangeWidget({ variant = 'exchange-sm', colSpan = 1, r
     ]
     return (
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-        <div className="flex items-center justify-between mb-1 shrink-0">
+        <div className="mb-1 shrink-0">
           <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
-          <LiveDot />
         </div>
         <div className="flex flex-1 min-h-0 divide-x divide-stroke">
           {cols2x1.map(({ pair, rate, change, rateSize, flex, pr, pl }, i) => {
@@ -128,9 +125,8 @@ export default function ExchangeWidget({ variant = 'exchange-sm', colSpan = 1, r
   if (variant === 'exchange-2x2') {
     return (
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-        <div className="flex items-center justify-between mb-1 shrink-0">
+        <div className="mb-1 shrink-0">
           <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
-          <LiveDot />
         </div>
         <div className="shrink-0">
           <div className="text-[9px] text-foreground-disabled">USD / KRW</div>

--- a/src/components/widgets/SortableWidgetCard.jsx
+++ b/src/components/widgets/SortableWidgetCard.jsx
@@ -1,32 +1,40 @@
-import { useSortable } from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
+import { useCallback } from 'react'
+import { useDraggable, useDroppable } from '@dnd-kit/core'
 import { cn } from '@/lib/cn'
 import useEditModeStore from '@/store/useEditModeStore'
 
 /**
- * 대시보드 위젯을 dnd-kit sortable item으로 래핑.
- * - grid col-span / row-span 처리 (WidgetCard에서 이 역할을 위임받음)
+ * 대시보드 위젯을 dnd-kit draggable + droppable item으로 래핑.
+ * - SortableContext/useSortable 미사용 → droppableRects 구독 루프 방지
+ * - grid col-span / row-span 처리
  * - isEditMode일 때만 drag 활성화
  * - isDragging 시 원본 자리 placeholder 유지 (opacity: 0)
  */
 export default function SortableWidgetCard({ instanceId, colSpan = 1, rowSpan = 1, children }) {
   const { isEditMode } = useEditModeStore()
 
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+  const { attributes, listeners, setNodeRef: setDraggableRef, isDragging } = useDraggable({
     id: instanceId,
     disabled: !isEditMode,
     data: { type: 'existing-widget', instanceId },
   })
 
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-  }
+  const { setNodeRef: setDroppableRef } = useDroppable({
+    id: instanceId,
+    data: { type: 'existing-widget', instanceId },
+  })
+
+  const setNodeRef = useCallback(
+    (node) => {
+      setDraggableRef(node)
+      setDroppableRef(node)
+    },
+    [setDraggableRef, setDroppableRef],
+  )
 
   return (
     <div
       ref={setNodeRef}
-      style={style}
       className={cn(
         'h-full',
         isEditMode && 'cursor-grab',

--- a/src/components/widgets/SortableWidgetCard.jsx
+++ b/src/components/widgets/SortableWidgetCard.jsx
@@ -1,0 +1,43 @@
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { cn } from '@/lib/cn'
+import useEditModeStore from '@/store/useEditModeStore'
+
+/**
+ * 대시보드 위젯을 dnd-kit sortable item으로 래핑.
+ * - grid col-span / row-span 처리 (WidgetCard에서 이 역할을 위임받음)
+ * - isEditMode일 때만 drag 활성화
+ * - isDragging 시 원본 자리 placeholder 유지 (opacity: 0)
+ */
+export default function SortableWidgetCard({ instanceId, colSpan = 1, rowSpan = 1, children }) {
+  const { isEditMode } = useEditModeStore()
+
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: instanceId,
+    disabled: !isEditMode,
+    data: { type: 'existing-widget', instanceId },
+  })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        'h-full',
+        isEditMode && 'cursor-grab',
+        colSpan === 3 ? 'col-span-3' : colSpan === 2 ? 'col-span-2' : 'col-span-1',
+        rowSpan === 2 ? 'row-span-2' : '',
+        isDragging && 'opacity-0',
+      )}
+      {...attributes}
+      {...listeners}
+    >
+      {children}
+    </div>
+  )
+}

--- a/src/components/widgets/SortableWidgetCard.jsx
+++ b/src/components/widgets/SortableWidgetCard.jsx
@@ -10,7 +10,7 @@ import useEditModeStore from '@/store/useEditModeStore'
  * - isEditMode일 때만 drag 활성화
  * - isDragging 시 원본 자리 placeholder 유지 (opacity: 0)
  */
-export default function SortableWidgetCard({ instanceId, colSpan = 1, rowSpan = 1, children }) {
+export default function SortableWidgetCard({ instanceId, colSpan = 1, rowSpan = 1, gridCol, gridRow, children }) {
   const { isEditMode } = useEditModeStore()
 
   const { attributes, listeners, setNodeRef: setDraggableRef, isDragging } = useDraggable({
@@ -35,13 +35,12 @@ export default function SortableWidgetCard({ instanceId, colSpan = 1, rowSpan = 
   return (
     <div
       ref={setNodeRef}
-      className={cn(
-        'h-full',
-        isEditMode && 'cursor-grab',
-        colSpan === 3 ? 'col-span-3' : colSpan === 2 ? 'col-span-2' : 'col-span-1',
-        rowSpan === 2 ? 'row-span-2' : '',
-        isDragging && 'opacity-0',
-      )}
+      className={cn('h-full', isEditMode && 'cursor-grab', isDragging && 'opacity-0')}
+      style={
+        gridCol && gridRow
+          ? { gridColumn: `${gridCol} / span ${colSpan}`, gridRow: `${gridRow} / span ${rowSpan}` }
+          : undefined
+      }
       {...attributes}
       {...listeners}
     >

--- a/src/components/widgets/WidgetCard.jsx
+++ b/src/components/widgets/WidgetCard.jsx
@@ -1,9 +1,11 @@
 import useEditModeStore from '@/store/useEditModeStore'
+import useWidgetStore from '@/store/useWidgetStore'
 import EditHandle from './EditHandle'
 import { cn } from '@/lib/cn'
 
 export default function WidgetCard({ children, className = '', onDelete }) {
-  const { isEditMode } = useEditModeStore()
+  const { isEditMode, wiggleDelay } = useEditModeStore()
+  const { isDraggingExistingWidget } = useWidgetStore()
 
   return (
     <div
@@ -14,6 +16,10 @@ export default function WidgetCard({ children, className = '', onDelete }) {
           : 'cursor-pointer transition-[transform] duration-[200ms] hover:-translate-y-px',
         className,
       )}
+      style={isEditMode ? {
+        animationDelay: `${wiggleDelay}ms`,
+        animationPlayState: isDraggingExistingWidget ? 'paused' : 'running',
+      } : undefined}
     >
       {isEditMode && <EditHandle onDelete={onDelete} />}
       {/* 콘텐츠 클리핑 래퍼 — 핸들은 relative 부모 기준으로 바깥에 위치 */}

--- a/src/components/widgets/WidgetCard.jsx
+++ b/src/components/widgets/WidgetCard.jsx
@@ -1,11 +1,9 @@
 import useEditModeStore from '@/store/useEditModeStore'
-import useWidgetStore from '@/store/useWidgetStore'
 import EditHandle from './EditHandle'
 import { cn } from '@/lib/cn'
 
 export default function WidgetCard({ children, className = '', onDelete }) {
   const { isEditMode, wiggleDelay, wiggleSyncKey } = useEditModeStore()
-  const { isDraggingNewWidget } = useWidgetStore()
 
   return (
     /* 바깥 div는 안정적 — EditHandle의 absolute 기준점 역할 */
@@ -20,10 +18,7 @@ export default function WidgetCard({ children, className = '', onDelete }) {
             ? 'animate-wiggle'
             : 'cursor-pointer transition-[transform] duration-[200ms] hover:-translate-y-px',
         )}
-        style={isEditMode ? {
-          animationDelay: `${wiggleDelay}ms`,
-          animationPlayState: isDraggingNewWidget ? 'paused' : 'running',
-        } : undefined}
+        style={isEditMode ? { animationDelay: `${wiggleDelay}ms` } : undefined}
       >
         <div
           className={cn(

--- a/src/components/widgets/WidgetCard.jsx
+++ b/src/components/widgets/WidgetCard.jsx
@@ -2,18 +2,16 @@ import useEditModeStore from '@/store/useEditModeStore'
 import EditHandle from './EditHandle'
 import { cn } from '@/lib/cn'
 
-export default function WidgetCard({ children, colSpan = 1, rowSpan = 1, className = '', onDelete }) {
+export default function WidgetCard({ children, className = '', onDelete }) {
   const { isEditMode } = useEditModeStore()
 
   return (
     <div
       className={cn(
-        'relative',
+        'relative h-full',
         isEditMode
-          ? 'animate-wiggle cursor-grab'
+          ? 'animate-wiggle'
           : 'cursor-pointer transition-[transform] duration-[200ms] hover:-translate-y-px',
-        colSpan === 3 ? 'col-span-3' : colSpan === 2 ? 'col-span-2' : 'col-span-1',
-        rowSpan === 2 ? 'row-span-2' : '',
         className,
       )}
     >

--- a/src/components/widgets/WidgetCard.jsx
+++ b/src/components/widgets/WidgetCard.jsx
@@ -4,35 +4,38 @@ import EditHandle from './EditHandle'
 import { cn } from '@/lib/cn'
 
 export default function WidgetCard({ children, className = '', onDelete }) {
-  const { isEditMode, wiggleDelay } = useEditModeStore()
-  const { isDraggingExistingWidget } = useWidgetStore()
+  const { isEditMode, wiggleDelay, wiggleSyncKey } = useEditModeStore()
+  const { isDraggingNewWidget } = useWidgetStore()
 
   return (
-    <div
-      className={cn(
-        'relative h-full',
-        isEditMode
-          ? 'animate-wiggle'
-          : 'cursor-pointer transition-[transform] duration-[200ms] hover:-translate-y-px',
-        className,
-      )}
-      style={isEditMode ? {
-        animationDelay: `${wiggleDelay}ms`,
-        animationPlayState: isDraggingExistingWidget ? 'paused' : 'running',
-      } : undefined}
-    >
+    /* 바깥 div는 안정적 — EditHandle의 absolute 기준점 역할 */
+    <div className={cn('relative h-full', className)}>
       {isEditMode && <EditHandle onDelete={onDelete} />}
-      {/* 콘텐츠 클리핑 래퍼 — 핸들은 relative 부모 기준으로 바깥에 위치 */}
+      {/* animation wrapper: wiggleSyncKey 변경 시 remount → 모든 위젯 animation 동시 재시작 */}
       <div
+        key={isEditMode ? wiggleSyncKey : undefined}
         className={cn(
-          'h-full bg-surface border rounded-2xl p-[14px_16px]',
-          'flex flex-col overflow-hidden',
+          'h-full',
           isEditMode
-            ? 'border-stroke-input shadow-widget-edit'
-            : 'border-stroke transition-[border-color,box-shadow] duration-[200ms] hover:border-widget-border-hover hover:shadow-widget-hover',
+            ? 'animate-wiggle'
+            : 'cursor-pointer transition-[transform] duration-[200ms] hover:-translate-y-px',
         )}
+        style={isEditMode ? {
+          animationDelay: `${wiggleDelay}ms`,
+          animationPlayState: isDraggingNewWidget ? 'paused' : 'running',
+        } : undefined}
       >
-        {children}
+        <div
+          className={cn(
+            'h-full bg-surface border rounded-2xl p-[14px_16px]',
+            'flex flex-col overflow-hidden',
+            isEditMode
+              ? 'border-stroke-input shadow-widget-edit'
+              : 'border-stroke transition-[border-color,box-shadow] duration-[200ms] hover:border-widget-border-hover hover:shadow-widget-hover',
+          )}
+        >
+          {children}
+        </div>
       </div>
     </div>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -101,7 +101,7 @@
   /* ── Animation ── */
   --animate-pulse-dot:  pulse-dot 2000ms ease-in-out infinite;
   --animate-bubble-in:  bubble-in 220ms ease both;
-  --animate-wiggle:     wiggle 900ms ease-in-out infinite;
+  --animate-wiggle:     wiggle 1100ms ease-in-out infinite;
   --animate-modal-in:   modal-in 200ms ease both;
 }
 
@@ -119,9 +119,9 @@
 }
 
 @keyframes wiggle {
-  0%   { transform: rotate(-1.2deg) translateY(-0.8px); }
-  50%  { transform: rotate(1.2deg) translateY(-0.8px); }
-  100% { transform: rotate(-1.2deg) translateY(-0.8px); }
+  0%   { transform: rotate(-0.7deg) translateY(-0.5px); }
+  50%  { transform: rotate(0.7deg) translateY(-0.5px); }
+  100% { transform: rotate(-0.7deg) translateY(-0.5px); }
 }
 
 @keyframes modal-in {

--- a/src/index.css
+++ b/src/index.css
@@ -101,7 +101,7 @@
   /* ── Animation ── */
   --animate-pulse-dot:  pulse-dot 2000ms ease-in-out infinite;
   --animate-bubble-in:  bubble-in 220ms ease both;
-  --animate-wiggle:     wiggle 550ms ease-in-out infinite;
+  --animate-wiggle:     wiggle 900ms ease-in-out infinite;
   --animate-modal-in:   modal-in 200ms ease both;
 }
 
@@ -119,9 +119,9 @@
 }
 
 @keyframes wiggle {
-  0%, 100% { transform: rotate(0deg) translateY(0); }
-  20%       { transform: rotate(-1.2deg) translateY(-1px); }
-  60%       { transform: rotate(1.2deg) translateY(-1px); }
+  0%   { transform: rotate(-1.2deg) translateY(-0.8px); }
+  50%  { transform: rotate(1.2deg) translateY(-0.8px); }
+  100% { transform: rotate(-1.2deg) translateY(-0.8px); }
 }
 
 @keyframes modal-in {

--- a/src/lib/gridConstants.js
+++ b/src/lib/gridConstants.js
@@ -8,3 +8,6 @@ export const MIN_CELL_HEIGHT = 130
 
 export const MIN_GRID_WIDTH = MIN_CELL_WIDTH * GRID_COLS + GRID_GAP * (GRID_COLS - 1)
 export const MIN_GRID_HEIGHT = MIN_CELL_HEIGHT * GRID_ROWS + GRID_GAP * (GRID_ROWS - 1)
+
+// 대시보드 그리드 DOM 요소 참조 — AppShell에서 포인터 좌표 → grid cell 변환에 사용
+export const gridElementRef = { current: null }

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -117,7 +117,7 @@ export default function HomePage() {
         <div
           ref={setGridRef}
           className={cn(
-            'grid grid-cols-6 grid-rows-4 grid-flow-dense gap-[10px] w-full h-full rounded-2xl transition-[outline] duration-[150ms]',
+            'grid grid-cols-6 grid-rows-4 gap-[10px] w-full h-full rounded-2xl transition-[outline] duration-[150ms]',
             isDraggingNewWidget && 'outline outline-2 outline-primary',
             isDraggingNewWidget && phantomWidget && 'bg-primary-light/30',
           )}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,6 +1,5 @@
-import { useEffect, useRef, useMemo } from 'react'
+import { useEffect, useRef } from 'react'
 import { Pencil } from 'lucide-react'
-import { SortableContext } from '@dnd-kit/sortable'
 import LiveDot from '@/components/ui/LiveDot'
 import useEditModeStore from '@/store/useEditModeStore'
 import useGridStore from '@/store/useGridStore'
@@ -10,11 +9,6 @@ import AddWidgetSlot from '@/components/widgets/AddWidgetSlot'
 import SortableWidgetCard from '@/components/widgets/SortableWidgetCard'
 import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry'
 import { GRID_COLS, GRID_ROWS, GRID_GAP, MIN_GRID_WIDTH, MIN_GRID_HEIGHT, MIN_CELL_WIDTH, MIN_CELL_HEIGHT } from '@/lib/gridConstants'
-
-/* col-span/row-span이 혼재한 그리드에서 rectSortingStrategy 사용 시
-   드래그 중 위젯 크기/위치 왜곡 발생 → 시각적 이동 비활성화.
-   모듈 레벨 정의로 참조 고정 — 인라인 정의 시 useDndContext 구독 루프 유발. */
-const noopSortingStrategy = () => null
 
 /* new-widget 드래그 중 삽입 예정 위치를 표시하는 placeholder.
    pointer-events-none으로 drag 이벤트를 그대로 통과시킨다. */
@@ -61,10 +55,7 @@ export default function HomePage() {
     return () => observer.disconnect()
   }, [setCellSize, setPreviewCellSize])
 
-  // widgets 참조가 바뀔 때만 새 배열 생성 — 안정적 참조로 SortableContext 재측정 루프 방지
-  const sortableItems = useMemo(() => widgets.map((w) => w.instanceId), [widgets])
-
-  // phantom을 지정 인덱스에 삽입한 display 전용 배열 (SortableContext items와 분리)
+  // phantom을 지정 인덱스에 삽입한 display 전용 배열
   const displayWidgets = phantomWidget
     ? [
         ...widgets.slice(0, phantomWidget.insertIndex),
@@ -113,47 +104,43 @@ export default function HomePage() {
         'flex-1 min-h-0',
         isEditMode ? 'overflow-visible' : 'overflow-auto',
       )}>
-        {/* SortableContext items는 실제 위젯만 (phantom 제외).
-            useMemo로 참조 안정화 → droppableRects 재측정 루프 방지 */}
-        <SortableContext items={sortableItems} strategy={noopSortingStrategy}>
-          <div
-            ref={gridRef}
-            className={cn(
-              'grid grid-cols-6 grid-rows-4 grid-flow-dense gap-[10px] w-full h-full rounded-2xl transition-[outline] duration-[150ms]',
-              isDraggingNewWidget && 'outline outline-2 outline-primary',
-              isDraggingNewWidget && phantomWidget && 'bg-primary-light/30',
-            )}
-            style={{
-              minWidth: `${MIN_GRID_WIDTH}px`,
-              minHeight: `${MIN_GRID_HEIGHT}px`,
-            }}
-          >
-            {displayWidgets.map((w) => {
-              if (w.instanceId === '__phantom__') {
-                return <PhantomSlot key="__phantom__" colSpan={w.colSpan} rowSpan={w.rowSpan} />
-              }
-              const Component = WIDGET_REGISTRY[w.widgetTypeId]
-              if (!Component) return null
-              return (
-                <SortableWidgetCard
-                  key={w.instanceId}
-                  instanceId={w.instanceId}
+        <div
+          ref={gridRef}
+          className={cn(
+            'grid grid-cols-6 grid-rows-4 grid-flow-dense gap-[10px] w-full h-full rounded-2xl transition-[outline] duration-[150ms]',
+            isDraggingNewWidget && 'outline outline-2 outline-primary',
+            isDraggingNewWidget && phantomWidget && 'bg-primary-light/30',
+          )}
+          style={{
+            minWidth: `${MIN_GRID_WIDTH}px`,
+            minHeight: `${MIN_GRID_HEIGHT}px`,
+          }}
+        >
+          {displayWidgets.map((w) => {
+            if (w.instanceId === '__phantom__') {
+              return <PhantomSlot key="__phantom__" colSpan={w.colSpan} rowSpan={w.rowSpan} />
+            }
+            const Component = WIDGET_REGISTRY[w.widgetTypeId]
+            if (!Component) return null
+            return (
+              <SortableWidgetCard
+                key={w.instanceId}
+                instanceId={w.instanceId}
+                colSpan={w.colSpan}
+                rowSpan={w.rowSpan}
+              >
+                <Component
+                  variant={w.variantId}
                   colSpan={w.colSpan}
                   rowSpan={w.rowSpan}
-                >
-                  <Component
-                    variant={w.variantId}
-                    colSpan={w.colSpan}
-                    rowSpan={w.rowSpan}
-                    config={w.config}
-                    onDelete={() => removeWidget(w.instanceId)}
-                  />
-                </SortableWidgetCard>
-              )
-            })}
-            {!isEditMode && !phantomWidget && canFitInGrid(widgets, 1, 1) && <AddWidgetSlot />}
-          </div>
-        </SortableContext>
+                  config={w.config}
+                  onDelete={() => removeWidget(w.instanceId)}
+                />
+              </SortableWidgetCard>
+            )
+          })}
+          {!isEditMode && !phantomWidget && canFitInGrid(widgets, 1, 1) && <AddWidgetSlot />}
+        </div>
       </div>
     </div>
   )

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,20 +1,45 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Pencil } from 'lucide-react'
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+} from '@dnd-kit/core'
+import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable'
 import LiveDot from '@/components/ui/LiveDot'
 import useEditModeStore from '@/store/useEditModeStore'
 import useGridStore from '@/store/useGridStore'
 import useWidgetStore, { canFitInGrid } from '@/store/useWidgetStore'
 import { cn } from '@/lib/cn'
 import AddWidgetSlot from '@/components/widgets/AddWidgetSlot'
+import SortableWidgetCard from '@/components/widgets/SortableWidgetCard'
 import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry'
 import { GRID_COLS, GRID_ROWS, GRID_GAP, MIN_GRID_WIDTH, MIN_GRID_HEIGHT, MIN_CELL_WIDTH, MIN_CELL_HEIGHT } from '@/lib/gridConstants'
 
 export default function HomePage() {
   const { isEditMode } = useEditModeStore()
   const { setCellSize, setPreviewCellSize } = useGridStore()
-  const { widgets, removeWidget } = useWidgetStore()
+  const { widgets, removeWidget, reorderWidgets } = useWidgetStore()
   const gridRef = useRef(null)
   const isEditModeRef = useRef(isEditMode)
+  const [activeId, setActiveId] = useState(null)
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  )
+
+  function handleDragStart({ active }) {
+    setActiveId(active.id)
+  }
+
+  function handleDragEnd({ active, over }) {
+    setActiveId(null)
+    if (!over || active.id === over.id) return
+    reorderWidgets(active.id, over.id)
+  }
 
   useEffect(() => {
     isEditModeRef.current = isEditMode
@@ -42,73 +67,105 @@ export default function HomePage() {
     return () => observer.disconnect()
   }, [setCellSize, setPreviewCellSize])
 
+  const activeWidget = activeId ? widgets.find((w) => w.instanceId === activeId) : null
+  const ActiveComponent = activeWidget ? WIDGET_REGISTRY[activeWidget.widgetTypeId] : null
+
   return (
-    <div className="flex flex-col h-full overflow-hidden p-3 gap-2.5">
-      {/* 서브바 */}
-      <div className="flex items-center justify-between shrink-0 px-1 h-7">
-        <div className="flex items-center gap-2">
-          <span className="text-[13px] font-bold text-foreground">나의 대시보드</span>
-          {isEditMode ? (
-            <div className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-primary-light border border-primary-border">
-              <Pencil className="w-2.5 h-2.5 text-primary" strokeWidth={2.5} />
-              <span className="text-[10px] text-primary font-semibold">편집 중</span>
-            </div>
-          ) : (
-            <div className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-background border border-stroke">
-              <LiveDot size="sm" />
-              <span className="text-[10px] text-foreground-disabled">실시간 반영</span>
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
+      <div className="flex flex-col h-full overflow-hidden p-3 gap-2.5">
+        {/* 서브바 */}
+        <div className="flex items-center justify-between shrink-0 px-1 h-7">
+          <div className="flex items-center gap-2">
+            <span className="text-[13px] font-bold text-foreground">나의 대시보드</span>
+            {isEditMode ? (
+              <div className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-primary-light border border-primary-border">
+                <Pencil className="w-2.5 h-2.5 text-primary" strokeWidth={2.5} />
+                <span className="text-[10px] text-primary font-semibold">편집 중</span>
+              </div>
+            ) : (
+              <div className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-background border border-stroke">
+                <LiveDot size="sm" />
+                <span className="text-[10px] text-foreground-disabled">실시간 반영</span>
+              </div>
+            )}
+          </div>
+          {isEditMode && (
+            <div className="flex items-center gap-2">
+              {/* 페이지 인디케이터 */}
+              <div className="flex items-center gap-1.5">
+                <div className="w-4 h-1.5 rounded-full bg-primary" />
+                <div className="w-1.5 h-1.5 rounded-full bg-stroke-input" />
+                <div className="w-1.5 h-1.5 rounded-full bg-stroke-input" />
+              </div>
+              <button className="flex items-center gap-1 px-2.5 py-1 rounded-lg border border-stroke-input bg-surface text-foreground-tertiary text-[11px] font-medium hover:border-primary hover:text-primary hover:bg-primary-light transition-all duration-[150ms]">
+                <svg className="w-[11px] h-[11px]" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h7" />
+                </svg>
+                페이지 편집
+              </button>
             </div>
           )}
         </div>
-        {isEditMode && (
-          <div className="flex items-center gap-2">
-            {/* 페이지 인디케이터 */}
-            <div className="flex items-center gap-1.5">
-              <div className="w-4 h-1.5 rounded-full bg-primary" />
-              <div className="w-1.5 h-1.5 rounded-full bg-stroke-input" />
-              <div className="w-1.5 h-1.5 rounded-full bg-stroke-input" />
-            </div>
-            <button className="flex items-center gap-1 px-2.5 py-1 rounded-lg border border-stroke-input bg-surface text-foreground-tertiary text-[11px] font-medium hover:border-primary hover:text-primary hover:bg-primary-light transition-all duration-[150ms]">
-              <svg className="w-[11px] h-[11px]" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h7" />
-              </svg>
-              페이지 편집
-            </button>
-          </div>
-        )}
-      </div>
 
-      {/* 스크롤 래퍼: 최솟값 이하로 줄어들면 스크롤 */}
-      <div className={cn(
-        'flex-1 min-h-0',
-        isEditMode ? 'overflow-visible' : 'overflow-auto',
-      )}>
-        {/* 위젯 그리드: 6열 × 4행, 뷰포트 채움 / 최솟값 이하면 고정 */}
-        <div
-          ref={gridRef}
-          className="grid grid-cols-6 grid-rows-4 grid-flow-dense gap-[10px] w-full h-full"
-          style={{
-            minWidth: `${MIN_GRID_WIDTH}px`,
-            minHeight: `${MIN_GRID_HEIGHT}px`,
-          }}
-        >
-          {widgets.map((w) => {
-            const Component = WIDGET_REGISTRY[w.widgetTypeId]
-            if (!Component) return null
-            return (
-              <Component
-                key={w.instanceId}
-                variant={w.variantId}
-                colSpan={w.colSpan}
-                rowSpan={w.rowSpan}
-                config={w.config}
-                onDelete={() => removeWidget(w.instanceId)}
-              />
-            )
-          })}
-          {!isEditMode && canFitInGrid(widgets, 1, 1) && <AddWidgetSlot />}
+        {/* 스크롤 래퍼: 최솟값 이하로 줄어들면 스크롤 */}
+        <div className={cn(
+          'flex-1 min-h-0',
+          isEditMode ? 'overflow-visible' : 'overflow-auto',
+        )}>
+          {/* 위젯 그리드: 6열 × 4행, 뷰포트 채움 / 최솟값 이하면 고정 */}
+          <SortableContext items={widgets.map((w) => w.instanceId)} strategy={rectSortingStrategy}>
+            <div
+              ref={gridRef}
+              className="grid grid-cols-6 grid-rows-4 grid-flow-dense gap-[10px] w-full h-full"
+              style={{
+                minWidth: `${MIN_GRID_WIDTH}px`,
+                minHeight: `${MIN_GRID_HEIGHT}px`,
+              }}
+            >
+              {widgets.map((w) => {
+                const Component = WIDGET_REGISTRY[w.widgetTypeId]
+                if (!Component) return null
+                return (
+                  <SortableWidgetCard
+                    key={w.instanceId}
+                    instanceId={w.instanceId}
+                    colSpan={w.colSpan}
+                    rowSpan={w.rowSpan}
+                  >
+                    <Component
+                      variant={w.variantId}
+                      colSpan={w.colSpan}
+                      rowSpan={w.rowSpan}
+                      config={w.config}
+                      onDelete={() => removeWidget(w.instanceId)}
+                    />
+                  </SortableWidgetCard>
+                )
+              })}
+              {!isEditMode && canFitInGrid(widgets, 1, 1) && <AddWidgetSlot />}
+            </div>
+          </SortableContext>
         </div>
       </div>
-    </div>
+
+      {/* 드래그 중 마우스를 따라다니는 위젯 미리보기 */}
+      <DragOverlay>
+        {ActiveComponent && (
+          <div className="opacity-90 rotate-1 scale-105 shadow-widget-edit rounded-2xl cursor-grabbing">
+            <ActiveComponent
+              variant={activeWidget.variantId}
+              colSpan={activeWidget.colSpan}
+              rowSpan={activeWidget.rowSpan}
+              config={activeWidget.config}
+            />
+          </div>
+        )}
+      </DragOverlay>
+    </DndContext>
   )
 }

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -12,6 +12,11 @@ import SortableWidgetCard from '@/components/widgets/SortableWidgetCard'
 import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry'
 import { GRID_COLS, GRID_ROWS, GRID_GAP, MIN_GRID_WIDTH, MIN_GRID_HEIGHT, MIN_CELL_WIDTH, MIN_CELL_HEIGHT } from '@/lib/gridConstants'
 
+/* col-span/row-span이 혼재한 그리드에서 rectSortingStrategy 사용 시
+   드래그 중 위젯 크기/위치 왜곡 발생 → 시각적 이동 비활성화.
+   모듈 레벨 정의로 참조 고정 (인라인 정의 시 매 렌더마다 새 참조 → SortableContext 무한 루프). */
+const noopSortingStrategy = () => null
+
 /* new-widget 드래그 중 삽입 예정 위치를 표시하는 placeholder.
    pointer-events-none으로 drag 이벤트를 그대로 통과시킨다. */
 function PhantomSlot({ colSpan, rowSpan }) {
@@ -116,7 +121,7 @@ export default function HomePage() {
         isEditMode ? 'overflow-visible' : 'overflow-auto',
       )}>
         {/* SortableContext items는 실제 위젯만 (phantom 제외) */}
-        <SortableContext items={widgets.map((w) => w.instanceId)} strategy={() => null}>
+        <SortableContext items={widgets.map((w) => w.instanceId)} strategy={noopSortingStrategy}>
           <div
             ref={setGridRef}
             className={cn(

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,7 +1,6 @@
-import { useEffect, useRef, useCallback } from 'react'
+import { useEffect, useRef, useMemo } from 'react'
 import { Pencil } from 'lucide-react'
 import { SortableContext } from '@dnd-kit/sortable'
-import { useDroppable, useDndContext } from '@dnd-kit/core'
 import LiveDot from '@/components/ui/LiveDot'
 import useEditModeStore from '@/store/useEditModeStore'
 import useGridStore from '@/store/useGridStore'
@@ -14,7 +13,7 @@ import { GRID_COLS, GRID_ROWS, GRID_GAP, MIN_GRID_WIDTH, MIN_GRID_HEIGHT, MIN_CE
 
 /* col-span/row-span이 혼재한 그리드에서 rectSortingStrategy 사용 시
    드래그 중 위젯 크기/위치 왜곡 발생 → 시각적 이동 비활성화.
-   모듈 레벨 정의로 참조 고정 (인라인 정의 시 매 렌더마다 새 참조 → SortableContext 무한 루프). */
+   모듈 레벨 정의로 참조 고정 — 인라인 정의 시 useDndContext 구독 루프 유발. */
 const noopSortingStrategy = () => null
 
 /* new-widget 드래그 중 삽입 예정 위치를 표시하는 placeholder.
@@ -34,18 +33,9 @@ function PhantomSlot({ colSpan, rowSpan }) {
 export default function HomePage() {
   const { isEditMode } = useEditModeStore()
   const { setCellSize, setPreviewCellSize } = useGridStore()
-  const { widgets, removeWidget, phantomWidget } = useWidgetStore()
+  const { widgets, removeWidget, phantomWidget, isDraggingNewWidget } = useWidgetStore()
   const gridRef = useRef(null)
   const isEditModeRef = useRef(isEditMode)
-
-  const { setNodeRef: setDropRef, isOver } = useDroppable({ id: 'dashboard' })
-  const { active } = useDndContext()
-  const isDraggingNewWidget = active?.data?.current?.type === 'new-widget'
-
-  const setGridRef = useCallback((el) => {
-    gridRef.current = el
-    setDropRef(el)
-  }, [setDropRef])
 
   useEffect(() => {
     isEditModeRef.current = isEditMode
@@ -70,6 +60,9 @@ export default function HomePage() {
     observer.observe(el)
     return () => observer.disconnect()
   }, [setCellSize, setPreviewCellSize])
+
+  // widgets 참조가 바뀔 때만 새 배열 생성 — 안정적 참조로 SortableContext 재측정 루프 방지
+  const sortableItems = useMemo(() => widgets.map((w) => w.instanceId), [widgets])
 
   // phantom을 지정 인덱스에 삽입한 display 전용 배열 (SortableContext items와 분리)
   const displayWidgets = phantomWidget
@@ -120,14 +113,15 @@ export default function HomePage() {
         'flex-1 min-h-0',
         isEditMode ? 'overflow-visible' : 'overflow-auto',
       )}>
-        {/* SortableContext items는 실제 위젯만 (phantom 제외) */}
-        <SortableContext items={widgets.map((w) => w.instanceId)} strategy={noopSortingStrategy}>
+        {/* SortableContext items는 실제 위젯만 (phantom 제외).
+            useMemo로 참조 안정화 → droppableRects 재측정 루프 방지 */}
+        <SortableContext items={sortableItems} strategy={noopSortingStrategy}>
           <div
-            ref={setGridRef}
+            ref={gridRef}
             className={cn(
               'grid grid-cols-6 grid-rows-4 grid-flow-dense gap-[10px] w-full h-full rounded-2xl transition-[outline] duration-[150ms]',
               isDraggingNewWidget && 'outline outline-2 outline-primary',
-              isDraggingNewWidget && isOver && 'bg-primary-light/30',
+              isDraggingNewWidget && phantomWidget && 'bg-primary-light/30',
             )}
             style={{
               minWidth: `${MIN_GRID_WIDTH}px`,

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -12,19 +12,31 @@ import SortableWidgetCard from '@/components/widgets/SortableWidgetCard'
 import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry'
 import { GRID_COLS, GRID_ROWS, GRID_GAP, MIN_GRID_WIDTH, MIN_GRID_HEIGHT, MIN_CELL_WIDTH, MIN_CELL_HEIGHT } from '@/lib/gridConstants'
 
+/* new-widget 드래그 중 삽입 예정 위치를 표시하는 placeholder.
+   pointer-events-none으로 drag 이벤트를 그대로 통과시킨다. */
+function PhantomSlot({ colSpan, rowSpan }) {
+  return (
+    <div
+      className={cn(
+        'rounded-2xl border-2 border-dashed border-primary bg-primary-light/30 pointer-events-none',
+        colSpan === 3 ? 'col-span-3' : colSpan === 2 ? 'col-span-2' : 'col-span-1',
+        rowSpan === 2 ? 'row-span-2' : '',
+      )}
+    />
+  )
+}
+
 export default function HomePage() {
   const { isEditMode } = useEditModeStore()
   const { setCellSize, setPreviewCellSize } = useGridStore()
-  const { widgets, removeWidget } = useWidgetStore()
+  const { widgets, removeWidget, phantomWidget } = useWidgetStore()
   const gridRef = useRef(null)
   const isEditModeRef = useRef(isEditMode)
 
-  // new-widget 드래그 중 대시보드 드롭존 활성화
   const { setNodeRef: setDropRef, isOver } = useDroppable({ id: 'dashboard' })
   const { active } = useDndContext()
   const isDraggingNewWidget = active?.data?.current?.type === 'new-widget'
 
-  // gridRef + dropRef 병합
   const setGridRef = useCallback((el) => {
     gridRef.current = el
     setDropRef(el)
@@ -38,7 +50,6 @@ export default function HomePage() {
     const el = gridRef.current
     if (!el) return
 
-    // ResizeObserver 콜백은 비동기 → 초기값을 MIN으로 설정해 측정 전 공백 방지
     setCellSize(MIN_CELL_WIDTH, MIN_CELL_HEIGHT)
 
     const observer = new ResizeObserver(([entry]) => {
@@ -46,7 +57,6 @@ export default function HomePage() {
       const cellWidth = (width - GRID_GAP * (GRID_COLS - 1)) / GRID_COLS
       const cellHeight = (height - GRID_GAP * (GRID_ROWS - 1)) / GRID_ROWS
       setCellSize(cellWidth, cellHeight)
-      // EditPanel 미열림 상태(full grid)의 셀 크기만 preview 기준으로 저장
       if (!isEditModeRef.current) {
         setPreviewCellSize(cellWidth, cellHeight)
       }
@@ -55,6 +65,15 @@ export default function HomePage() {
     observer.observe(el)
     return () => observer.disconnect()
   }, [setCellSize, setPreviewCellSize])
+
+  // phantom을 지정 인덱스에 삽입한 display 전용 배열 (SortableContext items와 분리)
+  const displayWidgets = phantomWidget
+    ? [
+        ...widgets.slice(0, phantomWidget.insertIndex),
+        { instanceId: '__phantom__', colSpan: phantomWidget.colSpan, rowSpan: phantomWidget.rowSpan },
+        ...widgets.slice(phantomWidget.insertIndex),
+      ]
+    : widgets
 
   return (
     <div className="flex flex-col h-full overflow-hidden p-3 gap-2.5">
@@ -76,7 +95,6 @@ export default function HomePage() {
         </div>
         {isEditMode && (
           <div className="flex items-center gap-2">
-            {/* 페이지 인디케이터 */}
             <div className="flex items-center gap-1.5">
               <div className="w-4 h-1.5 rounded-full bg-primary" />
               <div className="w-1.5 h-1.5 rounded-full bg-stroke-input" />
@@ -92,14 +110,12 @@ export default function HomePage() {
         )}
       </div>
 
-      {/* 스크롤 래퍼: 최솟값 이하로 줄어들면 스크롤 */}
+      {/* 스크롤 래퍼 */}
       <div className={cn(
         'flex-1 min-h-0',
         isEditMode ? 'overflow-visible' : 'overflow-auto',
       )}>
-        {/* 위젯 그리드: 6열 × 4행, 뷰포트 채움 / 최솟값 이하면 고정 */}
-        {/* noopSortingStrategy: col-span/row-span이 혼재한 그리드에서 rectSortingStrategy 사용 시
-            드래그 중 위젯 크기/위치 왜곡이 발생하므로 시각적 이동을 비활성화. */}
+        {/* SortableContext items는 실제 위젯만 (phantom 제외) */}
         <SortableContext items={widgets.map((w) => w.instanceId)} strategy={() => null}>
           <div
             ref={setGridRef}
@@ -113,7 +129,10 @@ export default function HomePage() {
               minHeight: `${MIN_GRID_HEIGHT}px`,
             }}
           >
-            {widgets.map((w) => {
+            {displayWidgets.map((w) => {
+              if (w.instanceId === '__phantom__') {
+                return <PhantomSlot key="__phantom__" colSpan={w.colSpan} rowSpan={w.rowSpan} />
+              }
               const Component = WIDGET_REGISTRY[w.widgetTypeId]
               if (!Component) return null
               return (
@@ -133,7 +152,7 @@ export default function HomePage() {
                 </SortableWidgetCard>
               )
             })}
-            {!isEditMode && canFitInGrid(widgets, 1, 1) && <AddWidgetSlot />}
+            {!isEditMode && !phantomWidget && canFitInGrid(widgets, 1, 1) && <AddWidgetSlot />}
           </div>
         </SortableContext>
       </div>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,14 +1,7 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useCallback } from 'react'
 import { Pencil } from 'lucide-react'
-import {
-  DndContext,
-  DragOverlay,
-  PointerSensor,
-  useSensor,
-  useSensors,
-  closestCenter,
-} from '@dnd-kit/core'
 import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable'
+import { useDroppable, useDndContext } from '@dnd-kit/core'
 import LiveDot from '@/components/ui/LiveDot'
 import useEditModeStore from '@/store/useEditModeStore'
 import useGridStore from '@/store/useGridStore'
@@ -22,24 +15,20 @@ import { GRID_COLS, GRID_ROWS, GRID_GAP, MIN_GRID_WIDTH, MIN_GRID_HEIGHT, MIN_CE
 export default function HomePage() {
   const { isEditMode } = useEditModeStore()
   const { setCellSize, setPreviewCellSize } = useGridStore()
-  const { widgets, removeWidget, reorderWidgets } = useWidgetStore()
+  const { widgets, removeWidget } = useWidgetStore()
   const gridRef = useRef(null)
   const isEditModeRef = useRef(isEditMode)
-  const [activeId, setActiveId] = useState(null)
 
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
-  )
+  // new-widget 드래그 중 대시보드 드롭존 활성화
+  const { setNodeRef: setDropRef, isOver } = useDroppable({ id: 'dashboard' })
+  const { active } = useDndContext()
+  const isDraggingNewWidget = active?.data?.current?.type === 'new-widget'
 
-  function handleDragStart({ active }) {
-    setActiveId(active.id)
-  }
-
-  function handleDragEnd({ active, over }) {
-    setActiveId(null)
-    if (!over || active.id === over.id) return
-    reorderWidgets(active.id, over.id)
-  }
+  // gridRef + dropRef 병합
+  const setGridRef = useCallback((el) => {
+    gridRef.current = el
+    setDropRef(el)
+  }, [setDropRef])
 
   useEffect(() => {
     isEditModeRef.current = isEditMode
@@ -67,105 +56,85 @@ export default function HomePage() {
     return () => observer.disconnect()
   }, [setCellSize, setPreviewCellSize])
 
-  const activeWidget = activeId ? widgets.find((w) => w.instanceId === activeId) : null
-  const ActiveComponent = activeWidget ? WIDGET_REGISTRY[activeWidget.widgetTypeId] : null
-
   return (
-    <DndContext
-      sensors={sensors}
-      collisionDetection={closestCenter}
-      onDragStart={handleDragStart}
-      onDragEnd={handleDragEnd}
-    >
-      <div className="flex flex-col h-full overflow-hidden p-3 gap-2.5">
-        {/* 서브바 */}
-        <div className="flex items-center justify-between shrink-0 px-1 h-7">
-          <div className="flex items-center gap-2">
-            <span className="text-[13px] font-bold text-foreground">나의 대시보드</span>
-            {isEditMode ? (
-              <div className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-primary-light border border-primary-border">
-                <Pencil className="w-2.5 h-2.5 text-primary" strokeWidth={2.5} />
-                <span className="text-[10px] text-primary font-semibold">편집 중</span>
-              </div>
-            ) : (
-              <div className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-background border border-stroke">
-                <LiveDot size="sm" />
-                <span className="text-[10px] text-foreground-disabled">실시간 반영</span>
-              </div>
-            )}
-          </div>
-          {isEditMode && (
-            <div className="flex items-center gap-2">
-              {/* 페이지 인디케이터 */}
-              <div className="flex items-center gap-1.5">
-                <div className="w-4 h-1.5 rounded-full bg-primary" />
-                <div className="w-1.5 h-1.5 rounded-full bg-stroke-input" />
-                <div className="w-1.5 h-1.5 rounded-full bg-stroke-input" />
-              </div>
-              <button className="flex items-center gap-1 px-2.5 py-1 rounded-lg border border-stroke-input bg-surface text-foreground-tertiary text-[11px] font-medium hover:border-primary hover:text-primary hover:bg-primary-light transition-all duration-[150ms]">
-                <svg className="w-[11px] h-[11px]" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h7" />
-                </svg>
-                페이지 편집
-              </button>
+    <div className="flex flex-col h-full overflow-hidden p-3 gap-2.5">
+      {/* 서브바 */}
+      <div className="flex items-center justify-between shrink-0 px-1 h-7">
+        <div className="flex items-center gap-2">
+          <span className="text-[13px] font-bold text-foreground">나의 대시보드</span>
+          {isEditMode ? (
+            <div className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-primary-light border border-primary-border">
+              <Pencil className="w-2.5 h-2.5 text-primary" strokeWidth={2.5} />
+              <span className="text-[10px] text-primary font-semibold">편집 중</span>
+            </div>
+          ) : (
+            <div className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-background border border-stroke">
+              <LiveDot size="sm" />
+              <span className="text-[10px] text-foreground-disabled">실시간 반영</span>
             </div>
           )}
         </div>
-
-        {/* 스크롤 래퍼: 최솟값 이하로 줄어들면 스크롤 */}
-        <div className={cn(
-          'flex-1 min-h-0',
-          isEditMode ? 'overflow-visible' : 'overflow-auto',
-        )}>
-          {/* 위젯 그리드: 6열 × 4행, 뷰포트 채움 / 최솟값 이하면 고정 */}
-          <SortableContext items={widgets.map((w) => w.instanceId)} strategy={rectSortingStrategy}>
-            <div
-              ref={gridRef}
-              className="grid grid-cols-6 grid-rows-4 grid-flow-dense gap-[10px] w-full h-full"
-              style={{
-                minWidth: `${MIN_GRID_WIDTH}px`,
-                minHeight: `${MIN_GRID_HEIGHT}px`,
-              }}
-            >
-              {widgets.map((w) => {
-                const Component = WIDGET_REGISTRY[w.widgetTypeId]
-                if (!Component) return null
-                return (
-                  <SortableWidgetCard
-                    key={w.instanceId}
-                    instanceId={w.instanceId}
-                    colSpan={w.colSpan}
-                    rowSpan={w.rowSpan}
-                  >
-                    <Component
-                      variant={w.variantId}
-                      colSpan={w.colSpan}
-                      rowSpan={w.rowSpan}
-                      config={w.config}
-                      onDelete={() => removeWidget(w.instanceId)}
-                    />
-                  </SortableWidgetCard>
-                )
-              })}
-              {!isEditMode && canFitInGrid(widgets, 1, 1) && <AddWidgetSlot />}
+        {isEditMode && (
+          <div className="flex items-center gap-2">
+            {/* 페이지 인디케이터 */}
+            <div className="flex items-center gap-1.5">
+              <div className="w-4 h-1.5 rounded-full bg-primary" />
+              <div className="w-1.5 h-1.5 rounded-full bg-stroke-input" />
+              <div className="w-1.5 h-1.5 rounded-full bg-stroke-input" />
             </div>
-          </SortableContext>
-        </div>
-      </div>
-
-      {/* 드래그 중 마우스를 따라다니는 위젯 미리보기 */}
-      <DragOverlay>
-        {ActiveComponent && (
-          <div className="opacity-90 rotate-1 scale-105 shadow-widget-edit rounded-2xl cursor-grabbing">
-            <ActiveComponent
-              variant={activeWidget.variantId}
-              colSpan={activeWidget.colSpan}
-              rowSpan={activeWidget.rowSpan}
-              config={activeWidget.config}
-            />
+            <button className="flex items-center gap-1 px-2.5 py-1 rounded-lg border border-stroke-input bg-surface text-foreground-tertiary text-[11px] font-medium hover:border-primary hover:text-primary hover:bg-primary-light transition-all duration-[150ms]">
+              <svg className="w-[11px] h-[11px]" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h7" />
+              </svg>
+              페이지 편집
+            </button>
           </div>
         )}
-      </DragOverlay>
-    </DndContext>
+      </div>
+
+      {/* 스크롤 래퍼: 최솟값 이하로 줄어들면 스크롤 */}
+      <div className={cn(
+        'flex-1 min-h-0',
+        isEditMode ? 'overflow-visible' : 'overflow-auto',
+      )}>
+        {/* 위젯 그리드: 6열 × 4행, 뷰포트 채움 / 최솟값 이하면 고정 */}
+        <SortableContext items={widgets.map((w) => w.instanceId)} strategy={rectSortingStrategy}>
+          <div
+            ref={setGridRef}
+            className={cn(
+              'grid grid-cols-6 grid-rows-4 grid-flow-dense gap-[10px] w-full h-full rounded-2xl transition-[outline] duration-[150ms]',
+              isDraggingNewWidget && 'outline outline-2 outline-primary',
+              isDraggingNewWidget && isOver && 'bg-primary-light/30',
+            )}
+            style={{
+              minWidth: `${MIN_GRID_WIDTH}px`,
+              minHeight: `${MIN_GRID_HEIGHT}px`,
+            }}
+          >
+            {widgets.map((w) => {
+              const Component = WIDGET_REGISTRY[w.widgetTypeId]
+              if (!Component) return null
+              return (
+                <SortableWidgetCard
+                  key={w.instanceId}
+                  instanceId={w.instanceId}
+                  colSpan={w.colSpan}
+                  rowSpan={w.rowSpan}
+                >
+                  <Component
+                    variant={w.variantId}
+                    colSpan={w.colSpan}
+                    rowSpan={w.rowSpan}
+                    config={w.config}
+                    onDelete={() => removeWidget(w.instanceId)}
+                  />
+                </SortableWidgetCard>
+              )
+            })}
+            {!isEditMode && canFitInGrid(widgets, 1, 1) && <AddWidgetSlot />}
+          </div>
+        </SortableContext>
+      </div>
+    </div>
   )
 }

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -4,7 +4,7 @@ import { useDroppable } from '@dnd-kit/core'
 import LiveDot from '@/components/ui/LiveDot'
 import useEditModeStore from '@/store/useEditModeStore'
 import useGridStore from '@/store/useGridStore'
-import useWidgetStore, { canFitInGrid } from '@/store/useWidgetStore'
+import useWidgetStore, { canFitInGrid, computeLayout } from '@/store/useWidgetStore'
 import { cn } from '@/lib/cn'
 import AddWidgetSlot from '@/components/widgets/AddWidgetSlot'
 import SortableWidgetCard from '@/components/widgets/SortableWidgetCard'
@@ -13,14 +13,15 @@ import { GRID_COLS, GRID_ROWS, GRID_GAP, MIN_GRID_WIDTH, MIN_GRID_HEIGHT, MIN_CE
 
 /* new-widget 드래그 중 삽입 예정 위치를 표시하는 placeholder.
    pointer-events-none으로 drag 이벤트를 그대로 통과시킨다. */
-function PhantomSlot({ colSpan, rowSpan }) {
+function PhantomSlot({ colSpan, rowSpan, gridCol, gridRow }) {
   return (
     <div
-      className={cn(
-        'rounded-2xl border-2 border-dashed border-primary bg-primary-light/30 pointer-events-none',
-        colSpan === 3 ? 'col-span-3' : colSpan === 2 ? 'col-span-2' : 'col-span-1',
-        rowSpan === 2 ? 'row-span-2' : '',
-      )}
+      className="rounded-2xl border-2 border-dashed border-primary bg-primary-light/30 pointer-events-none"
+      style={
+        gridCol && gridRow
+          ? { gridColumn: `${gridCol} / span ${colSpan}`, gridRow: `${gridRow} / span ${rowSpan}` }
+          : undefined
+      }
     />
   )
 }
@@ -74,6 +75,9 @@ export default function HomePage() {
       ]
     : widgets
 
+  // CSS auto-placement 대신 명시적 grid 좌표를 계산해 레이아웃 불일치/overflow 방지
+  const layout = computeLayout(displayWidgets)
+
   return (
     <div className="flex flex-col h-full overflow-hidden p-3 gap-2.5">
       {/* 서브바 */}
@@ -126,9 +130,18 @@ export default function HomePage() {
             minHeight: `${MIN_GRID_HEIGHT}px`,
           }}
         >
-          {displayWidgets.map((w) => {
+          {displayWidgets.map((w, i) => {
+            const pos = layout[i]
             if (w.instanceId === '__phantom__') {
-              return <PhantomSlot key="__phantom__" colSpan={w.colSpan} rowSpan={w.rowSpan} />
+              return (
+                <PhantomSlot
+                  key="__phantom__"
+                  colSpan={w.colSpan}
+                  rowSpan={w.rowSpan}
+                  gridCol={pos?.col}
+                  gridRow={pos?.row}
+                />
+              )
             }
             const Component = WIDGET_REGISTRY[w.widgetTypeId]
             if (!Component) return null
@@ -138,6 +151,8 @@ export default function HomePage() {
                 instanceId={w.instanceId}
                 colSpan={w.colSpan}
                 rowSpan={w.rowSpan}
+                gridCol={pos?.col}
+                gridRow={pos?.row}
               >
                 <Component
                   variant={w.variantId}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useCallback } from 'react'
 import { Pencil } from 'lucide-react'
+import { useDroppable } from '@dnd-kit/core'
 import LiveDot from '@/components/ui/LiveDot'
 import useEditModeStore from '@/store/useEditModeStore'
 import useGridStore from '@/store/useGridStore'
@@ -8,7 +9,7 @@ import { cn } from '@/lib/cn'
 import AddWidgetSlot from '@/components/widgets/AddWidgetSlot'
 import SortableWidgetCard from '@/components/widgets/SortableWidgetCard'
 import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry'
-import { GRID_COLS, GRID_ROWS, GRID_GAP, MIN_GRID_WIDTH, MIN_GRID_HEIGHT, MIN_CELL_WIDTH, MIN_CELL_HEIGHT } from '@/lib/gridConstants'
+import { GRID_COLS, GRID_ROWS, GRID_GAP, MIN_GRID_WIDTH, MIN_GRID_HEIGHT, MIN_CELL_WIDTH, MIN_CELL_HEIGHT, gridElementRef } from '@/lib/gridConstants'
 
 /* new-widget 드래그 중 삽입 예정 위치를 표시하는 placeholder.
    pointer-events-none으로 drag 이벤트를 그대로 통과시킨다. */
@@ -30,6 +31,15 @@ export default function HomePage() {
   const { widgets, removeWidget, phantomWidget, isDraggingNewWidget } = useWidgetStore()
   const gridRef = useRef(null)
   const isEditModeRef = useRef(isEditMode)
+
+  // 빈 대시보드에서도 드롭 가능하도록 그리드 전체를 droppable로 등록
+  const { setNodeRef: setGridDroppableRef } = useDroppable({ id: 'dashboard-grid' })
+
+  const setGridRef = useCallback((node) => {
+    gridRef.current = node
+    setGridDroppableRef(node)
+    gridElementRef.current = node
+  }, [setGridDroppableRef])
 
   useEffect(() => {
     isEditModeRef.current = isEditMode
@@ -105,7 +115,7 @@ export default function HomePage() {
         isEditMode ? 'overflow-visible' : 'overflow-auto',
       )}>
         <div
-          ref={gridRef}
+          ref={setGridRef}
           className={cn(
             'grid grid-cols-6 grid-rows-4 grid-flow-dense gap-[10px] w-full h-full rounded-2xl transition-[outline] duration-[150ms]',
             isDraggingNewWidget && 'outline outline-2 outline-primary',

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useCallback } from 'react'
 import { Pencil } from 'lucide-react'
-import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable'
+import { SortableContext } from '@dnd-kit/sortable'
 import { useDroppable, useDndContext } from '@dnd-kit/core'
 import LiveDot from '@/components/ui/LiveDot'
 import useEditModeStore from '@/store/useEditModeStore'
@@ -98,7 +98,9 @@ export default function HomePage() {
         isEditMode ? 'overflow-visible' : 'overflow-auto',
       )}>
         {/* 위젯 그리드: 6열 × 4행, 뷰포트 채움 / 최솟값 이하면 고정 */}
-        <SortableContext items={widgets.map((w) => w.instanceId)} strategy={rectSortingStrategy}>
+        {/* noopSortingStrategy: col-span/row-span이 혼재한 그리드에서 rectSortingStrategy 사용 시
+            드래그 중 위젯 크기/위치 왜곡이 발생하므로 시각적 이동을 비활성화. */}
+        <SortableContext items={widgets.map((w) => w.instanceId)} strategy={() => null}>
           <div
             ref={setGridRef}
             className={cn(

--- a/src/store/useEditModeStore.js
+++ b/src/store/useEditModeStore.js
@@ -1,21 +1,31 @@
 import { create } from 'zustand'
 
 // CSS --animate-wiggle duration과 동일하게 유지
-export const WIGGLE_DURATION_MS = 900
+export const WIGGLE_DURATION_MS = 1100
 
 const useEditModeStore = create((set) => ({
   isEditMode: false,
 
   // 편집 모드 진입 시 계산 — 모든 위젯이 동일 위상(phase)으로 시작하도록 동기화
   wiggleDelay: 0,
+  // drop 시점마다 증가 → WidgetCard의 animation wrapper remount → 위상 재동기화
+  wiggleSyncKey: 0,
 
   enterEditMode: () =>
     set({
       isEditMode: true,
       wiggleDelay: -(performance.now() % WIGGLE_DURATION_MS),
+      wiggleSyncKey: 0,
     }),
   exitEditMode: () => set({ isEditMode: false }),
   saveLayout: () => set({ isEditMode: false }),
+
+  // drop/cancel 시 호출 — wiggleDelay 재계산 + wiggleSyncKey 증가로 전체 재동기화
+  resyncWiggle: () =>
+    set((state) => ({
+      wiggleDelay: -(performance.now() % WIGGLE_DURATION_MS),
+      wiggleSyncKey: state.wiggleSyncKey + 1,
+    })),
 }))
 
 export default useEditModeStore

--- a/src/store/useEditModeStore.js
+++ b/src/store/useEditModeStore.js
@@ -1,8 +1,19 @@
 import { create } from 'zustand'
 
+// CSS --animate-wiggle duration과 동일하게 유지
+export const WIGGLE_DURATION_MS = 900
+
 const useEditModeStore = create((set) => ({
   isEditMode: false,
-  enterEditMode: () => set({ isEditMode: true }),
+
+  // 편집 모드 진입 시 계산 — 모든 위젯이 동일 위상(phase)으로 시작하도록 동기화
+  wiggleDelay: 0,
+
+  enterEditMode: () =>
+    set({
+      isEditMode: true,
+      wiggleDelay: -(performance.now() % WIGGLE_DURATION_MS),
+    }),
   exitEditMode: () => set({ isEditMode: false }),
   saveLayout: () => set({ isEditMode: false }),
 }))

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -76,6 +76,10 @@ const useWidgetStore = create((set) => ({
     set((state) => ({ widgets: state._snapshot ?? state.widgets, _snapshot: null })),
   clearSnapshot: () => set({ _snapshot: null }),
 
+  // new-widget 드래그 중 대시보드 outline 표시용 (useDndContext 구독 없이)
+  isDraggingNewWidget: false,
+  setIsDraggingNewWidget: (v) => set({ isDraggingNewWidget: v }),
+
   // 드래그 중 ghost placeholder (new-widget 드래그 시 push-aside 표시용)
   phantomWidget: null,
   setPhantom: (phantom) => set({ phantomWidget: phantom }),

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -121,11 +121,7 @@ const useWidgetStore = create((set) => ({
   isDraggingNewWidget: false,
   setIsDraggingNewWidget: (v) => set({ isDraggingNewWidget: v }),
 
-  // existing-widget 드래그 중 wiggle animation 일시정지용
-  isDraggingExistingWidget: false,
-  setIsDraggingExistingWidget: (v) => set({ isDraggingExistingWidget: v }),
-
-  // 드래그 중 ghost placeholder (new-widget 드래그 시 push-aside 표시용)
+// 드래그 중 ghost placeholder (new-widget 드래그 시 push-aside 표시용)
   phantomWidget: null,
   setPhantom: (phantom) => set({ phantomWidget: phantom }),
   clearPhantom: () => set({ phantomWidget: null }),

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -26,10 +26,27 @@ function _tryPlace(grid, colSpan, rowSpan) {
   return false
 }
 
+function _simulatePlacement(widgets) {
+  const grid = Array.from({ length: GRID_ROWS }, () => Array(GRID_COLS).fill(false))
+  for (const w of widgets) {
+    if (!_tryPlace(grid, w.colSpan, w.rowSpan)) return false
+  }
+  return true
+}
+
 export function canFitInGrid(widgets, colSpan, rowSpan) {
   const grid = Array.from({ length: GRID_ROWS }, () => Array(GRID_COLS).fill(false))
   for (const w of widgets) _tryPlace(grid, w.colSpan, w.rowSpan)
   return _tryPlace(grid, colSpan, rowSpan)
+}
+
+/* 재배치 후 전체 위젯이 그리드에 정상 배치 가능한지 검증.
+   false 반환 시 해당 순서 변경은 허용하지 않는다. */
+export function canReorderWidgets(widgets, activeId, overId) {
+  const oldIndex = widgets.findIndex((w) => w.instanceId === activeId)
+  const newIndex = widgets.findIndex((w) => w.instanceId === overId)
+  if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) return false
+  return _simulatePlacement(arrayMove([...widgets], oldIndex, newIndex))
 }
 
 // 6열 × 4행 (24셀) 기본 레이아웃
@@ -59,6 +76,13 @@ const useWidgetStore = create((set) => ({
     set((state) => ({ widgets: state._snapshot ?? state.widgets, _snapshot: null })),
   clearSnapshot: () => set({ _snapshot: null }),
 
+  // 드래그 중 ghost placeholder (new-widget 드래그 시 push-aside 표시용)
+  phantomWidget: null,
+  setPhantom: (phantom) => set({ phantomWidget: phantom }),
+  clearPhantom: () => set({ phantomWidget: null }),
+
+  setWidgetsOrder: (ordered) => set({ widgets: ordered }),
+
   addWidget: (widgetTypeId, variant) =>
     set((state) => {
       if (!canFitInGrid(state.widgets, variant.colSpan, variant.rowSpan)) return state
@@ -75,10 +99,28 @@ const useWidgetStore = create((set) => ({
         ],
       }
     }),
+
+  // 지정 인덱스에 위젯 삽입 (new-widget drag-to-add 용)
+  addWidgetAt: (widgetTypeId, variant, insertIndex) =>
+    set((state) => {
+      if (!canFitInGrid(state.widgets, variant.colSpan, variant.rowSpan)) return state
+      const newWidget = {
+        instanceId: crypto.randomUUID(),
+        widgetTypeId,
+        variantId: variant.id,
+        colSpan: variant.colSpan,
+        rowSpan: variant.rowSpan,
+      }
+      const next = [...state.widgets]
+      next.splice(Math.min(insertIndex, next.length), 0, newWidget)
+      return { widgets: next }
+    }),
+
   removeWidget: (instanceId) =>
     set((state) => ({
       widgets: state.widgets.filter((w) => w.instanceId !== instanceId),
     })),
+
   reorderWidgets: (activeId, overId) =>
     set((state) => {
       const oldIndex = state.widgets.findIndex((w) => w.instanceId === activeId)

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -34,6 +34,31 @@ function _simulatePlacement(widgets) {
   return true
 }
 
+/* 위젯 배열을 시뮬레이션해 각 위젯의 CSS grid 좌표(1-indexed)를 반환.
+   CSS auto-placement 대신 이 좌표를 직접 style에 적용해 레이아웃 불일치를 방지. */
+export function computeLayout(items) {
+  const grid = Array.from({ length: GRID_ROWS }, () => Array(GRID_COLS).fill(false))
+  return items.map(({ colSpan, rowSpan }) => {
+    for (let row = 0; row <= GRID_ROWS - rowSpan; row++) {
+      for (let col = 0; col <= GRID_COLS - colSpan; col++) {
+        let ok = true
+        check: for (let r = row; r < row + rowSpan; r++) {
+          for (let c = col; c < col + colSpan; c++) {
+            if (grid[r][c]) { ok = false; break check }
+          }
+        }
+        if (ok) {
+          for (let r = row; r < row + rowSpan; r++)
+            for (let c = col; c < col + colSpan; c++)
+              grid[r][c] = true
+          return { row: row + 1, col: col + 1 } // CSS grid는 1-indexed
+        }
+      }
+    }
+    return null // canReorderWidgets/canFitInGrid가 정상 작동하면 발생 안 함
+  })
+}
+
 /* 포인터가 위치한 grid cell(row, col) 기준으로 삽입 인덱스 계산.
    위젯 배치를 시뮬레이션해 target cell 이후 첫 번째 위젯 앞에 삽입. */
 export function findInsertIndex(widgets, targetRow, targetCol) {

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { arrayMove } from '@dnd-kit/sortable'
 import { GRID_COLS, GRID_ROWS } from '@/lib/gridConstants'
 
 /* ── 그리드 배치 시뮬레이션 ────────────────────────────────
@@ -78,6 +79,13 @@ const useWidgetStore = create((set) => ({
     set((state) => ({
       widgets: state.widgets.filter((w) => w.instanceId !== instanceId),
     })),
+  reorderWidgets: (activeId, overId) =>
+    set((state) => {
+      const oldIndex = state.widgets.findIndex((w) => w.instanceId === activeId)
+      const newIndex = state.widgets.findIndex((w) => w.instanceId === overId)
+      if (oldIndex === -1 || newIndex === -1) return state
+      return { widgets: arrayMove(state.widgets, oldIndex, newIndex) }
+    }),
 }))
 
 export default useWidgetStore

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -34,6 +34,47 @@ function _simulatePlacement(widgets) {
   return true
 }
 
+/* 포인터가 위치한 grid cell(row, col) 기준으로 삽입 인덱스 계산.
+   위젯 배치를 시뮬레이션해 target cell 이후 첫 번째 위젯 앞에 삽입. */
+export function findInsertIndex(widgets, targetRow, targetCol) {
+  if (widgets.length === 0) return 0
+
+  const grid = Array.from({ length: GRID_ROWS }, () => Array(GRID_COLS).fill(-1))
+  const positions = []
+
+  for (let i = 0; i < widgets.length; i++) {
+    const { colSpan, rowSpan } = widgets[i]
+    let found = false
+    outer: for (let row = 0; row <= GRID_ROWS - rowSpan; row++) {
+      for (let col = 0; col <= GRID_COLS - colSpan; col++) {
+        let ok = true
+        check: for (let r = row; r < row + rowSpan; r++) {
+          for (let c = col; c < col + colSpan; c++) {
+            if (grid[r][c] !== -1) { ok = false; break check }
+          }
+        }
+        if (ok) {
+          for (let r = row; r < row + rowSpan; r++)
+            for (let c = col; c < col + colSpan; c++)
+              grid[r][c] = i
+          positions.push({ row, col })
+          found = true
+          break outer
+        }
+      }
+    }
+    if (!found) positions.push(null)
+  }
+
+  const targetOrder = targetRow * GRID_COLS + targetCol
+  for (let i = 0; i < positions.length; i++) {
+    if (!positions[i]) continue
+    const order = positions[i].row * GRID_COLS + positions[i].col
+    if (order >= targetOrder) return i
+  }
+  return widgets.length
+}
+
 export function canFitInGrid(widgets, colSpan, rowSpan) {
   const grid = Array.from({ length: GRID_ROWS }, () => Array(GRID_COLS).fill(false))
   for (const w of widgets) _tryPlace(grid, w.colSpan, w.rowSpan)

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -121,6 +121,10 @@ const useWidgetStore = create((set) => ({
   isDraggingNewWidget: false,
   setIsDraggingNewWidget: (v) => set({ isDraggingNewWidget: v }),
 
+  // existing-widget 드래그 중 wiggle animation 일시정지용
+  isDraggingExistingWidget: false,
+  setIsDraggingExistingWidget: (v) => set({ isDraggingExistingWidget: v }),
+
   // 드래그 중 ghost placeholder (new-widget 드래그 시 push-aside 표시용)
   phantomWidget: null,
   setPhantom: (phantom) => set({ phantomWidget: phantom }),

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -146,7 +146,7 @@ const useWidgetStore = create((set) => ({
   isDraggingNewWidget: false,
   setIsDraggingNewWidget: (v) => set({ isDraggingNewWidget: v }),
 
-// 드래그 중 ghost placeholder (new-widget 드래그 시 push-aside 표시용)
+  // 드래그 중 ghost placeholder (new-widget 드래그 시 push-aside 표시용)
   phantomWidget: null,
   setPhantom: (phantom) => set({ phantomWidget: phantom }),
   clearPhantom: () => set({ phantomWidget: null }),


### PR DESCRIPTION
## 개요

#50, #51 을 하나의 PR로 구현합니다.
편집 모드에서 위젯 순서 변경 drag&drop, EditPanel에서 대시보드로 drag-to-add,
그리고 구현 과정에서 발생한 다수의 버그를 수정합니다.

## 작업 내용

### feat
- `@dnd-kit/core` + `@dnd-kit/sortable` 기반 drag&drop 인프라 구축
- 편집 모드에서 위젯 drag으로 순서 변경 (`useDraggable` + `useDroppable`, `arrayMove`)
- EditPanel variant 프리뷰에서 dashboard로 drag-to-add 구현
- `DndContext`를 `AppShell` 레벨로 끌어올려 cross-container drag 지원
- drag 중 `DragOverlay`로 실제 크기 미리보기 표시
- 포인터 좌표 기반 phantom 삽입 위치 계산 (`findInsertIndex`)
- 편집 모드 진입/종료 시 wiggle animation 동기화 (`wiggleSyncKey`, `resyncWiggle`)

### fix
- `SortableContext` → `useDraggable`+`useDroppable` 교체로 `droppableRects` 구독 무한 루프 해결
- EditPanel 영역에 drop 시 위젯이 추가되던 버그 수정 (`savedPhantom` guard)
- 빈 대시보드에서 첫 위젯 추가 불가 버그 수정 (`useDroppable({ id: 'dashboard-grid' })`)
- drag 중 위젯 크기 축소 버그 완전 해결: `computeLayout()`으로 명시적 `grid-column`/`grid-row` 좌표 적용, CSS auto-placement 우회
- 위젯 우측 상단 LiveDot 제거
- wiggle animation 중간 멈춤 현상 수정 (0%/100% 동일 위치로 seamless loop)
- drag 후 wiggle 방향 불일치 수정 (`wiggleSyncKey` key remount로 전체 재동기화)

## 비고

- CSS `grid-flow-row`의 one-way 커서와 `_simulatePlacement`의 top-left 스캔이 불일치해 위젯이 암묵적 5번째 행으로 overflow되는 근본 원인을 `computeLayout()`으로 해결
- wiggle 속도/각도 조정: `src/index.css` `--animate-wiggle` 및 `@keyframes wiggle`, `src/store/useEditModeStore.js` `WIGGLE_DURATION_MS`

Closes #50
Closes #51