### PR TITLE
fix(home): 페이지 인디케이터 페이지 수 무관 항상 표시

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -103,8 +103,7 @@ export default function HomePage() {
           )}
         </div>
         <div className="flex items-center gap-2">
-          {pages.length > 1 && (
-            <div className="flex items-center gap-1.5">
+          <div className="flex items-center gap-1.5">
               {pages.map((page) => (
                 <button
                   key={page.id}
@@ -118,8 +117,7 @@ export default function HomePage() {
                   )}
                 />
               ))}
-            </div>
-          )}
+          </div>
           {isEditMode && (
             <button
               onClick={() => setIsPageEditOpen(true)}


### PR DESCRIPTION
## 작업 내용

- `pages.length > 1` 조건 제거
- 페이지가 1개여도 상단 dot 인디케이터 항상 표시

close #60

## 확인 방법

1. 홈 페이지 진입
2. 서브바 우측에 dot 인디케이터 표시 확인 (페이지 1개 상태)