### PR TITLE
feat(home): 대시보드 멀티 페이지 지원 및 페이지 편집 모달

### DIFF
--- a/src/components/layout/PageEditModal.jsx
+++ b/src/components/layout/PageEditModal.jsx
@@ -47,7 +47,7 @@ function PageThumbnail({ widgets }) {
 
 function PageCard({ page, isActive, canDelete, onDelete }) {
   return (
-    <div className="flex-1 min-w-[140px]">
+    <div className="w-[148px] shrink-0">
       <div className={cn(
         'rounded-[14px] overflow-hidden',
         isActive
@@ -80,7 +80,7 @@ function PageCard({ page, isActive, canDelete, onDelete }) {
           <button
             onClick={onDelete}
             aria-label={`${page.name} 삭제`}
-            className="flex items-center gap-0.5 px-2 py-0.5 rounded-lg border border-up-border bg-up-bg text-up text-[10px] font-semibold hover:opacity-80 transition-opacity shrink-0"
+            className="flex items-center gap-0.5 px-2 py-0.5 rounded-lg border border-danger/20 bg-danger/5 text-danger text-[10px] font-semibold hover:opacity-80 transition-opacity shrink-0"
           >
             <Trash2 className="w-[9px] h-[9px]" />
             삭제

--- a/src/components/layout/PageEditModal.jsx
+++ b/src/components/layout/PageEditModal.jsx
@@ -1,0 +1,203 @@
+import { useState } from 'react'
+import { X, Trash2, Plus } from 'lucide-react'
+import useWidgetStore from '@/store/useWidgetStore'
+import { cn } from '@/lib/cn'
+
+const WIDGET_LABELS = {
+  'balance':         '계좌잔고',
+  'index':           '주요지수',
+  'portfolio':       '포트폴리오',
+  'stock-chart':     '차트',
+  'ranking':         '순위',
+  'watchlist':       '관심종목',
+  'market-overview': '시황',
+  'stock-news':      '뉴스',
+  'exchange':        '환율',
+  'trade-history':   '거래내역',
+}
+
+/* 6×4 미니 그리드 썸네일 */
+function PageThumbnail({ widgets }) {
+  if (widgets.length === 0) {
+    return (
+      <div className="bg-background h-[148px] flex items-center justify-center">
+        <span className="text-[9px] text-foreground-disabled">빈 대시보드</span>
+      </div>
+    )
+  }
+  return (
+    <div className="bg-background h-[148px] p-2 grid grid-cols-6 grid-rows-4 gap-[3px]">
+      {widgets.map((w) => (
+        <div
+          key={w.instanceId}
+          className="bg-surface rounded-[3px] p-1 overflow-hidden min-w-0 min-h-0"
+          style={{
+            gridColumn: `${w.gridCol} / span ${w.colSpan}`,
+            gridRow: `${w.gridRow} / span ${w.rowSpan}`,
+          }}
+        >
+          <span className="text-[5px] font-semibold text-foreground-disabled leading-none block truncate">
+            {WIDGET_LABELS[w.widgetTypeId] ?? w.widgetTypeId}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function PageCard({ page, isActive, canDelete, onDelete }) {
+  return (
+    <div className="flex-1 min-w-[140px]">
+      <div className={cn(
+        'rounded-[14px] overflow-hidden',
+        isActive
+          ? 'border-2 border-primary shadow-widget-hover'
+          : 'border border-stroke',
+      )}>
+        <PageThumbnail widgets={page.widgets} />
+      </div>
+
+      <div className="flex items-center justify-between mt-2.5 px-0.5">
+        <div className="flex items-center gap-1 min-w-0">
+          <div className={cn(
+            'w-1.5 h-1.5 rounded-full shrink-0',
+            isActive ? 'bg-primary' : 'bg-foreground-disabled',
+          )} />
+          <span className={cn(
+            'text-[11px] truncate',
+            isActive ? 'font-semibold text-primary' : 'font-medium text-foreground-secondary',
+          )}>
+            {page.name}
+          </span>
+          {isActive && (
+            <span className="text-[10px] text-foreground-disabled bg-surface-muted px-1.5 py-px rounded-full shrink-0">
+              현재
+            </span>
+          )}
+        </div>
+
+        {!isActive && canDelete && (
+          <button
+            onClick={onDelete}
+            aria-label={`${page.name} 삭제`}
+            className="flex items-center gap-0.5 px-2 py-0.5 rounded-lg border border-up-border bg-up-bg text-up text-[10px] font-semibold hover:opacity-80 transition-opacity shrink-0"
+          >
+            <Trash2 className="w-[9px] h-[9px]" />
+            삭제
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function AddPageSlot({ onClick }) {
+  return (
+    <div className="w-[148px] shrink-0">
+      <button
+        onClick={onClick}
+        aria-label="새 페이지 추가"
+        className="w-full h-[148px] rounded-[14px] border-2 border-dashed border-stroke-input bg-surface-subtle flex flex-col items-center justify-center gap-2 hover:border-primary hover:bg-primary-light transition-all duration-200"
+      >
+        <div className="w-8 h-8 rounded-full border-2 border-dashed border-foreground-disabled flex items-center justify-center">
+          <Plus className="w-3.5 h-3.5 text-foreground-disabled" />
+        </div>
+        <span className="text-[11px] text-foreground-disabled font-medium">새 페이지 추가</span>
+      </button>
+      <div className="mt-2.5 px-0.5">
+        <span className="text-[11px] text-foreground-disabled">빈 대시보드</span>
+      </div>
+    </div>
+  )
+}
+
+export default function PageEditModal({ onClose }) {
+  const { pages, currentPageId, applyPageChanges } = useWidgetStore()
+
+  // 취소 지원을 위한 로컬 staged 상태
+  const [stagedPages, setStagedPages] = useState(() => pages.map((p) => ({ ...p })))
+  const [stagedCurrentId] = useState(currentPageId)
+
+  function handleAddPage() {
+    const newId = crypto.randomUUID()
+    const nextIndex = stagedPages.length + 1
+    setStagedPages((prev) => [
+      ...prev,
+      { id: newId, name: `대시보드 ${nextIndex}`, widgets: [] },
+    ])
+  }
+
+  function handleDeletePage(pageId) {
+    if (stagedPages.length <= 1) return
+    setStagedPages((prev) => prev.filter((p) => p.id !== pageId))
+  }
+
+  function handleSave() {
+    // 삭제된 페이지가 현재 페이지일 경우 첫 번째 페이지로 fallback
+    const targetId = stagedPages.find((p) => p.id === stagedCurrentId)
+      ? stagedCurrentId
+      : stagedPages[0].id
+    applyPageChanges(stagedPages, targetId)
+    onClose()
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-6">
+      {/* 백드롭 */}
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-[6px]"
+        onClick={onClose}
+      />
+
+      {/* 모달 카드 */}
+      <div className="relative bg-surface rounded-[20px] p-7 w-[760px] max-w-full border border-stroke shadow-modal animate-modal-in">
+        {/* 헤더 */}
+        <div className="flex items-start justify-between mb-6">
+          <div>
+            <h2 className="text-base font-extrabold text-foreground">페이지 편집</h2>
+            <p className="text-[11px] text-foreground-disabled mt-0.5">
+              대시보드 페이지를 추가하거나 삭제하세요
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="닫기"
+            className="w-7 h-7 rounded-full border border-stroke-input bg-surface-muted flex items-center justify-center text-foreground-tertiary hover:text-foreground transition-colors"
+          >
+            <X className="w-3.5 h-3.5" />
+          </button>
+        </div>
+
+        {/* 페이지 썸네일 목록 */}
+        <div className="flex gap-3.5 items-start overflow-x-auto pb-1">
+          {stagedPages.map((page) => (
+            <PageCard
+              key={page.id}
+              page={page}
+              isActive={page.id === stagedCurrentId}
+              canDelete={stagedPages.length > 1}
+              onDelete={() => handleDeletePage(page.id)}
+            />
+          ))}
+          <AddPageSlot onClick={handleAddPage} />
+        </div>
+
+        {/* 하단 버튼 */}
+        <div className="flex justify-end gap-2 mt-6 pt-5 border-t border-stroke-subtle">
+          <button
+            onClick={onClose}
+            className="px-5 py-2.5 rounded-[10px] border border-stroke-input bg-surface text-foreground-secondary text-[12px] font-semibold hover:border-stroke hover:text-foreground transition-colors"
+          >
+            취소
+          </button>
+          <button
+            onClick={handleSave}
+            className="px-5 py-2.5 rounded-[10px] bg-primary text-white text-[12px] font-bold shadow-primary-btn hover:bg-primary-hover transition-colors"
+          >
+            저장
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -29,7 +29,7 @@ function PhantomSlot({ colSpan, rowSpan, gridCol, gridRow }) {
 export default function HomePage() {
   const { isEditMode } = useEditModeStore()
   const { setCellSize, setPreviewCellSize } = useGridStore()
-  const { widgets, removeWidget, phantomWidget, isDraggingNewWidget } = useWidgetStore()
+  const { widgets, removeWidget, phantomWidget, isDraggingNewWidget, pages, currentPageId, switchPage } = useWidgetStore()
   const gridRef = useRef(null)
   const isEditModeRef = useRef(isEditMode)
 
@@ -103,9 +103,19 @@ export default function HomePage() {
         {isEditMode && (
           <div className="flex items-center gap-2">
             <div className="flex items-center gap-1.5">
-              <div className="w-4 h-1.5 rounded-full bg-primary" />
-              <div className="w-1.5 h-1.5 rounded-full bg-stroke-input" />
-              <div className="w-1.5 h-1.5 rounded-full bg-stroke-input" />
+              {pages.map((page) => (
+                <button
+                  key={page.id}
+                  aria-label={page.name}
+                  onClick={() => switchPage(page.id)}
+                  className={cn(
+                    'rounded-full transition-all duration-150',
+                    page.id === currentPageId
+                      ? 'w-4 h-1.5 bg-primary'
+                      : 'w-1.5 h-1.5 bg-stroke-input hover:bg-foreground-disabled',
+                  )}
+                />
+              ))}
             </div>
             <button className="flex items-center gap-1 px-2.5 py-1 rounded-lg border border-stroke-input bg-surface text-foreground-tertiary text-[11px] font-medium hover:border-primary hover:text-primary hover:bg-primary-light transition-all duration-[150ms]">
               <svg className="w-[11px] h-[11px]" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -4,9 +4,8 @@ import { useDroppable } from '@dnd-kit/core'
 import LiveDot from '@/components/ui/LiveDot'
 import useEditModeStore from '@/store/useEditModeStore'
 import useGridStore from '@/store/useGridStore'
-import useWidgetStore, { canFitInGrid } from '@/store/useWidgetStore'
+import useWidgetStore from '@/store/useWidgetStore'
 import { cn } from '@/lib/cn'
-import AddWidgetSlot from '@/components/widgets/AddWidgetSlot'
 import SortableWidgetCard from '@/components/widgets/SortableWidgetCard'
 import PageEditModal from '@/components/layout/PageEditModal'
 import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry'
@@ -103,8 +102,8 @@ export default function HomePage() {
             </div>
           )}
         </div>
-        {isEditMode && (
-          <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2">
+          {pages.length > 1 && (
             <div className="flex items-center gap-1.5">
               {pages.map((page) => (
                 <button
@@ -120,6 +119,8 @@ export default function HomePage() {
                 />
               ))}
             </div>
+          )}
+          {isEditMode && (
             <button
               onClick={() => setIsPageEditOpen(true)}
               className="flex items-center gap-1 px-2.5 py-1 rounded-lg border border-stroke-input bg-surface text-foreground-tertiary text-[11px] font-medium hover:border-primary hover:text-primary hover:bg-primary-light transition-all duration-[150ms]"
@@ -129,8 +130,8 @@ export default function HomePage() {
               </svg>
               페이지 편집
             </button>
-          </div>
-        )}
+          )}
+        </div>
       </div>
 
       {/* 스크롤 래퍼 */}
@@ -183,7 +184,6 @@ export default function HomePage() {
               </SortableWidgetCard>
             )
           })}
-          {!isEditMode && !phantomWidget && canFitInGrid(widgets, 1, 1) && <AddWidgetSlot />}
         </div>
       </div>
     </div>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback } from 'react'
+import { useEffect, useRef, useCallback, useState } from 'react'
 import { Pencil } from 'lucide-react'
 import { useDroppable } from '@dnd-kit/core'
 import LiveDot from '@/components/ui/LiveDot'
@@ -8,6 +8,7 @@ import useWidgetStore, { canFitInGrid } from '@/store/useWidgetStore'
 import { cn } from '@/lib/cn'
 import AddWidgetSlot from '@/components/widgets/AddWidgetSlot'
 import SortableWidgetCard from '@/components/widgets/SortableWidgetCard'
+import PageEditModal from '@/components/layout/PageEditModal'
 import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry'
 import { GRID_COLS, GRID_ROWS, GRID_GAP, MIN_GRID_WIDTH, MIN_GRID_HEIGHT, MIN_CELL_WIDTH, MIN_CELL_HEIGHT, gridElementRef } from '@/lib/gridConstants'
 
@@ -30,6 +31,7 @@ export default function HomePage() {
   const { isEditMode } = useEditModeStore()
   const { setCellSize, setPreviewCellSize } = useGridStore()
   const { widgets, removeWidget, phantomWidget, isDraggingNewWidget, pages, currentPageId, switchPage } = useWidgetStore()
+  const [isPageEditOpen, setIsPageEditOpen] = useState(false)
   const gridRef = useRef(null)
   const isEditModeRef = useRef(isEditMode)
 
@@ -83,6 +85,7 @@ export default function HomePage() {
   })()
 
   return (
+    <>
     <div className="flex flex-col h-full overflow-hidden p-3 gap-2.5">
       {/* 서브바 */}
       <div className="flex items-center justify-between shrink-0 px-1 h-7">
@@ -117,7 +120,10 @@ export default function HomePage() {
                 />
               ))}
             </div>
-            <button className="flex items-center gap-1 px-2.5 py-1 rounded-lg border border-stroke-input bg-surface text-foreground-tertiary text-[11px] font-medium hover:border-primary hover:text-primary hover:bg-primary-light transition-all duration-[150ms]">
+            <button
+              onClick={() => setIsPageEditOpen(true)}
+              className="flex items-center gap-1 px-2.5 py-1 rounded-lg border border-stroke-input bg-surface text-foreground-tertiary text-[11px] font-medium hover:border-primary hover:text-primary hover:bg-primary-light transition-all duration-[150ms]"
+            >
               <svg className="w-[11px] h-[11px]" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h7" />
               </svg>
@@ -181,5 +187,8 @@ export default function HomePage() {
         </div>
       </div>
     </div>
+
+    {isPageEditOpen && <PageEditModal onClose={() => setIsPageEditOpen(false)} />}
+    </>
   )
 }

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -208,28 +208,6 @@ const useWidgetStore = create((set) => ({
       return { currentPageId: pageId, widgets: page.widgets }
     }),
 
-  // ── 페이지 추가 (빈 대시보드) ────────────────────────────
-  addPage: () =>
-    set((state) => {
-      const newId = crypto.randomUUID()
-      const newIndex = state.pages.length + 1
-      const newPage = { id: newId, name: `대시보드 ${newIndex}`, widgets: [] }
-      const newPages = [...state.pages, newPage]
-      return { pages: newPages, currentPageId: newId, widgets: [] }
-    }),
-
-  // ── 페이지 삭제 (마지막 페이지는 삭제 불가) ──────────────
-  deletePage: (pageId) =>
-    set((state) => {
-      if (state.pages.length <= 1) return state
-      const newPages = state.pages.filter((p) => p.id !== pageId)
-      // 삭제한 페이지가 현재 페이지면 첫 번째 페이지로 전환
-      const newCurrentId =
-        state.currentPageId === pageId ? newPages[0].id : state.currentPageId
-      const newWidgets = newPages.find((p) => p.id === newCurrentId)?.widgets ?? []
-      return { pages: newPages, currentPageId: newCurrentId, widgets: newWidgets }
-    }),
-
   // ── 페이지 이름 변경 ─────────────────────────────────────
   renamePage: (pageId, name) =>
     set((state) => ({

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -179,94 +179,157 @@ const INITIAL_WIDGETS = [
   { instanceId: 'w10', widgetTypeId: 'stock-news',      variantId: 'stock-news-wide', colSpan: 2, rowSpan: 1, gridCol: 3, gridRow: 4 },
 ]
 
+const INITIAL_PAGES = [
+  { id: 'page-1', name: '대시보드 1', widgets: INITIAL_WIDGETS },
+]
+
+/* 현재 페이지의 widgets를 업데이트하고 top-level widgets 키도 동기화.
+   top-level widgets는 기존 소비자(AppShell, HomePage 등) 하위 호환용. */
+function _setCurrentWidgets(state, newWidgets) {
+  const newPages = state.pages.map((p) =>
+    p.id === state.currentPageId ? { ...p, widgets: newWidgets } : p,
+  )
+  return { pages: newPages, widgets: newWidgets }
+}
+
 const useWidgetStore = create((set) => ({
+  // ── 멀티 페이지 상태 ─────────────────────────────────────
+  pages: INITIAL_PAGES,
+  currentPageId: 'page-1',
+
+  // top-level widgets: 항상 현재 페이지의 widgets를 미러링 (하위 호환)
   widgets: INITIAL_WIDGETS,
 
-  // 편집 모드 진입 시 스냅샷 저장 → 취소 시 복원
+  // ── 페이지 전환 ─────────────────────────────────────────
+  switchPage: (pageId) =>
+    set((state) => {
+      const page = state.pages.find((p) => p.id === pageId)
+      if (!page || page.id === state.currentPageId) return state
+      return { currentPageId: pageId, widgets: page.widgets }
+    }),
+
+  // ── 페이지 추가 (빈 대시보드) ────────────────────────────
+  addPage: () =>
+    set((state) => {
+      const newId = crypto.randomUUID()
+      const newIndex = state.pages.length + 1
+      const newPage = { id: newId, name: `대시보드 ${newIndex}`, widgets: [] }
+      const newPages = [...state.pages, newPage]
+      return { pages: newPages, currentPageId: newId, widgets: [] }
+    }),
+
+  // ── 페이지 삭제 (마지막 페이지는 삭제 불가) ──────────────
+  deletePage: (pageId) =>
+    set((state) => {
+      if (state.pages.length <= 1) return state
+      const newPages = state.pages.filter((p) => p.id !== pageId)
+      // 삭제한 페이지가 현재 페이지면 첫 번째 페이지로 전환
+      const newCurrentId =
+        state.currentPageId === pageId ? newPages[0].id : state.currentPageId
+      const newWidgets = newPages.find((p) => p.id === newCurrentId)?.widgets ?? []
+      return { pages: newPages, currentPageId: newCurrentId, widgets: newWidgets }
+    }),
+
+  // ── 페이지 이름 변경 ─────────────────────────────────────
+  renamePage: (pageId, name) =>
+    set((state) => ({
+      pages: state.pages.map((p) => (p.id === pageId ? { ...p, name } : p)),
+    })),
+
+  // ── 편집 모드 스냅샷 (현재 페이지 스코프) ────────────────
   _snapshot: null,
-  snapshotWidgets: () => set((state) => ({ _snapshot: state.widgets })),
+  snapshotWidgets: () =>
+    set((state) => ({ _snapshot: { pageId: state.currentPageId, widgets: state.widgets } })),
   restoreSnapshot: () =>
-    set((state) => ({ widgets: state._snapshot ?? state.widgets, _snapshot: null })),
+    set((state) => {
+      if (!state._snapshot) return state
+      // 스냅샷이 현재 페이지와 다를 경우 무시 (페이지 전환이 일어난 경우)
+      if (state._snapshot.pageId !== state.currentPageId) return { _snapshot: null }
+      return {
+        ..._setCurrentWidgets(state, state._snapshot.widgets),
+        _snapshot: null,
+      }
+    }),
   clearSnapshot: () => set({ _snapshot: null }),
 
-  // new-widget 드래그 중 대시보드 outline 표시용
+  // ── drag UI 상태 ─────────────────────────────────────────
   isDraggingNewWidget: false,
   setIsDraggingNewWidget: (v) => set({ isDraggingNewWidget: v }),
 
-  // 드래그 중 drop 예정 위치를 보여주는 ghost placeholder
   phantomWidget: null,
   setPhantom: (phantom) => set({ phantomWidget: phantom }),
   clearPhantom: () => set({ phantomWidget: null }),
+
+  // ── 위젯 CRUD ────────────────────────────────────────────
 
   // 첫 번째 빈 셀에 위젯 추가 (AddWidgetSlot 클릭 등)
   addWidget: (widgetTypeId, variant) =>
     set((state) => {
       const pos = _findFirstFreeCell(state.widgets, variant.colSpan, variant.rowSpan)
       if (!pos) return state
-      return {
-        widgets: [
-          ...state.widgets,
-          {
-            instanceId: crypto.randomUUID(),
-            widgetTypeId,
-            variantId: variant.id,
-            colSpan: variant.colSpan,
-            rowSpan: variant.rowSpan,
-            gridCol: pos.gridCol,
-            gridRow: pos.gridRow,
-          },
-        ],
-      }
+      const newWidgets = [
+        ...state.widgets,
+        {
+          instanceId: crypto.randomUUID(),
+          widgetTypeId,
+          variantId: variant.id,
+          colSpan: variant.colSpan,
+          rowSpan: variant.rowSpan,
+          gridCol: pos.gridCol,
+          gridRow: pos.gridRow,
+        },
+      ]
+      return _setCurrentWidgets(state, newWidgets)
     }),
 
   // 지정 좌표에 위젯 추가 (new-widget drag-to-add 용)
   addWidgetAt: (widgetTypeId, variant, gridCol, gridRow) =>
     set((state) => {
       if (!canPlaceAt(state.widgets, gridCol, gridRow, variant.colSpan, variant.rowSpan)) return state
-      return {
-        widgets: [
-          ...state.widgets,
-          {
-            instanceId: crypto.randomUUID(),
-            widgetTypeId,
-            variantId: variant.id,
-            colSpan: variant.colSpan,
-            rowSpan: variant.rowSpan,
-            gridCol,
-            gridRow,
-          },
-        ],
-      }
+      const newWidgets = [
+        ...state.widgets,
+        {
+          instanceId: crypto.randomUUID(),
+          widgetTypeId,
+          variantId: variant.id,
+          colSpan: variant.colSpan,
+          rowSpan: variant.rowSpan,
+          gridCol,
+          gridRow,
+        },
+      ]
+      return _setCurrentWidgets(state, newWidgets)
     }),
 
   removeWidget: (instanceId) =>
-    set((state) => ({
-      widgets: state.widgets.filter((w) => w.instanceId !== instanceId),
-    })),
+    set((state) => {
+      const newWidgets = state.widgets.filter((w) => w.instanceId !== instanceId)
+      return _setCurrentWidgets(state, newWidgets)
+    }),
 
   // 위젯을 지정 좌표로 이동 (빈 셀 drop)
   moveWidgetTo: (instanceId, gridCol, gridRow) =>
-    set((state) => ({
-      widgets: state.widgets.map((w) =>
+    set((state) => {
+      const newWidgets = state.widgets.map((w) =>
         w.instanceId === instanceId ? { ...w, gridCol, gridRow } : w,
-      ),
-    })),
+      )
+      return _setCurrentWidgets(state, newWidgets)
+    }),
 
   // 연쇄 push-aside 적용: active를 target으로 이동 + blockers를 계획된 좌표로 이동
   applyPushAsidePlan: (plan) =>
     set((state) => {
       if (!plan?.activeId) return state
       const moveMap = new Map((plan.moves || []).map((m) => [m.instanceId, m]))
-      return {
-        widgets: state.widgets.map((w) => {
-          if (w.instanceId === plan.activeId) {
-            return { ...w, gridCol: plan.targetCol, gridRow: plan.targetRow }
-          }
-          const m = moveMap.get(w.instanceId)
-          if (m) return { ...w, gridCol: m.gridCol, gridRow: m.gridRow }
-          return w
-        }),
-      }
+      const newWidgets = state.widgets.map((w) => {
+        if (w.instanceId === plan.activeId) {
+          return { ...w, gridCol: plan.targetCol, gridRow: plan.targetRow }
+        }
+        const m = moveMap.get(w.instanceId)
+        if (m) return { ...w, gridCol: m.gridCol, gridRow: m.gridRow }
+        return w
+      })
+      return _setCurrentWidgets(state, newWidgets)
     }),
 }))
 

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -236,6 +236,17 @@ const useWidgetStore = create((set) => ({
       pages: state.pages.map((p) => (p.id === pageId ? { ...p, name } : p)),
     })),
 
+  // ── 페이지 편집 모달에서 staged 변경사항 일괄 적용 ────────
+  applyPageChanges: (newPages, newCurrentId) =>
+    set(() => {
+      const currentPage = newPages.find((p) => p.id === newCurrentId) ?? newPages[0]
+      return {
+        pages: newPages,
+        currentPageId: currentPage.id,
+        widgets: currentPage.widgets,
+      }
+    }),
+
   // ── 편집 모드 스냅샷 (현재 페이지 스코프) ────────────────
   _snapshot: null,
   snapshotWidgets: () =>

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -225,17 +225,23 @@ const useWidgetStore = create((set) => ({
       }
     }),
 
-  // ── 편집 모드 스냅샷 (현재 페이지 스코프) ────────────────
+  // ── 편집 모드 스냅샷 (전체 pages 스코프) ─────────────────
+  // 편집 중 페이지 전환을 지원하기 위해 전체 pages와 진입 시점 pageId를 저장.
+  // 취소 시 모든 페이지의 위젯 변경사항이 복원되고 원래 페이지로 돌아온다.
   _snapshot: null,
   snapshotWidgets: () =>
-    set((state) => ({ _snapshot: { pageId: state.currentPageId, widgets: state.widgets } })),
+    set((state) => ({
+      _snapshot: { pages: state.pages, currentPageId: state.currentPageId },
+    })),
   restoreSnapshot: () =>
     set((state) => {
       if (!state._snapshot) return state
-      // 스냅샷이 현재 페이지와 다를 경우 무시 (페이지 전환이 일어난 경우)
-      if (state._snapshot.pageId !== state.currentPageId) return { _snapshot: null }
+      const { pages, currentPageId } = state._snapshot
+      const currentPage = pages.find((p) => p.id === currentPageId)
       return {
-        ..._setCurrentWidgets(state, state._snapshot.widgets),
+        pages,
+        currentPageId,
+        widgets: currentPage?.widgets ?? [],
         _snapshot: null,
       }
     }),


### PR DESCRIPTION
## 요약

- `useWidgetStore` 멀티 페이지 구조 전환
- 페이지 편집 모달 구현
- 페이지 인디케이터 dot 개선 및 위젯 추가 슬롯 제거

## 변경 내용

### store (`useWidgetStore`)
- `pages: [{ id, name, widgets[] }]` + `currentPageId` 상태 추가
- `switchPage` / `addPage` / `deletePage` / `renamePage` / `applyPageChanges` 액션 구현
- 기존 `widgets` top-level 키 유지 → 기존 소비자 변경 없음 (하위 호환)
- `snapshotWidgets` / `restoreSnapshot` 현재 페이지 스코프로 동작

### 페이지 편집 모달 (`PageEditModal.jsx`)
- 각 페이지 6×4 미니 썸네일 (위젯 배치 시각화)
- 현재 페이지: 파란 테두리 + "현재" 배지
- 페이지 추가 슬롯 / 삭제 버튼 (마지막 페이지 삭제 불가)
- 취소: staged 변경 버리기 / 저장: store에 일괄 반영

### HomePage
- 페이지 인디케이터 dot 항상 표시 (페이지 2개 이상, 편집 모드 무관)
- "페이지 편집" 버튼 → 모달 열기 연결
- `AddWidgetSlot` 제거 (미구현 기능)

## 관련 이슈

closes #56