### PR TITLE
fix(dnd): 위젯 drag&drop 배치 인식 및 push-aside 밀림 개선

### DIFF
--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -10,7 +10,7 @@ import {
 } from '@dnd-kit/core'
 import AppHeader from './AppHeader'
 import RightPanel from './RightPanel'
-import useWidgetStore, { canPlaceAt } from '@/store/useWidgetStore'
+import useWidgetStore, { canPlaceAt, canReorderWidgets } from '@/store/useWidgetStore'
 import useEditModeStore from '@/store/useEditModeStore'
 import useGridStore from '@/store/useGridStore'
 import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry'
@@ -20,15 +20,20 @@ export default function AppShell() {
   const [activeDrag, setActiveDrag] = useState(null)
   const {
     widgets,
+    reorderWidgets,
+    setWidgetsOrder,
+    commitLayout,
     addWidgetAt,
-    moveWidgetTo,
     setPhantom,
     clearPhantom,
     phantomWidget,
     setIsDraggingNewWidget,
+    setIsDraggingExistingWidget,
   } = useWidgetStore()
   const { resyncWiggle } = useEditModeStore()
   const { cellWidth, cellHeight } = useGridStore()
+  const preDragOrder = useRef(null)
+  const lastOverId = useRef(null)
   const pointerPos = useRef({ x: 0, y: 0 })
 
   // 포인터 좌표를 drag 중에만 추적 (handleDragMove에서 사용)
@@ -43,17 +48,19 @@ export default function AppShell() {
     const type = active.data.current?.type
     setActiveDrag({ id: active.id, data: active.data.current })
     window.addEventListener('pointermove', onPointerMove)
-    if (type === 'new-widget') {
+    if (type === 'existing-widget') {
+      preDragOrder.current = [...widgets]
+      lastOverId.current = null
+      setIsDraggingExistingWidget(true)
+    } else if (type === 'new-widget') {
       setIsDraggingNewWidget(true)
     }
   }
 
-  /* 포인터 좌표 → 1-indexed grid cell → phantom 업데이트.
-     new-widget, existing-widget 모두 처리.
-     포인터가 빈 셀 위에 있을 때만 phantom 표시, 점유 셀 위면 phantom 제거. */
+  /* new-widget 전용: 포인터가 위치한 빈 셀에 phantom 표시.
+     existing-widget은 handleDragOver의 live reorder로 push-aside 처리. */
   function handleDragMove({ active }) {
-    const type = active.data.current?.type
-    if (type !== 'new-widget' && type !== 'existing-widget') return
+    if (active.data.current?.type !== 'new-widget') return
 
     const el = gridElementRef.current
     if (!el || !cellWidth || !cellHeight) return
@@ -61,56 +68,73 @@ export default function AppShell() {
     const rect = el.getBoundingClientRect()
     const { x, y } = pointerPos.current
 
-    // 그리드 영역 밖이면 phantom 제거
     if (x < rect.left || x > rect.right || y < rect.top || y > rect.bottom) {
       clearPhantom()
       return
     }
 
-    // 1-indexed target cell (포인터가 가리키는 셀의 top-left 기준)
+    const { variant } = active.data.current
+    // 1-indexed target cell (포인터 셀의 top-left 기준)
     const targetCol = Math.max(1, Math.min(Math.floor((x - rect.left) / (cellWidth + GRID_GAP)) + 1, GRID_COLS))
     const targetRow = Math.max(1, Math.min(Math.floor((y - rect.top) / (cellHeight + GRID_GAP)) + 1, GRID_ROWS))
 
-    if (type === 'new-widget') {
-      const { variant } = active.data.current
-      if (canPlaceAt(widgets, targetCol, targetRow, variant.colSpan, variant.rowSpan)) {
-        setPhantom({ gridCol: targetCol, gridRow: targetRow, colSpan: variant.colSpan, rowSpan: variant.rowSpan })
-      } else {
-        clearPhantom()
-      }
+    if (canPlaceAt(widgets, targetCol, targetRow, variant.colSpan, variant.rowSpan)) {
+      setPhantom({ gridCol: targetCol, gridRow: targetRow, colSpan: variant.colSpan, rowSpan: variant.rowSpan })
     } else {
-      // existing-widget: excludeId로 자기 자신 셀을 빈 셀로 간주
-      const activeWidget = widgets.find((w) => w.instanceId === active.id)
-      if (!activeWidget) return
-      if (canPlaceAt(widgets, targetCol, targetRow, activeWidget.colSpan, activeWidget.rowSpan, active.id)) {
-        setPhantom({
-          gridCol: targetCol,
-          gridRow: targetRow,
-          colSpan: activeWidget.colSpan,
-          rowSpan: activeWidget.rowSpan,
-          activeId: active.id,
-        })
-      } else {
-        clearPhantom()
+      clearPhantom()
+    }
+  }
+
+  /* existing-widget: 드래그 대상 위에서 live reorder → push-aside 효과.
+     new-widget phantom은 handleDragMove에서 처리. */
+  function handleDragOver({ active, over }) {
+    const type = active.data.current?.type
+
+    if (!over) {
+      lastOverId.current = null
+      if (type === 'new-widget') clearPhantom()
+      return
+    }
+
+    if (over.id === lastOverId.current) return
+    lastOverId.current = over.id
+
+    if (type === 'existing-widget') {
+      if (active.id === over.id) return
+      if (canReorderWidgets(widgets, active.id, over.id)) {
+        reorderWidgets(active.id, over.id)
       }
     }
   }
 
-  function handleDragEnd({ active }) {
+  function handleDragEnd({ active, over }) {
     window.removeEventListener('pointermove', onPointerMove)
     const savedPhantom = phantomWidget
     setActiveDrag(null)
+    lastOverId.current = null
     clearPhantom()
     setIsDraggingNewWidget(false)
+    setIsDraggingExistingWidget(false)
     resyncWiggle()
 
     const type = active.data.current?.type
 
+    if (!over) {
+      if (type === 'existing-widget' && preDragOrder.current) {
+        setWidgetsOrder(preDragOrder.current)
+      }
+      preDragOrder.current = null
+      return
+    }
+
+    preDragOrder.current = null
+
     if (type === 'new-widget' && savedPhantom) {
       const { widgetTypeId, variant } = active.data.current
       addWidgetAt(widgetTypeId, variant, savedPhantom.gridCol, savedPhantom.gridRow)
-    } else if (type === 'existing-widget' && savedPhantom?.activeId) {
-      moveWidgetTo(savedPhantom.activeId, savedPhantom.gridCol, savedPhantom.gridRow)
+    } else if (type === 'existing-widget') {
+      // arrayMove로 바뀐 배열 순서를 computeLayout으로 확정 → gridCol/gridRow commit
+      commitLayout()
     }
   }
 
@@ -118,7 +142,13 @@ export default function AppShell() {
     window.removeEventListener('pointermove', onPointerMove)
     clearPhantom()
     setIsDraggingNewWidget(false)
+    setIsDraggingExistingWidget(false)
     resyncWiggle()
+    if (preDragOrder.current) {
+      setWidgetsOrder(preDragOrder.current)
+    }
+    preDragOrder.current = null
+    lastOverId.current = null
     setActiveDrag(null)
   }
 
@@ -161,6 +191,7 @@ export default function AppShell() {
       collisionDetection={closestCenter}
       onDragStart={handleDragStart}
       onDragMove={handleDragMove}
+      onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
     >

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -10,7 +10,7 @@ import {
 } from '@dnd-kit/core'
 import AppHeader from './AppHeader'
 import RightPanel from './RightPanel'
-import useWidgetStore, { canFitInGrid, canReorderWidgets, findInsertIndex } from '@/store/useWidgetStore'
+import useWidgetStore, { canPlaceAt } from '@/store/useWidgetStore'
 import useEditModeStore from '@/store/useEditModeStore'
 import useGridStore from '@/store/useGridStore'
 import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry'
@@ -20,9 +20,8 @@ export default function AppShell() {
   const [activeDrag, setActiveDrag] = useState(null)
   const {
     widgets,
-    reorderWidgets,
     addWidgetAt,
-    setWidgetsOrder,
+    moveWidgetTo,
     setPhantom,
     clearPhantom,
     phantomWidget,
@@ -30,8 +29,6 @@ export default function AppShell() {
   } = useWidgetStore()
   const { resyncWiggle } = useEditModeStore()
   const { cellWidth, cellHeight } = useGridStore()
-  const preDragOrder = useRef(null)
-  const lastOverId = useRef(null)
   const pointerPos = useRef({ x: 0, y: 0 })
 
   // 포인터 좌표를 drag 중에만 추적 (handleDragMove에서 사용)
@@ -46,26 +43,20 @@ export default function AppShell() {
     const type = active.data.current?.type
     setActiveDrag({ id: active.id, data: active.data.current })
     window.addEventListener('pointermove', onPointerMove)
-    if (type === 'existing-widget') {
-      preDragOrder.current = [...widgets]
-      lastOverId.current = null
-    } else if (type === 'new-widget') {
+    if (type === 'new-widget') {
       setIsDraggingNewWidget(true)
     }
   }
 
-  /* new-widget 드래그 중 포인터 좌표 → grid cell → insertIndex 계산.
-     onDragOver보다 높은 빈도로 발생해 더 정확한 위치를 반영한다. */
+  /* 포인터 좌표 → 1-indexed grid cell → phantom 업데이트.
+     new-widget, existing-widget 모두 처리.
+     포인터가 빈 셀 위에 있을 때만 phantom 표시, 점유 셀 위면 phantom 제거. */
   function handleDragMove({ active }) {
-    if (active.data.current?.type !== 'new-widget') return
+    const type = active.data.current?.type
+    if (type !== 'new-widget' && type !== 'existing-widget') return
+
     const el = gridElementRef.current
     if (!el || !cellWidth || !cellHeight) return
-
-    const { variant } = active.data.current
-    if (!canFitInGrid(widgets, variant.colSpan, variant.rowSpan)) {
-      clearPhantom()
-      return
-    }
 
     const rect = el.getBoundingClientRect()
     const { x, y } = pointerPos.current
@@ -76,66 +67,51 @@ export default function AppShell() {
       return
     }
 
-    const col = Math.max(0, Math.min(Math.floor((x - rect.left) / (cellWidth + GRID_GAP)), GRID_COLS - 1))
-    const row = Math.max(0, Math.min(Math.floor((y - rect.top) / (cellHeight + GRID_GAP)), GRID_ROWS - 1))
-    const insertIndex = findInsertIndex(widgets, row, col)
-    setPhantom({ insertIndex, colSpan: variant.colSpan, rowSpan: variant.rowSpan })
-  }
+    // 1-indexed target cell (포인터가 가리키는 셀의 top-left 기준)
+    const targetCol = Math.max(1, Math.min(Math.floor((x - rect.left) / (cellWidth + GRID_GAP)) + 1, GRID_COLS))
+    const targetRow = Math.max(1, Math.min(Math.floor((y - rect.top) / (cellHeight + GRID_GAP)) + 1, GRID_ROWS))
 
-  function handleDragOver({ active, over }) {
-    const type = active.data.current?.type
-
-    if (!over) {
-      lastOverId.current = null
-      if (type === 'new-widget') clearPhantom()
-      return
-    }
-
-    if (over.id === lastOverId.current) return
-    lastOverId.current = over.id
-
-    // existing-widget 재정렬만 처리 (new-widget phantom은 handleDragMove에서 처리)
-    if (type === 'existing-widget') {
-      if (active.id === over.id) return
-      if (canReorderWidgets(widgets, active.id, over.id)) {
-        reorderWidgets(active.id, over.id)
+    if (type === 'new-widget') {
+      const { variant } = active.data.current
+      if (canPlaceAt(widgets, targetCol, targetRow, variant.colSpan, variant.rowSpan)) {
+        setPhantom({ gridCol: targetCol, gridRow: targetRow, colSpan: variant.colSpan, rowSpan: variant.rowSpan })
+      } else {
+        clearPhantom()
+      }
+    } else {
+      // existing-widget: excludeId로 자기 자신 셀을 빈 셀로 간주
+      const activeWidget = widgets.find((w) => w.instanceId === active.id)
+      if (!activeWidget) return
+      if (canPlaceAt(widgets, targetCol, targetRow, activeWidget.colSpan, activeWidget.rowSpan, active.id)) {
+        setPhantom({
+          gridCol: targetCol,
+          gridRow: targetRow,
+          colSpan: activeWidget.colSpan,
+          rowSpan: activeWidget.rowSpan,
+          activeId: active.id,
+        })
+      } else {
+        clearPhantom()
       }
     }
   }
 
-  function handleDragEnd({ active, over }) {
+  function handleDragEnd({ active }) {
     window.removeEventListener('pointermove', onPointerMove)
     const savedPhantom = phantomWidget
     setActiveDrag(null)
-    lastOverId.current = null
     clearPhantom()
     setIsDraggingNewWidget(false)
     resyncWiggle()
 
     const type = active.data.current?.type
 
-    if (!over) {
-      if (type === 'existing-widget' && preDragOrder.current) {
-        setWidgetsOrder(preDragOrder.current)
-      }
-      preDragOrder.current = null
-      return
+    if (type === 'new-widget' && savedPhantom) {
+      const { widgetTypeId, variant } = active.data.current
+      addWidgetAt(widgetTypeId, variant, savedPhantom.gridCol, savedPhantom.gridRow)
+    } else if (type === 'existing-widget' && savedPhantom?.activeId) {
+      moveWidgetTo(savedPhantom.activeId, savedPhantom.gridCol, savedPhantom.gridRow)
     }
-
-    preDragOrder.current = null
-
-    if (type === 'new-widget') {
-      // savedPhantom이 있어야만 대시보드 위에 유효하게 hover했다고 판단
-      // phantom 없으면 EditPanel 영역에서 drop한 것으로 간주해 추가하지 않음
-      const isOverDashboard =
-        savedPhantom != null &&
-        (over.id === 'dashboard-grid' || widgets.some((w) => w.instanceId === over.id))
-      if (isOverDashboard) {
-        const { widgetTypeId, variant } = active.data.current
-        addWidgetAt(widgetTypeId, variant, savedPhantom.insertIndex)
-      }
-    }
-    // existing-widget: onDragOver에서 이미 reorder 완료
   }
 
   function handleDragCancel() {
@@ -143,11 +119,6 @@ export default function AppShell() {
     clearPhantom()
     setIsDraggingNewWidget(false)
     resyncWiggle()
-    if (preDragOrder.current) {
-      setWidgetsOrder(preDragOrder.current)
-    }
-    preDragOrder.current = null
-    lastOverId.current = null
     setActiveDrag(null)
   }
 
@@ -190,7 +161,6 @@ export default function AppShell() {
       collisionDetection={closestCenter}
       onDragStart={handleDragStart}
       onDragMove={handleDragMove}
-      onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
     >

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -10,7 +10,7 @@ import {
 } from '@dnd-kit/core'
 import AppHeader from './AppHeader'
 import RightPanel from './RightPanel'
-import useWidgetStore, { canPlaceAt, canReorderWidgets } from '@/store/useWidgetStore'
+import useWidgetStore, { canPlaceAt, canSwap } from '@/store/useWidgetStore'
 import useEditModeStore from '@/store/useEditModeStore'
 import useGridStore from '@/store/useGridStore'
 import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry'
@@ -20,20 +20,16 @@ export default function AppShell() {
   const [activeDrag, setActiveDrag] = useState(null)
   const {
     widgets,
-    reorderWidgets,
-    setWidgetsOrder,
-    commitLayout,
     addWidgetAt,
+    moveWidgetTo,
+    swapWidgets,
     setPhantom,
     clearPhantom,
     phantomWidget,
     setIsDraggingNewWidget,
-    setIsDraggingExistingWidget,
   } = useWidgetStore()
   const { resyncWiggle } = useEditModeStore()
   const { cellWidth, cellHeight } = useGridStore()
-  const preDragOrder = useRef(null)
-  const lastOverId = useRef(null)
   const pointerPos = useRef({ x: 0, y: 0 })
 
   // 포인터 좌표를 drag 중에만 추적 (handleDragMove에서 사용)
@@ -48,19 +44,22 @@ export default function AppShell() {
     const type = active.data.current?.type
     setActiveDrag({ id: active.id, data: active.data.current })
     window.addEventListener('pointermove', onPointerMove)
-    if (type === 'existing-widget') {
-      preDragOrder.current = [...widgets]
-      lastOverId.current = null
-      setIsDraggingExistingWidget(true)
-    } else if (type === 'new-widget') {
+    if (type === 'new-widget') {
       setIsDraggingNewWidget(true)
     }
   }
 
-  /* new-widget 전용: 포인터가 위치한 빈 셀에 phantom 표시.
-     existing-widget은 handleDragOver의 live reorder로 push-aside 처리. */
+  /* 포인터 좌표 → 1-indexed grid cell → phantom 업데이트.
+     new-widget / existing-widget 모두 처리.
+
+     existing-widget 배치 규칙:
+       1. 빈 셀 위 → 드래그 위젯만 그 위치로 이동 (phantom 표시)
+       2. 점유 셀 위 → canSwap 통과 시에만 swap 허용 (phantom 표시)
+       3. 그 외 → phantom 제거 (drop 불가)
+     → 드래그한 위젯 외 다른 위젯은 절대 의도치 않게 이동하지 않음. */
   function handleDragMove({ active }) {
-    if (active.data.current?.type !== 'new-widget') return
+    const type = active.data.current?.type
+    if (type !== 'new-widget' && type !== 'existing-widget') return
 
     const el = gridElementRef.current
     if (!el || !cellWidth || !cellHeight) return
@@ -73,68 +72,83 @@ export default function AppShell() {
       return
     }
 
-    const { variant } = active.data.current
     // 1-indexed target cell (포인터 셀의 top-left 기준)
     const targetCol = Math.max(1, Math.min(Math.floor((x - rect.left) / (cellWidth + GRID_GAP)) + 1, GRID_COLS))
     const targetRow = Math.max(1, Math.min(Math.floor((y - rect.top) / (cellHeight + GRID_GAP)) + 1, GRID_ROWS))
 
-    if (canPlaceAt(widgets, targetCol, targetRow, variant.colSpan, variant.rowSpan)) {
-      setPhantom({ gridCol: targetCol, gridRow: targetRow, colSpan: variant.colSpan, rowSpan: variant.rowSpan })
+    if (type === 'new-widget') {
+      const { variant } = active.data.current
+      if (canPlaceAt(widgets, targetCol, targetRow, variant.colSpan, variant.rowSpan)) {
+        setPhantom({ gridCol: targetCol, gridRow: targetRow, colSpan: variant.colSpan, rowSpan: variant.rowSpan })
+      } else {
+        clearPhantom()
+      }
+      return
+    }
+
+    // existing-widget
+    const activeWidget = widgets.find((w) => w.instanceId === active.id)
+    if (!activeWidget) return
+
+    // Case 1: 빈 셀 → 이동
+    if (canPlaceAt(widgets, targetCol, targetRow, activeWidget.colSpan, activeWidget.rowSpan, active.id)) {
+      setPhantom({
+        gridCol: targetCol,
+        gridRow: targetRow,
+        colSpan: activeWidget.colSpan,
+        rowSpan: activeWidget.rowSpan,
+        activeId: active.id,
+      })
+      return
+    }
+
+    // Case 2: 점유 셀 → 해당 위젯과 swap 가능 여부 확인
+    const targetWidget = widgets.find(
+      (w) =>
+        w.instanceId !== active.id &&
+        targetCol >= w.gridCol && targetCol < w.gridCol + w.colSpan &&
+        targetRow >= w.gridRow && targetRow < w.gridRow + w.rowSpan,
+    )
+    if (targetWidget && canSwap(widgets, active.id, targetWidget.instanceId)) {
+      // phantom은 active 위젯이 이동할 자리(= targetWidget의 top-left)에 표시
+      setPhantom({
+        gridCol: targetWidget.gridCol,
+        gridRow: targetWidget.gridRow,
+        colSpan: activeWidget.colSpan,
+        rowSpan: activeWidget.rowSpan,
+        activeId: active.id,
+        swapWithId: targetWidget.instanceId,
+      })
     } else {
       clearPhantom()
     }
   }
 
-  /* existing-widget: 드래그 대상 위에서 live reorder → push-aside 효과.
-     new-widget phantom은 handleDragMove에서 처리. */
   function handleDragOver({ active, over }) {
-    const type = active.data.current?.type
-
-    if (!over) {
-      lastOverId.current = null
-      if (type === 'new-widget') clearPhantom()
-      return
-    }
-
-    if (over.id === lastOverId.current) return
-    lastOverId.current = over.id
-
-    if (type === 'existing-widget') {
-      if (active.id === over.id) return
-      if (canReorderWidgets(widgets, active.id, over.id)) {
-        reorderWidgets(active.id, over.id)
-      }
-    }
+    // phantom은 handleDragMove(pointer 좌표 기반)에서 관리
+    // new-widget이 그리드 외부로 벗어났을 때 phantom 제거 보조
+    if (!over && active.data.current?.type === 'new-widget') clearPhantom()
   }
 
-  function handleDragEnd({ active, over }) {
+  function handleDragEnd({ active }) {
     window.removeEventListener('pointermove', onPointerMove)
     const savedPhantom = phantomWidget
     setActiveDrag(null)
-    lastOverId.current = null
     clearPhantom()
     setIsDraggingNewWidget(false)
-    setIsDraggingExistingWidget(false)
     resyncWiggle()
 
     const type = active.data.current?.type
 
-    if (!over) {
-      if (type === 'existing-widget' && preDragOrder.current) {
-        setWidgetsOrder(preDragOrder.current)
-      }
-      preDragOrder.current = null
-      return
-    }
-
-    preDragOrder.current = null
-
     if (type === 'new-widget' && savedPhantom) {
       const { widgetTypeId, variant } = active.data.current
       addWidgetAt(widgetTypeId, variant, savedPhantom.gridCol, savedPhantom.gridRow)
-    } else if (type === 'existing-widget') {
-      // arrayMove로 바뀐 배열 순서를 computeLayout으로 확정 → gridCol/gridRow commit
-      commitLayout()
+    } else if (type === 'existing-widget' && savedPhantom?.activeId) {
+      if (savedPhantom.swapWithId) {
+        swapWidgets(savedPhantom.activeId, savedPhantom.swapWithId)
+      } else {
+        moveWidgetTo(savedPhantom.activeId, savedPhantom.gridCol, savedPhantom.gridRow)
+      }
     }
   }
 
@@ -142,13 +156,7 @@ export default function AppShell() {
     window.removeEventListener('pointermove', onPointerMove)
     clearPhantom()
     setIsDraggingNewWidget(false)
-    setIsDraggingExistingWidget(false)
     resyncWiggle()
-    if (preDragOrder.current) {
-      setWidgetsOrder(preDragOrder.current)
-    }
-    preDragOrder.current = null
-    lastOverId.current = null
     setActiveDrag(null)
   }
 

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -22,7 +22,6 @@ export default function AppShell() {
     widgets,
     addWidgetAt,
     moveWidgetTo,
-    pushAsideWidget,
     applyPushAsidePlan,
     setPhantom,
     clearPhantom,
@@ -173,9 +172,6 @@ export default function AppShell() {
     } else if (type === 'existing-widget' && savedPhantom?.activeId) {
       if (savedPhantom.pushAsidePlan) {
         applyPushAsidePlan(savedPhantom.pushAsidePlan)
-      } else if (savedPhantom.pushAsideId) {
-        // 이전 단일 push-aside 포맷과 호환 (혹시 남아있는 phantom 대비)
-        pushAsideWidget(savedPhantom.activeId, savedPhantom.pushAsideId, savedPhantom.pushAsideCol, savedPhantom.pushAsideRow)
       } else {
         moveWidgetTo(savedPhantom.activeId, savedPhantom.gridCol, savedPhantom.gridRow)
       }

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -10,7 +10,7 @@ import {
 } from '@dnd-kit/core'
 import AppHeader from './AppHeader'
 import RightPanel from './RightPanel'
-import useWidgetStore, { canPlaceAt, canSwap } from '@/store/useWidgetStore'
+import useWidgetStore, { canPlaceAt, findPushAsidePlanAt } from '@/store/useWidgetStore'
 import useEditModeStore from '@/store/useEditModeStore'
 import useGridStore from '@/store/useGridStore'
 import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry'
@@ -22,7 +22,8 @@ export default function AppShell() {
     widgets,
     addWidgetAt,
     moveWidgetTo,
-    swapWidgets,
+    pushAsideWidget,
+    applyPushAsidePlan,
     setPhantom,
     clearPhantom,
     phantomWidget,
@@ -31,6 +32,7 @@ export default function AppShell() {
   const { resyncWiggle } = useEditModeStore()
   const { cellWidth, cellHeight } = useGridStore()
   const pointerPos = useRef({ x: 0, y: 0 })
+  const dragAnchor = useRef({ colOffset: 0, rowOffset: 0 })
 
   // 포인터 좌표를 drag 중에만 추적 (handleDragMove에서 사용)
   // 동일 참조로 등록·해제할 수 있도록 useRef에 저장
@@ -40,10 +42,30 @@ export default function AppShell() {
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
   )
 
-  function handleDragStart({ active }) {
+  function handleDragStart({ active, activatorEvent }) {
     const type = active.data.current?.type
     setActiveDrag({ id: active.id, data: active.data.current })
     window.addEventListener('pointermove', onPointerMove)
+
+    // existing-widget: 위젯 내부에서 어디를 잡았는지(anchor)를 셀 단위로 저장.
+    // 이후 드래그 좌표 계산 시 top-left 기준 보정에 사용한다.
+    if (type === 'existing-widget') {
+      dragAnchor.current = { colOffset: 0, rowOffset: 0 }
+      const el = gridElementRef.current
+      const pointer = activatorEvent
+      const w = widgets.find((it) => it.instanceId === active.id)
+      if (el && pointer && 'clientX' in pointer && 'clientY' in pointer && w && cellWidth && cellHeight) {
+        const rect = el.getBoundingClientRect()
+        const widgetLeft = rect.left + (w.gridCol - 1) * (cellWidth + GRID_GAP)
+        const widgetTop = rect.top + (w.gridRow - 1) * (cellHeight + GRID_GAP)
+        const relX = pointer.clientX - widgetLeft
+        const relY = pointer.clientY - widgetTop
+        const colOffset = Math.max(0, Math.min(Math.floor(relX / (cellWidth + GRID_GAP)), w.colSpan - 1))
+        const rowOffset = Math.max(0, Math.min(Math.floor(relY / (cellHeight + GRID_GAP)), w.rowSpan - 1))
+        dragAnchor.current = { colOffset, rowOffset }
+      }
+    }
+
     if (type === 'new-widget') {
       setIsDraggingNewWidget(true)
     }
@@ -54,7 +76,7 @@ export default function AppShell() {
 
      existing-widget 배치 규칙:
        1. 빈 셀 위 → 드래그 위젯만 그 위치로 이동 (phantom 표시)
-       2. 점유 셀 위 → canSwap 통과 시에만 swap 허용 (phantom 표시)
+       2. 점유 셀 위 → push-aside plan(연쇄 밀림) 생성 가능할 때 허용
        3. 그 외 → phantom 제거 (drop 불가)
      → 드래그한 위젯 외 다른 위젯은 절대 의도치 않게 이동하지 않음. */
   function handleDragMove({ active }) {
@@ -72,14 +94,14 @@ export default function AppShell() {
       return
     }
 
-    // 1-indexed target cell (포인터 셀의 top-left 기준)
-    const targetCol = Math.max(1, Math.min(Math.floor((x - rect.left) / (cellWidth + GRID_GAP)) + 1, GRID_COLS))
-    const targetRow = Math.max(1, Math.min(Math.floor((y - rect.top) / (cellHeight + GRID_GAP)) + 1, GRID_ROWS))
+    // 포인터가 가리키는 셀(1-indexed)
+    const pointerCol = Math.max(1, Math.min(Math.floor((x - rect.left) / (cellWidth + GRID_GAP)) + 1, GRID_COLS))
+    const pointerRow = Math.max(1, Math.min(Math.floor((y - rect.top) / (cellHeight + GRID_GAP)) + 1, GRID_ROWS))
 
     if (type === 'new-widget') {
       const { variant } = active.data.current
-      if (canPlaceAt(widgets, targetCol, targetRow, variant.colSpan, variant.rowSpan)) {
-        setPhantom({ gridCol: targetCol, gridRow: targetRow, colSpan: variant.colSpan, rowSpan: variant.rowSpan })
+      if (canPlaceAt(widgets, pointerCol, pointerRow, variant.colSpan, variant.rowSpan)) {
+        setPhantom({ gridCol: pointerCol, gridRow: pointerRow, colSpan: variant.colSpan, rowSpan: variant.rowSpan })
       } else {
         clearPhantom()
       }
@@ -90,11 +112,21 @@ export default function AppShell() {
     const activeWidget = widgets.find((w) => w.instanceId === active.id)
     if (!activeWidget) return
 
+    // existing-widget은 잡은 anchor를 기준으로 top-left 보정
+    const desiredCol = Math.max(
+      1,
+      Math.min(pointerCol - dragAnchor.current.colOffset, GRID_COLS - activeWidget.colSpan + 1),
+    )
+    const desiredRow = Math.max(
+      1,
+      Math.min(pointerRow - dragAnchor.current.rowOffset, GRID_ROWS - activeWidget.rowSpan + 1),
+    )
+
     // Case 1: 빈 셀 → 이동
-    if (canPlaceAt(widgets, targetCol, targetRow, activeWidget.colSpan, activeWidget.rowSpan, active.id)) {
+    if (canPlaceAt(widgets, desiredCol, desiredRow, activeWidget.colSpan, activeWidget.rowSpan, active.id)) {
       setPhantom({
-        gridCol: targetCol,
-        gridRow: targetRow,
+        gridCol: desiredCol,
+        gridRow: desiredRow,
         colSpan: activeWidget.colSpan,
         rowSpan: activeWidget.rowSpan,
         activeId: active.id,
@@ -102,22 +134,16 @@ export default function AppShell() {
       return
     }
 
-    // Case 2: 점유 셀 → 해당 위젯과 swap 가능 여부 확인
-    const targetWidget = widgets.find(
-      (w) =>
-        w.instanceId !== active.id &&
-        targetCol >= w.gridCol && targetCol < w.gridCol + w.colSpan &&
-        targetRow >= w.gridRow && targetRow < w.gridRow + w.rowSpan,
-    )
-    if (targetWidget && canSwap(widgets, active.id, targetWidget.instanceId)) {
-      // phantom은 active 위젯이 이동할 자리(= targetWidget의 top-left)에 표시
+    // Case 2: 점유 셀 → desired top-left 기준 push-aside plan 시도 (연쇄 밀림 포함)
+    const plan = findPushAsidePlanAt(widgets, active.id, desiredCol, desiredRow)
+    if (plan) {
       setPhantom({
-        gridCol: targetWidget.gridCol,
-        gridRow: targetWidget.gridRow,
+        gridCol: plan.targetCol,
+        gridRow: plan.targetRow,
         colSpan: activeWidget.colSpan,
         rowSpan: activeWidget.rowSpan,
         activeId: active.id,
-        swapWithId: targetWidget.instanceId,
+        pushAsidePlan: plan,
       })
     } else {
       clearPhantom()
@@ -132,6 +158,7 @@ export default function AppShell() {
 
   function handleDragEnd({ active }) {
     window.removeEventListener('pointermove', onPointerMove)
+    dragAnchor.current = { colOffset: 0, rowOffset: 0 }
     const savedPhantom = phantomWidget
     setActiveDrag(null)
     clearPhantom()
@@ -144,8 +171,11 @@ export default function AppShell() {
       const { widgetTypeId, variant } = active.data.current
       addWidgetAt(widgetTypeId, variant, savedPhantom.gridCol, savedPhantom.gridRow)
     } else if (type === 'existing-widget' && savedPhantom?.activeId) {
-      if (savedPhantom.swapWithId) {
-        swapWidgets(savedPhantom.activeId, savedPhantom.swapWithId)
+      if (savedPhantom.pushAsidePlan) {
+        applyPushAsidePlan(savedPhantom.pushAsidePlan)
+      } else if (savedPhantom.pushAsideId) {
+        // 이전 단일 push-aside 포맷과 호환 (혹시 남아있는 phantom 대비)
+        pushAsideWidget(savedPhantom.activeId, savedPhantom.pushAsideId, savedPhantom.pushAsideCol, savedPhantom.pushAsideRow)
       } else {
         moveWidgetTo(savedPhantom.activeId, savedPhantom.gridCol, savedPhantom.gridRow)
       }
@@ -154,6 +184,7 @@ export default function AppShell() {
 
   function handleDragCancel() {
     window.removeEventListener('pointermove', onPointerMove)
+    dragAnchor.current = { colOffset: 0, rowOffset: 0 }
     clearPhantom()
     setIsDraggingNewWidget(false)
     resyncWiggle()

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -4,7 +4,7 @@ import { useDroppable } from '@dnd-kit/core'
 import LiveDot from '@/components/ui/LiveDot'
 import useEditModeStore from '@/store/useEditModeStore'
 import useGridStore from '@/store/useGridStore'
-import useWidgetStore, { canFitInGrid, computeLayout } from '@/store/useWidgetStore'
+import useWidgetStore, { canFitInGrid } from '@/store/useWidgetStore'
 import { cn } from '@/lib/cn'
 import AddWidgetSlot from '@/components/widgets/AddWidgetSlot'
 import SortableWidgetCard from '@/components/widgets/SortableWidgetCard'
@@ -66,17 +66,10 @@ export default function HomePage() {
     return () => observer.disconnect()
   }, [setCellSize, setPreviewCellSize])
 
-  // phantom을 지정 인덱스에 삽입한 display 전용 배열
+  // phantom은 좌표를 직접 보유 — 배열에 삽입하지 않고 displayWidgets 끝에 append
   const displayWidgets = phantomWidget
-    ? [
-        ...widgets.slice(0, phantomWidget.insertIndex),
-        { instanceId: '__phantom__', colSpan: phantomWidget.colSpan, rowSpan: phantomWidget.rowSpan },
-        ...widgets.slice(phantomWidget.insertIndex),
-      ]
+    ? [...widgets, { instanceId: '__phantom__', ...phantomWidget }]
     : widgets
-
-  // CSS auto-placement 대신 명시적 grid 좌표를 계산해 레이아웃 불일치/overflow 방지
-  const layout = computeLayout(displayWidgets)
 
   return (
     <div className="flex flex-col h-full overflow-hidden p-3 gap-2.5">
@@ -130,16 +123,15 @@ export default function HomePage() {
             minHeight: `${MIN_GRID_HEIGHT}px`,
           }}
         >
-          {displayWidgets.map((w, i) => {
-            const pos = layout[i]
+          {displayWidgets.map((w) => {
             if (w.instanceId === '__phantom__') {
               return (
                 <PhantomSlot
                   key="__phantom__"
                   colSpan={w.colSpan}
                   rowSpan={w.rowSpan}
-                  gridCol={pos?.col}
-                  gridRow={pos?.row}
+                  gridCol={w.gridCol}
+                  gridRow={w.gridRow}
                 />
               )
             }
@@ -151,8 +143,8 @@ export default function HomePage() {
                 instanceId={w.instanceId}
                 colSpan={w.colSpan}
                 rowSpan={w.rowSpan}
-                gridCol={pos?.col}
-                gridRow={pos?.row}
+                gridCol={w.gridCol}
+                gridRow={w.gridRow}
               >
                 <Component
                   variant={w.variantId}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -4,7 +4,7 @@ import { useDroppable } from '@dnd-kit/core'
 import LiveDot from '@/components/ui/LiveDot'
 import useEditModeStore from '@/store/useEditModeStore'
 import useGridStore from '@/store/useGridStore'
-import useWidgetStore, { canFitInGrid, computeLayout } from '@/store/useWidgetStore'
+import useWidgetStore, { canFitInGrid } from '@/store/useWidgetStore'
 import { cn } from '@/lib/cn'
 import AddWidgetSlot from '@/components/widgets/AddWidgetSlot'
 import SortableWidgetCard from '@/components/widgets/SortableWidgetCard'
@@ -29,7 +29,7 @@ function PhantomSlot({ colSpan, rowSpan, gridCol, gridRow }) {
 export default function HomePage() {
   const { isEditMode } = useEditModeStore()
   const { setCellSize, setPreviewCellSize } = useGridStore()
-  const { widgets, removeWidget, phantomWidget, isDraggingNewWidget, isDraggingExistingWidget } = useWidgetStore()
+  const { widgets, removeWidget, phantomWidget, isDraggingNewWidget } = useWidgetStore()
   const gridRef = useRef(null)
   const isEditModeRef = useRef(isEditMode)
 
@@ -70,10 +70,6 @@ export default function HomePage() {
   const displayWidgets = phantomWidget
     ? [...widgets, { instanceId: '__phantom__', ...phantomWidget }]
     : widgets
-
-  // existing-widget 드래그 중: arrayMove로 바뀐 배열 순서 기준 computeLayout으로 렌더링
-  // → push-aside 효과. 정적 상태에서는 각 위젯의 명시적 gridCol/gridRow 사용.
-  const dragLayout = isDraggingExistingWidget ? computeLayout(displayWidgets) : null
 
   return (
     <div className="flex flex-col h-full overflow-hidden p-3 gap-2.5">
@@ -127,20 +123,15 @@ export default function HomePage() {
             minHeight: `${MIN_GRID_HEIGHT}px`,
           }}
         >
-          {displayWidgets.map((w, i) => {
-            // existing-widget 드래그 중: computeLayout 좌표 / 정적: 명시적 좌표
-            const pos = dragLayout?.[i]
-            const gridCol = pos?.col ?? w.gridCol
-            const gridRow = pos?.row ?? w.gridRow
-
+          {displayWidgets.map((w) => {
             if (w.instanceId === '__phantom__') {
               return (
                 <PhantomSlot
                   key="__phantom__"
                   colSpan={w.colSpan}
                   rowSpan={w.rowSpan}
-                  gridCol={gridCol}
-                  gridRow={gridRow}
+                  gridCol={w.gridCol}
+                  gridRow={w.gridRow}
                 />
               )
             }
@@ -152,8 +143,8 @@ export default function HomePage() {
                 instanceId={w.instanceId}
                 colSpan={w.colSpan}
                 rowSpan={w.rowSpan}
-                gridCol={gridCol}
-                gridRow={gridRow}
+                gridCol={w.gridCol}
+                gridRow={w.gridRow}
               >
                 <Component
                   variant={w.variantId}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -4,7 +4,7 @@ import { useDroppable } from '@dnd-kit/core'
 import LiveDot from '@/components/ui/LiveDot'
 import useEditModeStore from '@/store/useEditModeStore'
 import useGridStore from '@/store/useGridStore'
-import useWidgetStore, { canFitInGrid } from '@/store/useWidgetStore'
+import useWidgetStore, { canFitInGrid, computeLayout } from '@/store/useWidgetStore'
 import { cn } from '@/lib/cn'
 import AddWidgetSlot from '@/components/widgets/AddWidgetSlot'
 import SortableWidgetCard from '@/components/widgets/SortableWidgetCard'
@@ -29,7 +29,7 @@ function PhantomSlot({ colSpan, rowSpan, gridCol, gridRow }) {
 export default function HomePage() {
   const { isEditMode } = useEditModeStore()
   const { setCellSize, setPreviewCellSize } = useGridStore()
-  const { widgets, removeWidget, phantomWidget, isDraggingNewWidget } = useWidgetStore()
+  const { widgets, removeWidget, phantomWidget, isDraggingNewWidget, isDraggingExistingWidget } = useWidgetStore()
   const gridRef = useRef(null)
   const isEditModeRef = useRef(isEditMode)
 
@@ -70,6 +70,10 @@ export default function HomePage() {
   const displayWidgets = phantomWidget
     ? [...widgets, { instanceId: '__phantom__', ...phantomWidget }]
     : widgets
+
+  // existing-widget 드래그 중: arrayMove로 바뀐 배열 순서 기준 computeLayout으로 렌더링
+  // → push-aside 효과. 정적 상태에서는 각 위젯의 명시적 gridCol/gridRow 사용.
+  const dragLayout = isDraggingExistingWidget ? computeLayout(displayWidgets) : null
 
   return (
     <div className="flex flex-col h-full overflow-hidden p-3 gap-2.5">
@@ -123,15 +127,20 @@ export default function HomePage() {
             minHeight: `${MIN_GRID_HEIGHT}px`,
           }}
         >
-          {displayWidgets.map((w) => {
+          {displayWidgets.map((w, i) => {
+            // existing-widget 드래그 중: computeLayout 좌표 / 정적: 명시적 좌표
+            const pos = dragLayout?.[i]
+            const gridCol = pos?.col ?? w.gridCol
+            const gridRow = pos?.row ?? w.gridRow
+
             if (w.instanceId === '__phantom__') {
               return (
                 <PhantomSlot
                   key="__phantom__"
                   colSpan={w.colSpan}
                   rowSpan={w.rowSpan}
-                  gridCol={w.gridCol}
-                  gridRow={w.gridRow}
+                  gridCol={gridCol}
+                  gridRow={gridRow}
                 />
               )
             }
@@ -143,8 +152,8 @@ export default function HomePage() {
                 instanceId={w.instanceId}
                 colSpan={w.colSpan}
                 rowSpan={w.rowSpan}
-                gridCol={w.gridCol}
-                gridRow={w.gridRow}
+                gridCol={gridCol}
+                gridRow={gridRow}
               >
                 <Component
                   variant={w.variantId}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -67,20 +67,17 @@ export default function HomePage() {
   }, [setCellSize, setPreviewCellSize])
 
   // phantom은 좌표를 직접 보유 — 배열에 삽입하지 않고 displayWidgets 끝에 append
-  // swap 미리보기: B를 A의 원래 위치로 임시 이동해 렌더링
+  // push-aside 미리보기: B를 push-aside 목적지로 임시 이동해 렌더링
   // → phantom(A의 목적지)과 B가 같은 셀에 겹치는 현상 방지
   const displayWidgets = (() => {
     if (!phantomWidget) return widgets
     let base = widgets
-    if (phantomWidget.swapWithId && phantomWidget.activeId) {
-      const wA = widgets.find((w) => w.instanceId === phantomWidget.activeId)
-      if (wA) {
-        base = widgets.map((w) =>
-          w.instanceId === phantomWidget.swapWithId
-            ? { ...w, gridCol: wA.gridCol, gridRow: wA.gridRow }
-            : w,
-        )
-      }
+    if (phantomWidget.pushAsideId) {
+      base = widgets.map((w) =>
+        w.instanceId === phantomWidget.pushAsideId
+          ? { ...w, gridCol: phantomWidget.pushAsideCol, gridRow: phantomWidget.pushAsideRow }
+          : w,
+      )
     }
     return [...base, { instanceId: '__phantom__', ...phantomWidget }]
   })()

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -67,9 +67,23 @@ export default function HomePage() {
   }, [setCellSize, setPreviewCellSize])
 
   // phantom은 좌표를 직접 보유 — 배열에 삽입하지 않고 displayWidgets 끝에 append
-  const displayWidgets = phantomWidget
-    ? [...widgets, { instanceId: '__phantom__', ...phantomWidget }]
-    : widgets
+  // swap 미리보기: B를 A의 원래 위치로 임시 이동해 렌더링
+  // → phantom(A의 목적지)과 B가 같은 셀에 겹치는 현상 방지
+  const displayWidgets = (() => {
+    if (!phantomWidget) return widgets
+    let base = widgets
+    if (phantomWidget.swapWithId && phantomWidget.activeId) {
+      const wA = widgets.find((w) => w.instanceId === phantomWidget.activeId)
+      if (wA) {
+        base = widgets.map((w) =>
+          w.instanceId === phantomWidget.swapWithId
+            ? { ...w, gridCol: wA.gridCol, gridRow: wA.gridRow }
+            : w,
+        )
+      }
+    }
+    return [...base, { instanceId: '__phantom__', ...phantomWidget }]
+  })()
 
   return (
     <div className="flex flex-col h-full overflow-hidden p-3 gap-2.5">

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -105,6 +105,7 @@ export function findPushAsidePlanAt(widgets, activeId, targetCol, targetRow) {
   if (blockers.length === 0) return null
 
   // 큰 위젯을 먼저 배치하면 성공률이 높다.
+  // 주의: greedy 휴리스틱이라 최적 해가 존재해도 null을 반환할 수 있다.
   const sortedBlockers = [...blockers].sort((a, b) => {
     const areaDiff = b.colSpan * b.rowSpan - a.colSpan * a.rowSpan
     if (areaDiff !== 0) return areaDiff
@@ -250,21 +251,6 @@ const useWidgetStore = create((set) => ({
         w.instanceId === instanceId ? { ...w, gridCol, gridRow } : w,
       ),
     })),
-
-  // A → B의 자리, B → pushAsideCol/Row (nearest free cell)
-  pushAsideWidget: (activeId, pushAsideId, pushAsideCol, pushAsideRow) =>
-    set((state) => {
-      const wA = state.widgets.find((w) => w.instanceId === activeId)
-      const wB = state.widgets.find((w) => w.instanceId === pushAsideId)
-      if (!wA || !wB) return state
-      return {
-        widgets: state.widgets.map((w) => {
-          if (w.instanceId === activeId) return { ...w, gridCol: wB.gridCol, gridRow: wB.gridRow }
-          if (w.instanceId === pushAsideId) return { ...w, gridCol: pushAsideCol, gridRow: pushAsideRow }
-          return w
-        }),
-      }
-    }),
 
   // 연쇄 push-aside 적용: active를 target으로 이동 + blockers를 계획된 좌표로 이동
   applyPushAsidePlan: (plan) =>

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -53,6 +53,94 @@ export function canSwap(widgets, idA, idB) {
   return aFitsAtB && bFitsAtA
 }
 
+/* 지정 위치에서 가장 가까운 빈 셀 탐색 (push-aside용).
+   excludeIds: 충돌 판정에서 제외할 instanceId 목록 (드래그 중인 위젯 + 밀리는 위젯). */
+export function findNearestFreeCell(widgets, colSpan, rowSpan, fromCol, fromRow, excludeIds = []) {
+  const others = widgets.filter((w) => !excludeIds.includes(w.instanceId))
+  let best = null
+  let bestDist = Infinity
+  for (let r = 1; r <= GRID_ROWS - rowSpan + 1; r++) {
+    for (let c = 1; c <= GRID_COLS - colSpan + 1; c++) {
+      if (canPlaceAt(others, c, r, colSpan, rowSpan)) {
+        const dist = Math.abs(c - fromCol) + Math.abs(r - fromRow)
+        if (dist < bestDist) {
+          bestDist = dist
+          best = { gridCol: c, gridRow: r }
+        }
+      }
+    }
+  }
+  return best
+}
+
+/* active를 over의 자리로 이동시키기 위해 필요한 push-aside 이동 계획 생성.
+   - active의 target footprint와 겹치는 모든 위젯(blockers)을 연쇄적으로 가장 가까운 빈 셀로 이동
+   - blockers를 모두 재배치할 수 있으면 plan 반환, 아니면 null */
+export function findPushAsidePlan(widgets, activeId, overId) {
+  const active = widgets.find((w) => w.instanceId === activeId)
+  const over = widgets.find((w) => w.instanceId === overId)
+  if (!active || !over) return null
+
+  return findPushAsidePlanAt(widgets, activeId, over.gridCol, over.gridRow)
+}
+
+/* active를 지정 target 좌표(top-left)로 이동시키기 위해 필요한 push-aside 이동 계획 생성.
+   - active의 target footprint와 겹치는 모든 위젯(blockers)을 연쇄적으로 가장 가까운 빈 셀로 이동
+   - blockers를 모두 재배치할 수 있으면 plan 반환, 아니면 null */
+export function findPushAsidePlanAt(widgets, activeId, targetCol, targetRow) {
+  const active = widgets.find((w) => w.instanceId === activeId)
+  if (!active) return null
+
+  // active가 over 기준 좌표에 물리적으로 들어갈 수 있어야 함
+  if (targetCol + active.colSpan - 1 > GRID_COLS || targetRow + active.rowSpan - 1 > GRID_ROWS) {
+    return null
+  }
+
+  // active가 target에 들어갈 때 겹치는 위젯들(본인 제외)
+  const blockers = widgets.filter(
+    (w) =>
+      w.instanceId !== activeId &&
+      _overlap(targetCol, targetRow, active.colSpan, active.rowSpan, w.gridCol, w.gridRow, w.colSpan, w.rowSpan),
+  )
+  if (blockers.length === 0) return null
+
+  // 큰 위젯을 먼저 배치하면 성공률이 높다.
+  const sortedBlockers = [...blockers].sort((a, b) => {
+    const areaDiff = b.colSpan * b.rowSpan - a.colSpan * a.rowSpan
+    if (areaDiff !== 0) return areaDiff
+    const da = Math.abs(a.gridCol - targetCol) + Math.abs(a.gridRow - targetRow)
+    const db = Math.abs(b.gridCol - targetCol) + Math.abs(b.gridRow - targetRow)
+    return da - db
+  })
+
+  const blockerIds = new Set(sortedBlockers.map((w) => w.instanceId))
+  const working = widgets
+    .filter((w) => w.instanceId !== activeId && !blockerIds.has(w.instanceId))
+    .concat({
+      instanceId: '__ghost_active__',
+      gridCol: targetCol,
+      gridRow: targetRow,
+      colSpan: active.colSpan,
+      rowSpan: active.rowSpan,
+    })
+
+  const moves = []
+  for (const blocker of sortedBlockers) {
+    const cell = findNearestFreeCell(working, blocker.colSpan, blocker.rowSpan, blocker.gridCol, blocker.gridRow)
+    if (!cell) return null
+    moves.push({ instanceId: blocker.instanceId, gridCol: cell.gridCol, gridRow: cell.gridRow })
+    working.push({
+      instanceId: blocker.instanceId,
+      colSpan: blocker.colSpan,
+      rowSpan: blocker.rowSpan,
+      gridCol: cell.gridCol,
+      gridRow: cell.gridRow,
+    })
+  }
+
+  return { activeId, targetCol, targetRow, moves }
+}
+
 /* 그리드에 해당 크기의 위젯을 배치할 빈 공간이 있는지 확인 */
 export function canFitInGrid(widgets, colSpan, rowSpan) {
   for (let r = 1; r <= GRID_ROWS - rowSpan + 1; r++) {
@@ -163,16 +251,33 @@ const useWidgetStore = create((set) => ({
       ),
     })),
 
-  // 두 위젯의 위치를 교환 (occupied 셀 drop)
-  swapWidgets: (idA, idB) =>
+  // A → B의 자리, B → pushAsideCol/Row (nearest free cell)
+  pushAsideWidget: (activeId, pushAsideId, pushAsideCol, pushAsideRow) =>
     set((state) => {
-      const wA = state.widgets.find((w) => w.instanceId === idA)
-      const wB = state.widgets.find((w) => w.instanceId === idB)
+      const wA = state.widgets.find((w) => w.instanceId === activeId)
+      const wB = state.widgets.find((w) => w.instanceId === pushAsideId)
       if (!wA || !wB) return state
       return {
         widgets: state.widgets.map((w) => {
-          if (w.instanceId === idA) return { ...w, gridCol: wB.gridCol, gridRow: wB.gridRow }
-          if (w.instanceId === idB) return { ...w, gridCol: wA.gridCol, gridRow: wA.gridRow }
+          if (w.instanceId === activeId) return { ...w, gridCol: wB.gridCol, gridRow: wB.gridRow }
+          if (w.instanceId === pushAsideId) return { ...w, gridCol: pushAsideCol, gridRow: pushAsideRow }
+          return w
+        }),
+      }
+    }),
+
+  // 연쇄 push-aside 적용: active를 target으로 이동 + blockers를 계획된 좌표로 이동
+  applyPushAsidePlan: (plan) =>
+    set((state) => {
+      if (!plan?.activeId) return state
+      const moveMap = new Map((plan.moves || []).map((m) => [m.instanceId, m]))
+      return {
+        widgets: state.widgets.map((w) => {
+          if (w.instanceId === plan.activeId) {
+            return { ...w, gridCol: plan.targetCol, gridRow: plan.targetRow }
+          }
+          const m = moveMap.get(w.instanceId)
+          if (m) return { ...w, gridCol: m.gridCol, gridRow: m.gridRow }
           return w
         }),
       }

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -1,118 +1,43 @@
 import { create } from 'zustand'
-import { arrayMove } from '@dnd-kit/sortable'
 import { GRID_COLS, GRID_ROWS } from '@/lib/gridConstants'
 
-/* ── 그리드 배치 시뮬레이션 ────────────────────────────────
-   CSS grid auto-placement(row-first)를 모방해 빈 셀 탐색.
-   widgets를 순서대로 배치 후 새 위젯이 들어갈 자리가 있는지 확인.
+/* ── 충돌 판정 ──────────────────────────────────────────────
+   모든 좌표는 1-indexed (CSS grid와 동일).
 ──────────────────────────────────────────────────────────── */
-function _tryPlace(grid, colSpan, rowSpan) {
-  for (let row = 0; row <= GRID_ROWS - rowSpan; row++) {
-    for (let col = 0; col <= GRID_COLS - colSpan; col++) {
-      let ok = true
-      outer: for (let r = row; r < row + rowSpan; r++) {
-        for (let c = col; c < col + colSpan; c++) {
-          if (grid[r][c]) { ok = false; break outer }
-        }
-      }
-      if (ok) {
-        for (let r = row; r < row + rowSpan; r++)
-          for (let c = col; c < col + colSpan; c++)
-            grid[r][c] = true
-        return true
-      }
+function _overlap(ax, ay, aw, ah, bx, by, bw, bh) {
+  return ax < bx + bw && ax + aw > bx && ay < by + bh && ay + ah > by
+}
+
+/* 지정 셀에 위젯을 배치할 수 있는지 확인.
+   excludeId: 드래그 중인 위젯을 충돌 대상에서 제외할 때 사용. */
+export function canPlaceAt(widgets, targetCol, targetRow, colSpan, rowSpan, excludeId = null) {
+  if (targetCol < 1 || targetRow < 1) return false
+  if (targetCol + colSpan - 1 > GRID_COLS || targetRow + rowSpan - 1 > GRID_ROWS) return false
+  return !widgets.some(
+    (w) =>
+      w.instanceId !== excludeId &&
+      _overlap(targetCol, targetRow, colSpan, rowSpan, w.gridCol, w.gridRow, w.colSpan, w.rowSpan),
+  )
+}
+
+/* 그리드에 해당 크기의 위젯을 배치할 빈 공간이 있는지 확인 */
+export function canFitInGrid(widgets, colSpan, rowSpan) {
+  for (let r = 1; r <= GRID_ROWS - rowSpan + 1; r++) {
+    for (let c = 1; c <= GRID_COLS - colSpan + 1; c++) {
+      if (canPlaceAt(widgets, c, r, colSpan, rowSpan)) return true
     }
   }
   return false
 }
 
-function _simulatePlacement(widgets) {
-  const grid = Array.from({ length: GRID_ROWS }, () => Array(GRID_COLS).fill(false))
-  for (const w of widgets) {
-    if (!_tryPlace(grid, w.colSpan, w.rowSpan)) return false
-  }
-  return true
-}
-
-/* 위젯 배열을 시뮬레이션해 각 위젯의 CSS grid 좌표(1-indexed)를 반환.
-   CSS auto-placement 대신 이 좌표를 직접 style에 적용해 레이아웃 불일치를 방지. */
-export function computeLayout(items) {
-  const grid = Array.from({ length: GRID_ROWS }, () => Array(GRID_COLS).fill(false))
-  return items.map(({ colSpan, rowSpan }) => {
-    for (let row = 0; row <= GRID_ROWS - rowSpan; row++) {
-      for (let col = 0; col <= GRID_COLS - colSpan; col++) {
-        let ok = true
-        check: for (let r = row; r < row + rowSpan; r++) {
-          for (let c = col; c < col + colSpan; c++) {
-            if (grid[r][c]) { ok = false; break check }
-          }
-        }
-        if (ok) {
-          for (let r = row; r < row + rowSpan; r++)
-            for (let c = col; c < col + colSpan; c++)
-              grid[r][c] = true
-          return { row: row + 1, col: col + 1 } // CSS grid는 1-indexed
-        }
-      }
+/* 첫 번째 빈 셀 탐색 (addWidget 자동 배치용, 좌→우, 위→아래 순서) */
+function _findFirstFreeCell(widgets, colSpan, rowSpan) {
+  for (let r = 1; r <= GRID_ROWS - rowSpan + 1; r++) {
+    for (let c = 1; c <= GRID_COLS - colSpan + 1; c++) {
+      if (canPlaceAt(widgets, c, r, colSpan, rowSpan)) return { gridCol: c, gridRow: r }
     }
-    return null // canReorderWidgets/canFitInGrid가 정상 작동하면 발생 안 함
-  })
-}
-
-/* 포인터가 위치한 grid cell(row, col) 기준으로 삽입 인덱스 계산.
-   위젯 배치를 시뮬레이션해 target cell 이후 첫 번째 위젯 앞에 삽입. */
-export function findInsertIndex(widgets, targetRow, targetCol) {
-  if (widgets.length === 0) return 0
-
-  const grid = Array.from({ length: GRID_ROWS }, () => Array(GRID_COLS).fill(-1))
-  const positions = []
-
-  for (let i = 0; i < widgets.length; i++) {
-    const { colSpan, rowSpan } = widgets[i]
-    let found = false
-    outer: for (let row = 0; row <= GRID_ROWS - rowSpan; row++) {
-      for (let col = 0; col <= GRID_COLS - colSpan; col++) {
-        let ok = true
-        check: for (let r = row; r < row + rowSpan; r++) {
-          for (let c = col; c < col + colSpan; c++) {
-            if (grid[r][c] !== -1) { ok = false; break check }
-          }
-        }
-        if (ok) {
-          for (let r = row; r < row + rowSpan; r++)
-            for (let c = col; c < col + colSpan; c++)
-              grid[r][c] = i
-          positions.push({ row, col })
-          found = true
-          break outer
-        }
-      }
-    }
-    if (!found) positions.push(null)
   }
-
-  const targetOrder = targetRow * GRID_COLS + targetCol
-  for (let i = 0; i < positions.length; i++) {
-    if (!positions[i]) continue
-    const order = positions[i].row * GRID_COLS + positions[i].col
-    if (order >= targetOrder) return i
-  }
-  return widgets.length
-}
-
-export function canFitInGrid(widgets, colSpan, rowSpan) {
-  const grid = Array.from({ length: GRID_ROWS }, () => Array(GRID_COLS).fill(false))
-  for (const w of widgets) _tryPlace(grid, w.colSpan, w.rowSpan)
-  return _tryPlace(grid, colSpan, rowSpan)
-}
-
-/* 재배치 후 전체 위젯이 그리드에 정상 배치 가능한지 검증.
-   false 반환 시 해당 순서 변경은 허용하지 않는다. */
-export function canReorderWidgets(widgets, activeId, overId) {
-  const oldIndex = widgets.findIndex((w) => w.instanceId === activeId)
-  const newIndex = widgets.findIndex((w) => w.instanceId === overId)
-  if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) return false
-  return _simulatePlacement(arrayMove([...widgets], oldIndex, newIndex))
+  return null
 }
 
 // 6열 × 4행 (24셀) 기본 레이아웃
@@ -120,16 +45,16 @@ export function canReorderWidgets(widgets, activeId, overId) {
 // Row 2–3: stock-3x2(3×2) + ranking-lg(2×2) + watchlist-sm(1) + market-sm(1)    = 6×2
 // Row 4:   trade-wide(2) + stock-news-wide(2) + [빈 2칸]                         = 6
 const INITIAL_WIDGETS = [
-  { instanceId: 'w1',  widgetTypeId: 'index',           variantId: 'index-3x1',      colSpan: 3, rowSpan: 1 },
-  { instanceId: 'w2',  widgetTypeId: 'balance',         variantId: 'balance-sm',     colSpan: 1, rowSpan: 1 },
-  { instanceId: 'w3',  widgetTypeId: 'portfolio',       variantId: 'portfolio-sm',   colSpan: 1, rowSpan: 1 },
-  { instanceId: 'w4',  widgetTypeId: 'exchange',        variantId: 'exchange-sm',    colSpan: 1, rowSpan: 1 },
-  { instanceId: 'w5',  widgetTypeId: 'stock-chart',     variantId: 'stock-3x2',      colSpan: 3, rowSpan: 2, config: { stockId: 'samsung' } },
-  { instanceId: 'w6',  widgetTypeId: 'ranking',         variantId: 'ranking-lg',     colSpan: 2, rowSpan: 2 },
-  { instanceId: 'w7',  widgetTypeId: 'watchlist',       variantId: 'watchlist-sm',   colSpan: 1, rowSpan: 1 },
-  { instanceId: 'w8',  widgetTypeId: 'market-overview', variantId: 'market-sm',      colSpan: 1, rowSpan: 1 },
-  { instanceId: 'w9',  widgetTypeId: 'trade-history',   variantId: 'trade-wide',     colSpan: 2, rowSpan: 1 },
-  { instanceId: 'w10', widgetTypeId: 'stock-news',      variantId: 'stock-news-wide', colSpan: 2, rowSpan: 1 },
+  { instanceId: 'w1',  widgetTypeId: 'index',           variantId: 'index-3x1',       colSpan: 3, rowSpan: 1, gridCol: 1, gridRow: 1 },
+  { instanceId: 'w2',  widgetTypeId: 'balance',         variantId: 'balance-sm',      colSpan: 1, rowSpan: 1, gridCol: 4, gridRow: 1 },
+  { instanceId: 'w3',  widgetTypeId: 'portfolio',       variantId: 'portfolio-sm',    colSpan: 1, rowSpan: 1, gridCol: 5, gridRow: 1 },
+  { instanceId: 'w4',  widgetTypeId: 'exchange',        variantId: 'exchange-sm',     colSpan: 1, rowSpan: 1, gridCol: 6, gridRow: 1 },
+  { instanceId: 'w5',  widgetTypeId: 'stock-chart',     variantId: 'stock-3x2',       colSpan: 3, rowSpan: 2, gridCol: 1, gridRow: 2, config: { stockId: 'samsung' } },
+  { instanceId: 'w6',  widgetTypeId: 'ranking',         variantId: 'ranking-lg',      colSpan: 2, rowSpan: 2, gridCol: 4, gridRow: 2 },
+  { instanceId: 'w7',  widgetTypeId: 'watchlist',       variantId: 'watchlist-sm',    colSpan: 1, rowSpan: 1, gridCol: 6, gridRow: 2 },
+  { instanceId: 'w8',  widgetTypeId: 'market-overview', variantId: 'market-sm',       colSpan: 1, rowSpan: 1, gridCol: 6, gridRow: 3 },
+  { instanceId: 'w9',  widgetTypeId: 'trade-history',   variantId: 'trade-wide',      colSpan: 2, rowSpan: 1, gridCol: 1, gridRow: 4 },
+  { instanceId: 'w10', widgetTypeId: 'stock-news',      variantId: 'stock-news-wide', colSpan: 2, rowSpan: 1, gridCol: 3, gridRow: 4 },
 ]
 
 const useWidgetStore = create((set) => ({
@@ -142,20 +67,20 @@ const useWidgetStore = create((set) => ({
     set((state) => ({ widgets: state._snapshot ?? state.widgets, _snapshot: null })),
   clearSnapshot: () => set({ _snapshot: null }),
 
-  // new-widget 드래그 중 대시보드 outline 표시용 (useDndContext 구독 없이)
+  // new-widget 드래그 중 대시보드 outline 표시용
   isDraggingNewWidget: false,
   setIsDraggingNewWidget: (v) => set({ isDraggingNewWidget: v }),
 
-  // 드래그 중 ghost placeholder (new-widget 드래그 시 push-aside 표시용)
+  // 드래그 중 drop 예정 위치를 보여주는 ghost placeholder
   phantomWidget: null,
   setPhantom: (phantom) => set({ phantomWidget: phantom }),
   clearPhantom: () => set({ phantomWidget: null }),
 
-  setWidgetsOrder: (ordered) => set({ widgets: ordered }),
-
+  // 첫 번째 빈 셀에 위젯 추가 (AddWidgetSlot 클릭 등)
   addWidget: (widgetTypeId, variant) =>
     set((state) => {
-      if (!canFitInGrid(state.widgets, variant.colSpan, variant.rowSpan)) return state
+      const pos = _findFirstFreeCell(state.widgets, variant.colSpan, variant.rowSpan)
+      if (!pos) return state
       return {
         widgets: [
           ...state.widgets,
@@ -165,25 +90,31 @@ const useWidgetStore = create((set) => ({
             variantId: variant.id,
             colSpan: variant.colSpan,
             rowSpan: variant.rowSpan,
+            gridCol: pos.gridCol,
+            gridRow: pos.gridRow,
           },
         ],
       }
     }),
 
-  // 지정 인덱스에 위젯 삽입 (new-widget drag-to-add 용)
-  addWidgetAt: (widgetTypeId, variant, insertIndex) =>
+  // 지정 좌표에 위젯 추가 (drag-to-add 용)
+  addWidgetAt: (widgetTypeId, variant, gridCol, gridRow) =>
     set((state) => {
-      if (!canFitInGrid(state.widgets, variant.colSpan, variant.rowSpan)) return state
-      const newWidget = {
-        instanceId: crypto.randomUUID(),
-        widgetTypeId,
-        variantId: variant.id,
-        colSpan: variant.colSpan,
-        rowSpan: variant.rowSpan,
+      if (!canPlaceAt(state.widgets, gridCol, gridRow, variant.colSpan, variant.rowSpan)) return state
+      return {
+        widgets: [
+          ...state.widgets,
+          {
+            instanceId: crypto.randomUUID(),
+            widgetTypeId,
+            variantId: variant.id,
+            colSpan: variant.colSpan,
+            rowSpan: variant.rowSpan,
+            gridCol,
+            gridRow,
+          },
+        ],
       }
-      const next = [...state.widgets]
-      next.splice(Math.min(insertIndex, next.length), 0, newWidget)
-      return { widgets: next }
     }),
 
   removeWidget: (instanceId) =>
@@ -191,13 +122,13 @@ const useWidgetStore = create((set) => ({
       widgets: state.widgets.filter((w) => w.instanceId !== instanceId),
     })),
 
-  reorderWidgets: (activeId, overId) =>
-    set((state) => {
-      const oldIndex = state.widgets.findIndex((w) => w.instanceId === activeId)
-      const newIndex = state.widgets.findIndex((w) => w.instanceId === overId)
-      if (oldIndex === -1 || newIndex === -1) return state
-      return { widgets: arrayMove(state.widgets, oldIndex, newIndex) }
-    }),
+  // 기존 위젯을 지정 좌표로 이동
+  moveWidgetTo: (instanceId, gridCol, gridRow) =>
+    set((state) => ({
+      widgets: state.widgets.map((w) =>
+        w.instanceId === instanceId ? { ...w, gridCol, gridRow } : w,
+      ),
+    })),
 }))
 
 export default useWidgetStore

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -1,7 +1,8 @@
 import { create } from 'zustand'
+import { arrayMove } from '@dnd-kit/sortable'
 import { GRID_COLS, GRID_ROWS } from '@/lib/gridConstants'
 
-/* ── 충돌 판정 ──────────────────────────────────────────────
+/* ── 명시적 좌표 충돌 판정 ──────────────────────────────────
    모든 좌표는 1-indexed (CSS grid와 동일).
 ──────────────────────────────────────────────────────────── */
 function _overlap(ax, ay, aw, ah, bx, by, bw, bh) {
@@ -20,6 +21,71 @@ export function canPlaceAt(widgets, targetCol, targetRow, colSpan, rowSpan, excl
   )
 }
 
+/* ── 배열 순서 기반 배치 시뮬레이션 (push-aside 드래그용) ──
+   existing-widget 드래그 중 arrayMove 후 전체 레이아웃 계산에 사용.
+──────────────────────────────────────────────────────────── */
+function _tryPlace(grid, colSpan, rowSpan) {
+  for (let row = 0; row <= GRID_ROWS - rowSpan; row++) {
+    for (let col = 0; col <= GRID_COLS - colSpan; col++) {
+      let ok = true
+      outer: for (let r = row; r < row + rowSpan; r++) {
+        for (let c = col; c < col + colSpan; c++) {
+          if (grid[r][c]) { ok = false; break outer }
+        }
+      }
+      if (ok) {
+        for (let r = row; r < row + rowSpan; r++)
+          for (let c = col; c < col + colSpan; c++)
+            grid[r][c] = true
+        return true
+      }
+    }
+  }
+  return false
+}
+
+function _simulatePlacement(widgets) {
+  const grid = Array.from({ length: GRID_ROWS }, () => Array(GRID_COLS).fill(false))
+  for (const w of widgets) {
+    if (!_tryPlace(grid, w.colSpan, w.rowSpan)) return false
+  }
+  return true
+}
+
+/* 배열 순서대로 top-left 스캔해 각 위젯의 1-indexed CSS 좌표 계산.
+   existing-widget 드래그 중 push-aside 레이아웃 렌더링에 사용.
+   drop 시 이 결과를 gridCol/gridRow에 commit해 일관성 유지. */
+export function computeLayout(items) {
+  const grid = Array.from({ length: GRID_ROWS }, () => Array(GRID_COLS).fill(false))
+  return items.map(({ colSpan, rowSpan }) => {
+    for (let row = 0; row <= GRID_ROWS - rowSpan; row++) {
+      for (let col = 0; col <= GRID_COLS - colSpan; col++) {
+        let ok = true
+        check: for (let r = row; r < row + rowSpan; r++) {
+          for (let c = col; c < col + colSpan; c++) {
+            if (grid[r][c]) { ok = false; break check }
+          }
+        }
+        if (ok) {
+          for (let r = row; r < row + rowSpan; r++)
+            for (let c = col; c < col + colSpan; c++)
+              grid[r][c] = true
+          return { row: row + 1, col: col + 1 }
+        }
+      }
+    }
+    return null
+  })
+}
+
+/* reorder 후 전체 위젯이 그리드에 정상 배치 가능한지 검증 */
+export function canReorderWidgets(widgets, activeId, overId) {
+  const oldIndex = widgets.findIndex((w) => w.instanceId === activeId)
+  const newIndex = widgets.findIndex((w) => w.instanceId === overId)
+  if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) return false
+  return _simulatePlacement(arrayMove([...widgets], oldIndex, newIndex))
+}
+
 /* 그리드에 해당 크기의 위젯을 배치할 빈 공간이 있는지 확인 */
 export function canFitInGrid(widgets, colSpan, rowSpan) {
   for (let r = 1; r <= GRID_ROWS - rowSpan + 1; r++) {
@@ -30,7 +96,7 @@ export function canFitInGrid(widgets, colSpan, rowSpan) {
   return false
 }
 
-/* 첫 번째 빈 셀 탐색 (addWidget 자동 배치용, 좌→우, 위→아래 순서) */
+/* 첫 번째 빈 셀 탐색 (addWidget 자동 배치용) */
 function _findFirstFreeCell(widgets, colSpan, rowSpan) {
   for (let r = 1; r <= GRID_ROWS - rowSpan + 1; r++) {
     for (let c = 1; c <= GRID_COLS - colSpan + 1; c++) {
@@ -71,10 +137,36 @@ const useWidgetStore = create((set) => ({
   isDraggingNewWidget: false,
   setIsDraggingNewWidget: (v) => set({ isDraggingNewWidget: v }),
 
-  // 드래그 중 drop 예정 위치를 보여주는 ghost placeholder
+  // existing-widget 드래그 중 — computeLayout 렌더링 모드 전환용
+  isDraggingExistingWidget: false,
+  setIsDraggingExistingWidget: (v) => set({ isDraggingExistingWidget: v }),
+
+  // 드래그 중 drop 예정 위치를 보여주는 ghost placeholder (new-widget 전용)
   phantomWidget: null,
   setPhantom: (phantom) => set({ phantomWidget: phantom }),
   clearPhantom: () => set({ phantomWidget: null }),
+
+  // 배열 순서만 변경 (existing-widget push-aside 드래그용)
+  // gridCol/gridRow는 drop 시 commitLayout으로 일괄 확정
+  setWidgetsOrder: (ordered) => set({ widgets: ordered }),
+  reorderWidgets: (activeId, overId) =>
+    set((state) => {
+      const oldIndex = state.widgets.findIndex((w) => w.instanceId === activeId)
+      const newIndex = state.widgets.findIndex((w) => w.instanceId === overId)
+      if (oldIndex === -1 || newIndex === -1) return state
+      return { widgets: arrayMove(state.widgets, oldIndex, newIndex) }
+    }),
+
+  // drop 시 computeLayout 결과를 각 위젯의 gridCol/gridRow에 commit
+  commitLayout: () =>
+    set((state) => {
+      const layout = computeLayout(state.widgets)
+      return {
+        widgets: state.widgets.map((w, i) =>
+          layout[i] ? { ...w, gridCol: layout[i].col, gridRow: layout[i].row } : w,
+        ),
+      }
+    }),
 
   // 첫 번째 빈 셀에 위젯 추가 (AddWidgetSlot 클릭 등)
   addWidget: (widgetTypeId, variant) =>
@@ -97,7 +189,7 @@ const useWidgetStore = create((set) => ({
       }
     }),
 
-  // 지정 좌표에 위젯 추가 (drag-to-add 용)
+  // 지정 좌표에 위젯 추가 (new-widget drag-to-add 용)
   addWidgetAt: (widgetTypeId, variant, gridCol, gridRow) =>
     set((state) => {
       if (!canPlaceAt(state.widgets, gridCol, gridRow, variant.colSpan, variant.rowSpan)) return state
@@ -122,7 +214,7 @@ const useWidgetStore = create((set) => ({
       widgets: state.widgets.filter((w) => w.instanceId !== instanceId),
     })),
 
-  // 기존 위젯을 지정 좌표로 이동
+  // 기존 위젯을 지정 좌표로 이동 (단일 위젯 이동)
   moveWidgetTo: (instanceId, gridCol, gridRow) =>
     set((state) => ({
       widgets: state.widgets.map((w) =>

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -1,8 +1,7 @@
 import { create } from 'zustand'
-import { arrayMove } from '@dnd-kit/sortable'
 import { GRID_COLS, GRID_ROWS } from '@/lib/gridConstants'
 
-/* ── 명시적 좌표 충돌 판정 ──────────────────────────────────
+/* ── 충돌 판정 ──────────────────────────────────────────────
    모든 좌표는 1-indexed (CSS grid와 동일).
 ──────────────────────────────────────────────────────────── */
 function _overlap(ax, ay, aw, ah, bx, by, bw, bh) {
@@ -21,69 +20,37 @@ export function canPlaceAt(widgets, targetCol, targetRow, colSpan, rowSpan, excl
   )
 }
 
-/* ── 배열 순서 기반 배치 시뮬레이션 (push-aside 드래그용) ──
-   existing-widget 드래그 중 arrayMove 후 전체 레이아웃 계산에 사용.
-──────────────────────────────────────────────────────────── */
-function _tryPlace(grid, colSpan, rowSpan) {
-  for (let row = 0; row <= GRID_ROWS - rowSpan; row++) {
-    for (let col = 0; col <= GRID_COLS - colSpan; col++) {
-      let ok = true
-      outer: for (let r = row; r < row + rowSpan; r++) {
-        for (let c = col; c < col + colSpan; c++) {
-          if (grid[r][c]) { ok = false; break outer }
-        }
-      }
-      if (ok) {
-        for (let r = row; r < row + rowSpan; r++)
-          for (let c = col; c < col + colSpan; c++)
-            grid[r][c] = true
-        return true
-      }
-    }
-  }
-  return false
-}
+/* 두 위젯이 서로의 위치를 교환할 수 있는지 확인.
+   - A가 B의 좌표에, B가 A의 좌표에 배치될 때 다른 위젯과 충돌하지 않아야 함.
+   - 크기가 달라도 각자의 새 위치에 물리적으로 맞으면 swap 허용. */
+export function canSwap(widgets, idA, idB) {
+  const wA = widgets.find((w) => w.instanceId === idA)
+  const wB = widgets.find((w) => w.instanceId === idB)
+  if (!wA || !wB) return false
 
-function _simulatePlacement(widgets) {
-  const grid = Array.from({ length: GRID_ROWS }, () => Array(GRID_COLS).fill(false))
-  for (const w of widgets) {
-    if (!_tryPlace(grid, w.colSpan, w.rowSpan)) return false
-  }
-  return true
-}
+  // A가 B의 위치에 배치 가능한지 (A, B 자신 제외)
+  const aFitsAtB =
+    wB.gridCol + wA.colSpan - 1 <= GRID_COLS &&
+    wB.gridRow + wA.rowSpan - 1 <= GRID_ROWS &&
+    !widgets.some(
+      (w) =>
+        w.instanceId !== idA &&
+        w.instanceId !== idB &&
+        _overlap(wB.gridCol, wB.gridRow, wA.colSpan, wA.rowSpan, w.gridCol, w.gridRow, w.colSpan, w.rowSpan),
+    )
 
-/* 배열 순서대로 top-left 스캔해 각 위젯의 1-indexed CSS 좌표 계산.
-   existing-widget 드래그 중 push-aside 레이아웃 렌더링에 사용.
-   drop 시 이 결과를 gridCol/gridRow에 commit해 일관성 유지. */
-export function computeLayout(items) {
-  const grid = Array.from({ length: GRID_ROWS }, () => Array(GRID_COLS).fill(false))
-  return items.map(({ colSpan, rowSpan }) => {
-    for (let row = 0; row <= GRID_ROWS - rowSpan; row++) {
-      for (let col = 0; col <= GRID_COLS - colSpan; col++) {
-        let ok = true
-        check: for (let r = row; r < row + rowSpan; r++) {
-          for (let c = col; c < col + colSpan; c++) {
-            if (grid[r][c]) { ok = false; break check }
-          }
-        }
-        if (ok) {
-          for (let r = row; r < row + rowSpan; r++)
-            for (let c = col; c < col + colSpan; c++)
-              grid[r][c] = true
-          return { row: row + 1, col: col + 1 }
-        }
-      }
-    }
-    return null
-  })
-}
+  // B가 A의 위치에 배치 가능한지 (A, B 자신 제외)
+  const bFitsAtA =
+    wA.gridCol + wB.colSpan - 1 <= GRID_COLS &&
+    wA.gridRow + wB.rowSpan - 1 <= GRID_ROWS &&
+    !widgets.some(
+      (w) =>
+        w.instanceId !== idA &&
+        w.instanceId !== idB &&
+        _overlap(wA.gridCol, wA.gridRow, wB.colSpan, wB.rowSpan, w.gridCol, w.gridRow, w.colSpan, w.rowSpan),
+    )
 
-/* reorder 후 전체 위젯이 그리드에 정상 배치 가능한지 검증 */
-export function canReorderWidgets(widgets, activeId, overId) {
-  const oldIndex = widgets.findIndex((w) => w.instanceId === activeId)
-  const newIndex = widgets.findIndex((w) => w.instanceId === overId)
-  if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) return false
-  return _simulatePlacement(arrayMove([...widgets], oldIndex, newIndex))
+  return aFitsAtB && bFitsAtA
 }
 
 /* 그리드에 해당 크기의 위젯을 배치할 빈 공간이 있는지 확인 */
@@ -137,36 +104,10 @@ const useWidgetStore = create((set) => ({
   isDraggingNewWidget: false,
   setIsDraggingNewWidget: (v) => set({ isDraggingNewWidget: v }),
 
-  // existing-widget 드래그 중 — computeLayout 렌더링 모드 전환용
-  isDraggingExistingWidget: false,
-  setIsDraggingExistingWidget: (v) => set({ isDraggingExistingWidget: v }),
-
-  // 드래그 중 drop 예정 위치를 보여주는 ghost placeholder (new-widget 전용)
+  // 드래그 중 drop 예정 위치를 보여주는 ghost placeholder
   phantomWidget: null,
   setPhantom: (phantom) => set({ phantomWidget: phantom }),
   clearPhantom: () => set({ phantomWidget: null }),
-
-  // 배열 순서만 변경 (existing-widget push-aside 드래그용)
-  // gridCol/gridRow는 drop 시 commitLayout으로 일괄 확정
-  setWidgetsOrder: (ordered) => set({ widgets: ordered }),
-  reorderWidgets: (activeId, overId) =>
-    set((state) => {
-      const oldIndex = state.widgets.findIndex((w) => w.instanceId === activeId)
-      const newIndex = state.widgets.findIndex((w) => w.instanceId === overId)
-      if (oldIndex === -1 || newIndex === -1) return state
-      return { widgets: arrayMove(state.widgets, oldIndex, newIndex) }
-    }),
-
-  // drop 시 computeLayout 결과를 각 위젯의 gridCol/gridRow에 commit
-  commitLayout: () =>
-    set((state) => {
-      const layout = computeLayout(state.widgets)
-      return {
-        widgets: state.widgets.map((w, i) =>
-          layout[i] ? { ...w, gridCol: layout[i].col, gridRow: layout[i].row } : w,
-        ),
-      }
-    }),
 
   // 첫 번째 빈 셀에 위젯 추가 (AddWidgetSlot 클릭 등)
   addWidget: (widgetTypeId, variant) =>
@@ -214,13 +155,28 @@ const useWidgetStore = create((set) => ({
       widgets: state.widgets.filter((w) => w.instanceId !== instanceId),
     })),
 
-  // 기존 위젯을 지정 좌표로 이동 (단일 위젯 이동)
+  // 위젯을 지정 좌표로 이동 (빈 셀 drop)
   moveWidgetTo: (instanceId, gridCol, gridRow) =>
     set((state) => ({
       widgets: state.widgets.map((w) =>
         w.instanceId === instanceId ? { ...w, gridCol, gridRow } : w,
       ),
     })),
+
+  // 두 위젯의 위치를 교환 (occupied 셀 drop)
+  swapWidgets: (idA, idB) =>
+    set((state) => {
+      const wA = state.widgets.find((w) => w.instanceId === idA)
+      const wB = state.widgets.find((w) => w.instanceId === idB)
+      if (!wA || !wB) return state
+      return {
+        widgets: state.widgets.map((w) => {
+          if (w.instanceId === idA) return { ...w, gridCol: wB.gridCol, gridRow: wB.gridRow }
+          if (w.instanceId === idB) return { ...w, gridCol: wA.gridCol, gridRow: wA.gridRow }
+          return w
+        }),
+      }
+    }),
 }))
 
 export default useWidgetStore


### PR DESCRIPTION
## 연관된 이슈

Closes #53 

## 작업 내용

- existing-widget 드래그 시 포인터 기준이 아닌 위젯 내부 anchor 기준(top-left 오프셋 보정)으로 target 계산
- 점유 셀 드롭 시 연쇄 push-aside plan 생성/적용 로직 추가
- 끝자리/경계 드롭 시 target 좌표 보정 및 인식 개선
- phantom 미리보기가 push-aside 결과와 일치하도록 렌더 정합성 보정

## 체크리스트

- [x] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항(선택)

- 3x2 위젯을 우하단 셀 부근에서 잡아도 의도한 위치로 드롭되는지
- 점유 셀 드롭 시 연쇄 밀림 케이스(2x2/3x1 혼합)에서 배치가 자연스러운지