### PR TITLE
fix: 주문 확인 단가 스냅샷 고정 및 STOMP 구독 관리 리팩토링

### DIFF
--- a/src/components/invest/InvestOrderSection.jsx
+++ b/src/components/invest/InvestOrderSection.jsx
@@ -22,6 +22,7 @@ export default function InvestOrderSection({
   const [orderType, setOrderType] = useState('market')
   const [quantity, setQuantity] = useState(1)
   const [selectedPrice, setSelectedPrice] = useState(defaultPrice)
+  const [confirmedUnitPrice, setConfirmedUnitPrice] = useState(null)
 
   const [step, setStep] = useState('input') // 'input' | 'confirm'
   const [showPin, setShowPin] = useState(false)
@@ -30,7 +31,10 @@ export default function InvestOrderSection({
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const marketPrice = currentPrice ?? defaultPrice
-  const unitPrice = orderType === 'limit' ? selectedPrice : marketPrice
+  const liveUnitPrice = orderType === 'limit' ? selectedPrice : marketPrice
+  const unitPrice = step === 'confirm' && confirmedUnitPrice != null
+    ? confirmedUnitPrice
+    : liveUnitPrice
 
   const { data: buyableData } = useBuyableAmount({
     stockCode,
@@ -74,16 +78,19 @@ export default function InvestOrderSection({
   }
 
   function handleSideChange(nextSide) {
+    setConfirmedUnitPrice(null)
     setSide(nextSide)
     setQuantity((prev) => Math.min(prev, getMaxOrderQuantity(nextSide)))
   }
 
   function handleOrderTypeChange(nextOrderType) {
+    setConfirmedUnitPrice(null)
     setOrderType(nextOrderType)
     setQuantity((prev) => Math.min(prev, getMaxOrderQuantity(side, nextOrderType)))
   }
 
   function handleSelectPrice(price) {
+    setConfirmedUnitPrice(null)
     setSelectedPrice(price)
     setOrderType('limit')
     setQuantity((prev) => Math.min(prev, getMaxOrderQuantity(side, 'limit', price)))
@@ -105,6 +112,7 @@ export default function InvestOrderSection({
       setShowPin(false)
       setPin('')
       setPinError('')
+      setConfirmedUnitPrice(null)
       setQuantity(1)
       queryClient.invalidateQueries({ queryKey: ['balance'] })
       queryClient.invalidateQueries({ queryKey: ['orders'] })
@@ -152,6 +160,7 @@ export default function InvestOrderSection({
 
   // 뒤로 (confirm → input)
   function handleBack() {
+    setConfirmedUnitPrice(null)
     setStep('input')
     setShowPin(false)
     setPin('')
@@ -188,7 +197,10 @@ export default function InvestOrderSection({
         onQuantityDelta={handleQuantityDelta}
         onQuantityChange={handleQuantityChange}
         onPresetApply={handleQuantityPreset}
-        onSubmit={() => setStep('confirm')}
+        onSubmit={() => {
+          setConfirmedUnitPrice(liveUnitPrice)
+          setStep('confirm')
+        }}
         onConfirm={handleConfirm}
         onBack={handleBack}
         onPinChange={setPin}

--- a/src/lib/stomp.js
+++ b/src/lib/stomp.js
@@ -2,27 +2,26 @@ import { Client } from '@stomp/stompjs'
 import useAuthStore from '@/store/useAuthStore'
 
 let client = null
-const pendingSubscriptions = []
+let subscriptionSeq = 0
+const activeSubscriptions = new Map()
+
+function subscribeEntry(stompClient, entry) {
+  if (!stompClient?.connected) return
+  entry.liveSubscription = stompClient.subscribe(entry.topic, entry.callback)
+}
 
 export function getStompClient() {
   if (client) return client
 
-  const token = useAuthStore.getState().accessToken
-
-  if (!token) {
-    console.warn('[STOMP] 토큰 없음 — 연결 생략')
-    return null
-  }
-
   client = new Client({
     brokerURL: `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.host}/ws`,
-    connectHeaders: { Authorization: `Bearer ${token}` },
+    connectHeaders: {},
     beforeConnect: () => {
       const freshToken = useAuthStore.getState().accessToken
       if (freshToken) {
         client.connectHeaders = { Authorization: `Bearer ${freshToken}` }
       } else {
-        client.deactivate()
+        client.connectHeaders = {}
       }
     },
     reconnectDelay: 3000,
@@ -33,8 +32,9 @@ export function getStompClient() {
     },
     onConnect: () => {
       console.log('[STOMP] 연결 성공')
-      pendingSubscriptions.forEach((fn) => fn())
-      pendingSubscriptions.length = 0
+      activeSubscriptions.forEach((entry) => {
+        subscribeEntry(client, entry)
+      })
     },
     onStompError: (frame) => {
       console.error('[STOMP] 에러:', frame.headers.message)
@@ -42,8 +42,16 @@ export function getStompClient() {
     onWebSocketError: (event) => {
       console.error('[STOMP] WebSocket 에러:', event)
     },
+    onWebSocketClose: () => {
+      activeSubscriptions.forEach((entry) => {
+        entry.liveSubscription = null
+      })
+    },
     onDisconnect: () => {
       console.log('[STOMP] 연결 종료')
+      activeSubscriptions.forEach((entry) => {
+        entry.liveSubscription = null
+      })
     },
   })
 
@@ -53,36 +61,28 @@ export function getStompClient() {
 
 export function subscribeTopic(topic, callback) {
   const stompClient = getStompClient()
+  const id = ++subscriptionSeq
+  const entry = { topic, callback, liveSubscription: null }
+  activeSubscriptions.set(id, entry)
 
-  if (!stompClient) return { unsubscribe: () => {} }
-
-  if (stompClient.connected) {
-    return stompClient.subscribe(topic, callback)
+  if (stompClient?.connected) {
+    subscribeEntry(stompClient, entry)
   }
-
-  let subscription = null
-  let cancelled = false
-
-  const pending = () => {
-    if (!cancelled) {
-      subscription = stompClient.subscribe(topic, callback)
-    }
-  }
-
-  pendingSubscriptions.push(pending)
 
   return {
     unsubscribe: () => {
-      cancelled = true
-      subscription?.unsubscribe()
-      const idx = pendingSubscriptions.indexOf(pending)
-      if (idx !== -1) pendingSubscriptions.splice(idx, 1)
+      const current = activeSubscriptions.get(id)
+      current?.liveSubscription?.unsubscribe()
+      activeSubscriptions.delete(id)
     },
   }
 }
 
 export function deactivateStompClient() {
   if (client) {
+    activeSubscriptions.forEach((entry) => {
+      entry.liveSubscription = null
+    })
     client.deactivate()
     client = null
   }


### PR DESCRIPTION
## 연관된 이슈

## 작업 내용

### 1. fix(invest): 주문 확인 단계 진입 시 단가 스냅샷 고정
- `confirmedUnitPrice` 상태 추가
- `onSubmit` 시 `liveUnitPrice`를 `confirmedUnitPrice`에 저장
- confirm 단계에서 실시간 가격 변동에 영향 받지 않도록 `unitPrice` 분기 처리
- 주문 완료, 뒤로가기, 매수/매도 전환, 주문 유형 변경, 호가 선택 시 `confirmedUnitPrice` 초기화

### 2. refactor(stomp): 구독 관리를 Map 기반으로 전환 및 재연결 시 재구독 처리
- `pendingSubscriptions` 배열 제거, `activeSubscriptions` Map으로 교체
- 구독 항목에 순번 ID 부여하여 개별 해제 가능하도록 개선
- `onConnect` 시 `activeSubscriptions` 전체 재구독
- `onWebSocketClose` / `onDisconnect` 시 `liveSubscription` 초기화
- 토큰 없을 때 연결 생략 로직 제거, `beforeConnect`에서 헤더 동적 갱신으로 대체

### 스크린샷 (선택)

## 체크리스트

- [ ] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [ ] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항(선택)