### PR TITLE
feat(widget): 미니차트 연결, 로딩 상태 개선, 포트폴리오·환율 실 API 연동

### DIFF
--- a/src/api/dashboard.js
+++ b/src/api/dashboard.js
@@ -1,0 +1,13 @@
+import { fetchWithAuth } from '@/lib/fetchWithAuth'
+
+const BASE = '/api/dashboards'
+
+export const dashboardApi = {
+  getMyDashboard: () => fetchWithAuth(`${BASE}/me`),
+  saveMyDashboard: (payload) =>
+    fetchWithAuth(`${BASE}/me`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }),
+}

--- a/src/components/layout/AppHeader.jsx
+++ b/src/components/layout/AppHeader.jsx
@@ -70,24 +70,36 @@ function UserArea() {
 function EditModeActions() {
   const { exitEditMode, saveLayout } = useEditModeStore()
   const { restoreSnapshot, clearSnapshot } = useWidgetStore()
-  const { mutate: saveDashboard } = useDashboardSave()
+  const { mutate: saveDashboard, isPending, isError } = useDashboardSave()
+
+  function handleSave() {
+    clearSnapshot()
+    // 저장 성공 시 editMode 종료, 실패 시 UI에 오류 표시
+    saveDashboard(undefined, { onSuccess: saveLayout })
+  }
+
   return (
     <div className="flex items-center gap-2">
       <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl bg-primary-light border border-primary-border">
         <LayoutGrid className="w-3.5 h-3.5 text-primary" strokeWidth={2} />
         <span className="text-[12px] font-semibold text-primary">위젯 편집</span>
       </div>
+      {isError && (
+        <span className="text-[11px] text-down">저장 실패. 다시 시도해주세요.</span>
+      )}
       <button
         onClick={() => { restoreSnapshot(); exitEditMode() }}
-        className="px-3 py-1.5 rounded-xl border border-stroke-input text-[12px] text-foreground-tertiary font-medium hover:bg-surface-muted transition-colors duration-[150ms]"
+        disabled={isPending}
+        className="px-3 py-1.5 rounded-xl border border-stroke-input text-[12px] text-foreground-tertiary font-medium hover:bg-surface-muted transition-colors duration-[150ms] disabled:opacity-50"
       >
         취소
       </button>
       <button
-        onClick={() => { clearSnapshot(); saveLayout(); saveDashboard() }}
-        className="px-3 py-1.5 rounded-xl bg-primary text-white text-[12px] font-semibold hover:bg-primary-hover transition-colors duration-[150ms] shadow-primary-btn"
+        onClick={handleSave}
+        disabled={isPending}
+        className="px-3 py-1.5 rounded-xl bg-primary text-white text-[12px] font-semibold hover:bg-primary-hover transition-colors duration-[150ms] shadow-primary-btn disabled:opacity-50"
       >
-        완료 · 저장
+        {isPending ? '저장 중…' : '완료 · 저장'}
       </button>
     </div>
   )

--- a/src/components/layout/AppHeader.jsx
+++ b/src/components/layout/AppHeader.jsx
@@ -6,6 +6,7 @@ import { useMyAccount } from '@/api/account'
 import useRightPanelStore from '@/store/useRightPanelStore'
 import useEditModeStore from '@/store/useEditModeStore'
 import useWidgetStore from '@/store/useWidgetStore'
+import { useDashboardSave } from '@/hooks/useDashboardSync'
 
 function Logo() {
   return (
@@ -69,6 +70,7 @@ function UserArea() {
 function EditModeActions() {
   const { exitEditMode, saveLayout } = useEditModeStore()
   const { restoreSnapshot, clearSnapshot } = useWidgetStore()
+  const { mutate: saveDashboard } = useDashboardSave()
   return (
     <div className="flex items-center gap-2">
       <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl bg-primary-light border border-primary-border">
@@ -82,7 +84,7 @@ function EditModeActions() {
         취소
       </button>
       <button
-        onClick={() => { clearSnapshot(); saveLayout() }}
+        onClick={() => { clearSnapshot(); saveLayout(); saveDashboard() }}
         className="px-3 py-1.5 rounded-xl bg-primary text-white text-[12px] font-semibold hover:bg-primary-hover transition-colors duration-[150ms] shadow-primary-btn"
       >
         완료 · 저장

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -15,6 +15,7 @@ import useWidgetStore, { canPlaceAt, findPushAsidePlanAt } from '@/store/useWidg
 import useEditModeStore from '@/store/useEditModeStore'
 import useGridStore from '@/store/useGridStore'
 import useAuthStore from '@/store/useAuthStore'
+import { useDashboardLoad } from '@/hooks/useDashboardSync'
 import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry'
 import { GRID_GAP, GRID_COLS, GRID_ROWS, gridElementRef } from '@/lib/gridConstants'
 
@@ -22,6 +23,7 @@ export default function AppShell() {
   const location = useLocation()
   const navigate = useNavigate()
   const openLoginModal = useAuthStore((s) => s.openLoginModal)
+  useDashboardLoad()
 
   useEffect(() => {
     if (location.state?.openAuthModal) {

--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -99,10 +99,11 @@ function PreviewContent({ type }) {
               <div className="text-[10px] text-up mt-0.5">▲ +1,200 (+1.62%)</div>
             </div>
           </div>
-          <div className="flex-1 min-h-0 flex items-end gap-px pb-1 pt-2">
-            {[35,48,42,55,48,62,55,70,60,78,68,88].map((h, i) => (
-              <div key={i} className="flex-1 bg-up/50 rounded-sm" style={{ height: `${h}%` }} />
-            ))}
+          <div className="flex-1 min-h-0">
+            <svg viewBox="0 0 100 30" preserveAspectRatio="none" style={{ width: '100%', height: '100%', display: 'block' }}>
+              <path d="M0,28 L8,24 L16,26 L24,20 L32,22 L40,16 L48,18 L56,12 L64,14 L72,8 L80,10 L88,5 L100,2 L100,30 L0,30 Z" fill="rgba(232,57,62,0.15)" />
+              <polyline points="0,28 8,24 16,26 24,20 32,22 40,16 48,18 56,12 64,14 72,8 80,10 88,5 100,2" fill="none" stroke="var(--color-up)" strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
+            </svg>
           </div>
         </div>
       )
@@ -175,56 +176,33 @@ function PreviewContent({ type }) {
       return (
         <div className="flex flex-col h-full">
           <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">주요 지수</span>
-          <div className="flex-1 flex flex-col justify-start items-center text-center min-h-0 pt-1">
+          <div className="flex-1 flex flex-col justify-center items-center text-center min-h-0">
             <div className="text-[8px] text-foreground-disabled">KOSPI</div>
             <div className="text-[15px] font-extrabold text-foreground leading-tight">2,685.42</div>
             <div className="text-[9px] text-up font-medium">▲ +0.46%</div>
-          </div>
-          <div className="h-[18px] w-full shrink-0">
-            <svg viewBox="0 0 100 30" preserveAspectRatio="none" style={{ width: '100%', height: '100%', display: 'block' }}>
-              <path d="M0,27 L25,21 L50,14 L75,8 L100,3 L100,30 L0,30 Z" fill="rgba(232,57,62,0.1)" />
-              <polyline points="0,27 25,21 50,14 75,8 100,3" fill="none" stroke="var(--color-up)" strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
-            </svg>
           </div>
         </div>
       )
 
     /* 주요 지수 — 복합 2×1 */
-    case 'index-wide': {
-      const WIDE_PATHS = [
-        { area: 'M0,27 L25,21 L50,14 L75,8 L100,3 L100,30 L0,30 Z', line: '0,27 25,21 50,14 75,8 100,3' },
-        { area: 'M0,3 L33,12 L66,20 L100,27 L100,30 L0,30 Z',        line: '0,3 33,12 66,20 100,27'      },
-      ]
+    case 'index-wide':
       return (
         <div className="flex flex-col h-full gap-1">
           <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">주요 지수</span>
           <div className="flex flex-1 min-h-0 divide-x divide-stroke">
             {[
-              { name: 'KOSPI',  val: '2,685', chg: '+0.46%', up: true,  ...WIDE_PATHS[0] },
-              { name: 'KOSDAQ', val: '842',   chg: '-0.63%', up: false, ...WIDE_PATHS[1] },
-            ].map(({ name, val, chg, up, area, line }) => {
-              const color = up ? 'var(--color-up)' : 'var(--color-down)'
-              const fill  = up ? 'rgba(232,57,62,0.1)' : 'rgba(0,117,232,0.1)'
-              return (
-                <div key={name} className="flex-1 flex flex-col justify-between items-center px-2 py-0.5">
-                  <div className="text-center">
-                    <span className="text-[9px] font-semibold text-foreground-disabled">{name}</span>
-                    <div className="text-[12px] font-extrabold text-foreground leading-none">{val}</div>
-                    <span className={`text-[9px] font-medium ${up ? 'text-up' : 'text-down'}`}>{chg}</span>
-                  </div>
-                  <div className="h-[16px] w-full shrink-0">
-                    <svg viewBox="0 0 100 30" preserveAspectRatio="none" style={{ width: '100%', height: '100%', display: 'block' }}>
-                      <path d={area} fill={fill} />
-                      <polyline points={line} fill="none" stroke={color} strokeWidth="2" vectorEffect="non-scaling-stroke" />
-                    </svg>
-                  </div>
-                </div>
-              )
-            })}
+              { name: 'KOSPI',  val: '2,685', chg: '+0.46%', up: true  },
+              { name: 'KOSDAQ', val: '842',   chg: '-0.63%', up: false },
+            ].map(({ name, val, chg, up }) => (
+              <div key={name} className="flex-1 flex flex-col justify-center items-center text-center px-2">
+                <span className="text-[9px] font-semibold text-foreground-disabled">{name}</span>
+                <div className="text-[12px] font-extrabold text-foreground leading-none">{val}</div>
+                <span className={`text-[9px] font-medium ${up ? 'text-up' : 'text-down'}`}>{chg}</span>
+              </div>
+            ))}
           </div>
         </div>
       )
-    }
 
     /* 포트폴리오 — 파이차트 1×1 */
     case 'portfolio-sm':
@@ -297,32 +275,22 @@ function PreviewContent({ type }) {
     /* 환율 — 복합 2×1 */
     case 'exchange-wide': {
       const EX_WIDE = [
-        { pair: 'USD / KRW', rate: '1,378.50', chg: '▼ −2.30 (−0.17%)', up: false, flex: '1.2', pr: 'pr-3', pl: '', area: 'M0,3 L25,10 L50,17 L75,22 L100,27 L100,30 L0,30 Z', line: '0,3 25,10 50,17 75,22 100,27', rateSize: 'text-[13px]' },
-        { pair: 'JPY / KRW', rate: '9.18',     chg: '▲ +0.05 (+0.54%)', up: true,  flex: '1',   pr: '',    pl: 'pl-3', area: 'M0,27 L33,20 L66,12 L100,3 L100,30 L0,30 Z',       line: '0,27 33,20 66,12 100,3',    rateSize: 'text-[11px]' },
+        { pair: 'USD / KRW', rate: '1,378.50', chg: '▼ −2.30 (−0.17%)', up: false, flex: '1.2', pr: 'pr-3', pl: '', rateSize: 'text-[13px]' },
+        { pair: 'JPY / KRW', rate: '9.18',     chg: '▲ +0.05 (+0.54%)', up: true,  flex: '1',   pr: '',    pl: 'pl-3', rateSize: 'text-[11px]' },
       ]
       return (
         <div className="flex flex-col h-full gap-1">
           <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">환율</span>
           <div className="flex flex-1 min-h-0 divide-x divide-stroke">
-            {EX_WIDE.map(({ pair, rate, chg, up, flex, pr, pl, area, line, rateSize }) => {
-              const color = up ? 'var(--color-up)' : 'var(--color-down)'
-              const fill  = up ? 'rgba(232,57,62,0.1)' : 'rgba(0,117,232,0.1)'
-              return (
-                <div key={pair} className={`flex flex-col justify-between ${pr} ${pl}`} style={{ flex }}>
-                  <div className="text-center">
-                    <div className="text-[8px] text-foreground-disabled">{pair}</div>
-                    <div className={`${rateSize} font-extrabold text-foreground leading-tight`}>{rate}</div>
-                    <span className={`text-[8px] ${up ? 'text-up' : 'text-down'}`}>{chg}</span>
-                  </div>
-                  <div className="h-[14px] w-full shrink-0">
-                    <svg viewBox="0 0 100 30" preserveAspectRatio="none" style={{ width: '100%', height: '100%', display: 'block' }}>
-                      <path d={area} fill={fill} />
-                      <polyline points={line} fill="none" stroke={color} strokeWidth="2" vectorEffect="non-scaling-stroke" />
-                    </svg>
-                  </div>
+            {EX_WIDE.map(({ pair, rate, chg, up, flex, pr, pl, rateSize }) => (
+              <div key={pair} className={`flex flex-col justify-center ${pr} ${pl}`} style={{ flex }}>
+                <div className="text-center">
+                  <div className="text-[8px] text-foreground-disabled">{pair}</div>
+                  <div className={`${rateSize} font-extrabold text-foreground leading-tight`}>{rate}</div>
+                  <span className={`text-[8px] ${up ? 'text-up' : 'text-down'}`}>{chg}</span>
                 </div>
-              )
-            })}
+              </div>
+            ))}
           </div>
         </div>
       )
@@ -551,10 +519,11 @@ function PreviewContent({ type }) {
             </div>
             <div className="flex flex-col flex-1 min-w-0 pl-3 border-l border-stroke">
               <div className="text-[8px] text-foreground-disabled shrink-0">수익 추이 (30일)</div>
-              <div className="flex-1 min-h-0 flex items-end gap-px my-1">
-                {[30,38,35,50,55,65,70,80,85,92].map((h, i) => (
-                  <div key={i} className="flex-1 bg-up/50 rounded-sm" style={{ height: `${h}%` }} />
-                ))}
+              <div className="flex-1 min-h-0 my-1">
+                <svg viewBox="0 0 100 30" preserveAspectRatio="none" style={{ width: '100%', height: '100%', display: 'block' }}>
+                  <path d="M0,27 L12,23 L24,25 L36,18 L50,14 L62,10 L74,7 L86,4 L100,1 L100,30 L0,30 Z" fill="rgba(232,57,62,0.15)" />
+                  <polyline points="0,27 12,23 24,25 36,18 50,14 62,10 74,7 86,4 100,1" fill="none" stroke="var(--color-up)" strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
+                </svg>
               </div>
               <div className="text-[8px] text-foreground-disabled text-right shrink-0">최고 +5.2%</div>
             </div>
@@ -584,10 +553,11 @@ function PreviewContent({ type }) {
               </div>
             ))}
           </div>
-          <div className="flex-1 min-h-0 bg-background rounded-lg flex items-end px-1.5 pb-1 pt-1.5 gap-px">
-            {[30, 45, 38, 60, 52, 65, 55, 70, 62, 78, 68, 85].map((h, i) => (
-              <div key={i} className="flex-1 bg-up/50 rounded-sm" style={{ height: `${h}%` }} />
-            ))}
+          <div className="flex-1 min-h-0 bg-background rounded-lg overflow-hidden">
+            <svg viewBox="0 0 100 30" preserveAspectRatio="none" style={{ width: '100%', height: '100%', display: 'block' }}>
+              <path d="M0,27 L10,22 L20,24 L30,18 L40,20 L50,13 L60,15 L70,8 L80,10 L90,5 L100,2 L100,30 L0,30 Z" fill="rgba(232,57,62,0.15)" />
+              <polyline points="0,27 10,22 20,24 30,18 40,20 50,13 60,15 70,8 80,10 90,5 100,2" fill="none" stroke="var(--color-up)" strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
+            </svg>
           </div>
         </div>
       )
@@ -611,10 +581,11 @@ function PreviewContent({ type }) {
               <div className="text-[10px] text-up">▲ +1,200 (+1.62%)</div>
             </div>
           </div>
-          <div className="flex-1 min-h-0 bg-background rounded-lg flex items-end px-2 pb-2 pt-2 gap-px">
-            {[38, 52, 44, 58, 48, 62, 50, 68, 56, 72, 60, 78, 65, 82, 70, 88, 75, 90, 78, 85].map((h, i) => (
-              <div key={i} className="flex-1 bg-up/50 rounded-sm" style={{ height: `${h}%` }} />
-            ))}
+          <div className="flex-1 min-h-0 overflow-hidden">
+            <svg viewBox="0 0 100 30" preserveAspectRatio="none" style={{ width: '100%', height: '100%', display: 'block' }}>
+              <path d="M0,28 L6,25 L12,26 L20,21 L28,23 L36,17 L44,19 L52,13 L60,15 L68,9 L76,11 L84,5 L92,7 L100,3 L100,30 L0,30 Z" fill="rgba(232,57,62,0.15)" />
+              <polyline points="0,28 6,25 12,26 20,21 28,23 36,17 44,19 52,13 60,15 68,9 76,11 84,5 92,7 100,3" fill="none" stroke="var(--color-up)" strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
+            </svg>
           </div>
           <div className="flex justify-between shrink-0">
             {[
@@ -633,62 +604,41 @@ function PreviewContent({ type }) {
       )
 
     /* 주요 지수 — 3지수 3×1 */
-    case 'index-3x1': {
-      const IDX_3X1 = [
-        { name: 'KOSPI',  val: '2,685.42', chg: '+0.46%', up: true,  area: 'M0,27 L25,21 L50,14 L75,8 L100,3 L100,30 L0,30 Z',  line: '0,27 25,21 50,14 75,8 100,3'  },
-        { name: 'KOSDAQ', val: '868.15',   chg: '-0.21%', up: false, area: 'M0,3 L25,10 L50,17 L75,22 L100,27 L100,30 L0,30 Z',  line: '0,3 25,10 50,17 75,22 100,27' },
-        { name: 'NASDAQ', val: '16,274',   chg: '+0.83%', up: true,  area: 'M0,27 L25,21 L50,14 L75,8 L100,3 L100,30 L0,30 Z',  line: '0,27 25,21 50,14 75,8 100,3'  },
-      ]
+    case 'index-3x1':
       return (
         <div className="flex flex-col h-full gap-1">
           <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">주요 지수</span>
           <div className="flex flex-1 min-h-0 divide-x divide-stroke">
-            {IDX_3X1.map(({ name, val, chg, up, area, line }) => {
-              const color = up ? 'var(--color-up)' : 'var(--color-down)'
-              const fill  = up ? 'rgba(232,57,62,0.1)' : 'rgba(0,117,232,0.1)'
-              return (
-                <div key={name} className="flex-1 flex flex-col items-center px-2">
-                  <div className="flex-1 flex flex-col justify-start items-center text-center pt-1">
-                    <div className="text-[8px] text-foreground-disabled">{name}</div>
-                    <div className="text-[11px] font-extrabold text-foreground leading-tight">{val}</div>
-                    <span className={`text-[9px] font-medium ${up ? 'text-up' : 'text-down'}`}>{chg}</span>
-                  </div>
-                  <div className="h-[18px] w-full shrink-0">
-                    <svg viewBox="0 0 100 30" preserveAspectRatio="none" style={{ width: '100%', height: '100%', display: 'block' }}>
-                      <path d={area} fill={fill} />
-                      <polyline points={line} fill="none" stroke={color} strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
-                    </svg>
-                  </div>
-                </div>
-              )
-            })}
+            {[
+              { name: 'KOSPI',  val: '2,685.42', chg: '+0.46%', up: true  },
+              { name: 'KOSDAQ', val: '868.15',   chg: '-0.21%', up: false },
+              { name: 'NASDAQ', val: '16,274',   chg: '+0.83%', up: true  },
+            ].map(({ name, val, chg, up }) => (
+              <div key={name} className="flex-1 flex flex-col justify-center items-center text-center px-2">
+                <div className="text-[8px] text-foreground-disabled">{name}</div>
+                <div className="text-[11px] font-extrabold text-foreground leading-tight">{val}</div>
+                <span className={`text-[9px] font-medium ${up ? 'text-up' : 'text-down'}`}>{chg}</span>
+              </div>
+            ))}
           </div>
         </div>
       )
-    }
 
     /* 주요 지수 — 대형 (구 2×2, 미사용) */
     case 'index-2x2':
       return (
         <div className="flex flex-col h-full gap-2">
           <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">주요 지수</span>
-          <div className="flex flex-col gap-2.5">
+          <div className="flex flex-col justify-center gap-2.5 flex-1">
             {[
-              { name: 'KOSPI',  val: '2,685.42', chg: '+12.3',  pct: '+0.46%', up: true,  bars: [50,55,48,60,52,58,54,62] },
-              { name: 'KOSDAQ', val: '868.15',   chg: '-1.8',   pct: '-0.21%', up: false, bars: [60,55,58,52,56,50,54,48] },
-              { name: 'NASDAQ', val: '16,274',   chg: '+135.2', pct: '+0.83%', up: true,  bars: [45,52,48,58,54,62,58,68] },
-            ].map(({ name, val, chg, pct, up, bars }) => (
-              <div key={name} className="flex items-center gap-2">
-                <div className="flex-1 min-w-0">
-                  <div className="text-[9px] font-semibold text-foreground-disabled">{name}</div>
-                  <div className="text-[12px] font-extrabold text-foreground leading-none">{val}</div>
-                  <div className={`text-[9px] font-medium ${up ? 'text-up' : 'text-down'}`}>{chg} ({pct})</div>
-                </div>
-                <div className="flex items-end gap-px h-7 shrink-0">
-                  {bars.map((h, i) => (
-                    <div key={i} className={`w-1 rounded-sm ${up ? 'bg-up/50' : 'bg-down/50'}`} style={{ height: `${h}%` }} />
-                  ))}
-                </div>
+              { name: 'KOSPI',  val: '2,685.42', chg: '+0.46%', up: true  },
+              { name: 'KOSDAQ', val: '868.15',   chg: '-0.21%', up: false },
+              { name: 'NASDAQ', val: '16,274',   chg: '+0.83%', up: true  },
+            ].map(({ name, val, chg, up }) => (
+              <div key={name} className="flex-1 min-w-0">
+                <div className="text-[9px] font-semibold text-foreground-disabled">{name}</div>
+                <div className="text-[12px] font-extrabold text-foreground leading-none">{val}</div>
+                <div className={`text-[9px] font-medium ${up ? 'text-up' : 'text-down'}`}>{chg}</div>
               </div>
             ))}
           </div>
@@ -759,10 +709,11 @@ function PreviewContent({ type }) {
               <span key={t} className={`text-[8px] px-1.5 py-0.5 rounded ${i === 0 ? 'bg-primary-light text-primary font-semibold' : 'text-foreground-disabled'}`}>{t}</span>
             ))}
           </div>
-          <div className="flex-1 min-h-0 bg-background rounded-lg flex items-end px-2 pb-2 gap-px">
-            {[28,35,32,44,48,54,58,65,70,76,82,88,92,96].map((h, i) => (
-              <div key={i} className="flex-1 bg-up/50 rounded-sm" style={{ height: `${h}%` }} />
-            ))}
+          <div className="flex-1 min-h-0 overflow-hidden">
+            <svg viewBox="0 0 100 30" preserveAspectRatio="none" style={{ width: '100%', height: '100%', display: 'block' }}>
+              <path d="M0,27 L10,24 L20,25 L30,19 L40,21 L50,15 L60,17 L70,10 L80,12 L90,6 L100,3 L100,30 L0,30 Z" fill="rgba(232,57,62,0.15)" />
+              <polyline points="0,27 10,24 20,25 30,19 40,21 50,15 60,17 70,10 80,12 90,6 100,3" fill="none" stroke="var(--color-up)" strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
+            </svg>
           </div>
           <div className="flex justify-between shrink-0">
             {[
@@ -784,33 +735,23 @@ function PreviewContent({ type }) {
     /* 환율 — 3통화 3×1 */
     case 'exchange-3x1': {
       const EX_3X1 = [
-        { pair: 'USD / KRW', rate: '1,378.50', chg: '▼ −2.30', up: false, flex: '1.2', pr: 'pr-3', pl: '',    rateSize: 'text-[13px]', area: 'M0,3 L25,10 L50,17 L75,22 L100,27 L100,30 L0,30 Z', line: '0,3 25,10 50,17 75,22 100,27' },
-        { pair: 'JPY / KRW', rate: '9.18',     chg: '▲ +0.05', up: true,  flex: '1',   pr: 'pr-2', pl: 'pl-2', rateSize: 'text-[11px]', area: 'M0,27 L33,20 L66,12 L100,3 L100,30 L0,30 Z',       line: '0,27 33,20 66,12 100,3'     },
-        { pair: 'EUR / KRW', rate: '1,502.30', chg: '▼ −3.20', up: false, flex: '1',   pr: '',    pl: 'pl-2', rateSize: 'text-[11px]', area: 'M0,3 L33,12 L66,20 L100,27 L100,30 L0,30 Z',        line: '0,3 33,12 66,20 100,27'     },
+        { pair: 'USD / KRW', rate: '1,378.50', chg: '▼ −2.30', up: false, flex: '1.2', pr: 'pr-3', pl: '',    rateSize: 'text-[13px]' },
+        { pair: 'JPY / KRW', rate: '9.18',     chg: '▲ +0.05', up: true,  flex: '1',   pr: 'pr-2', pl: 'pl-2', rateSize: 'text-[11px]' },
+        { pair: 'EUR / KRW', rate: '1,502.30', chg: '▼ −3.20', up: false, flex: '1',   pr: '',    pl: 'pl-2', rateSize: 'text-[11px]' },
       ]
       return (
         <div className="flex flex-col h-full gap-1">
           <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">환율</span>
           <div className="flex flex-1 min-h-0 divide-x divide-stroke">
-            {EX_3X1.map(({ pair, rate, chg, up, flex, pr, pl, rateSize, area, line }) => {
-              const color = up ? 'var(--color-up)' : 'var(--color-down)'
-              const fill  = up ? 'rgba(232,57,62,0.1)' : 'rgba(0,117,232,0.1)'
-              return (
-                <div key={pair} className={`flex flex-col justify-between ${pr} ${pl}`} style={{ flex }}>
-                  <div className="text-center">
-                    <div className="text-[8px] text-foreground-disabled">{pair}</div>
-                    <div className={`${rateSize} font-extrabold text-foreground leading-tight`}>{rate}</div>
-                    <span className={`text-[8px] ${up ? 'text-up' : 'text-down'}`}>{chg}</span>
-                  </div>
-                  <div className="h-[14px] w-full shrink-0">
-                    <svg viewBox="0 0 100 30" preserveAspectRatio="none" style={{ width: '100%', height: '100%', display: 'block' }}>
-                      <path d={area} fill={fill} />
-                      <polyline points={line} fill="none" stroke={color} strokeWidth="2" vectorEffect="non-scaling-stroke" />
-                    </svg>
-                  </div>
+            {EX_3X1.map(({ pair, rate, chg, up, flex, pr, pl, rateSize }) => (
+              <div key={pair} className={`flex flex-col justify-center ${pr} ${pl}`} style={{ flex }}>
+                <div className="text-center">
+                  <div className="text-[8px] text-foreground-disabled">{pair}</div>
+                  <div className={`${rateSize} font-extrabold text-foreground leading-tight`}>{rate}</div>
+                  <span className={`text-[8px] ${up ? 'text-up' : 'text-down'}`}>{chg}</span>
                 </div>
-              )
-            })}
+              </div>
+            ))}
           </div>
         </div>
       )
@@ -828,11 +769,7 @@ function PreviewContent({ type }) {
             <div className="text-[20px] font-extrabold text-foreground leading-none">1,378.50</div>
             <div className="text-[10px] text-down">▼ -2.30 (-0.17%)</div>
           </div>
-          <div className="h-10 bg-background rounded-lg flex items-end px-1.5 pb-1 gap-px shrink-0">
-            {[60, 58, 62, 55, 58, 52, 56, 50, 54, 48, 52, 46].map((h, i) => (
-              <div key={i} className="flex-1 bg-down/40 rounded-sm" style={{ height: `${h}%` }} />
-            ))}
-          </div>
+
           <div className="flex flex-col gap-2">
             {[
               { pair: 'JPY / KRW', rate: '9.18',     chg: '+0.11%', up: true  },

--- a/src/components/ui/MiniChart.jsx
+++ b/src/components/ui/MiniChart.jsx
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from 'react'
+import { AreaSeries, createChart } from 'lightweight-charts'
+
+const UP_LINE     = 'rgb(232,57,62)'
+const DOWN_LINE   = 'rgb(0,117,232)'
+const UP_FILL     = 'rgba(232,57,62,0.2)'
+const DOWN_FILL   = 'rgba(0,117,232,0.2)'
+const TRANSPARENT = 'rgba(0,0,0,0)'
+
+/**
+ * 위젯용 미니 라인+에리어 차트 (lightweight-charts)
+ * @param {{ time: number, value: number }[]} data  - unix seconds
+ * @param {boolean} isUp
+ * @param {string}  className
+ */
+export default function MiniChart({ data, isUp, className = '' }) {
+  const ref = useRef(null)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    const chart = createChart(el, {
+      width:  el.clientWidth,
+      height: el.clientHeight,
+      layout: {
+        background: { color: 'transparent' },
+        textColor:  'transparent',
+      },
+      grid: {
+        vertLines: { visible: false },
+        horzLines: { visible: false },
+      },
+      leftPriceScale:  { visible: false },
+      rightPriceScale: { visible: false },
+      timeScale:       { visible: false },
+      crosshair: {
+        vertLine: { visible: false, labelVisible: false },
+        horzLine: { visible: false, labelVisible: false },
+      },
+      handleScroll: false,
+      handleScale:  false,
+    })
+
+    const series = chart.addSeries(AreaSeries, {
+      lineColor:             isUp ? UP_LINE   : DOWN_LINE,
+      topColor:              isUp ? UP_FILL   : DOWN_FILL,
+      bottomColor:           TRANSPARENT,
+      lineWidth:             1.5,
+      priceLineVisible:      false,
+      lastValueVisible:      false,
+      crosshairMarkerVisible: false,
+    })
+
+    if (data?.length) {
+      series.setData(data)
+      chart.timeScale().fitContent()
+    }
+
+    const ro = new ResizeObserver(([entry]) => {
+      if (!entry) return
+      chart.applyOptions({
+        width:  entry.contentRect.width,
+        height: entry.contentRect.height,
+      })
+    })
+    ro.observe(el)
+
+    return () => {
+      ro.disconnect()
+      chart.remove()
+    }
+  }, [data, isUp])
+
+  return <div ref={ref} className={`overflow-hidden ${className}`} />
+}

--- a/src/components/ui/MiniChart.jsx
+++ b/src/components/ui/MiniChart.jsx
@@ -1,11 +1,17 @@
 import { useEffect, useRef } from 'react'
 import { AreaSeries, createChart } from 'lightweight-charts'
 
-const UP_LINE     = 'rgb(232,57,62)'
-const DOWN_LINE   = 'rgb(0,117,232)'
-const UP_FILL     = 'rgba(232,57,62,0.2)'
-const DOWN_FILL   = 'rgba(0,117,232,0.2)'
-const TRANSPARENT = 'rgba(0,0,0,0)'
+function getChartColors() {
+  const style = getComputedStyle(document.documentElement)
+  const up   = style.getPropertyValue('--color-up').trim()   || '#E8393E'
+  const down = style.getPropertyValue('--color-down').trim() || '#0075E8'
+  return {
+    upLine:   up,
+    downLine: down,
+    upFill:   `${up}33`,    // 20% opacity
+    downFill: `${down}33`,
+  }
+}
 
 /**
  * 위젯용 미니 라인+에리어 차트 (lightweight-charts)
@@ -14,11 +20,15 @@ const TRANSPARENT = 'rgba(0,0,0,0)'
  * @param {string}  className
  */
 export default function MiniChart({ data, isUp, className = '' }) {
-  const ref = useRef(null)
+  const ref       = useRef(null)
+  const seriesRef = useRef(null)
 
+  // 차트·시리즈 생성 — data가 바뀔 때만 재생성
   useEffect(() => {
     const el = ref.current
     if (!el) return
+
+    const { upLine, downLine, upFill, downFill } = getChartColors()
 
     const chart = createChart(el, {
       width:  el.clientWidth,
@@ -43,14 +53,15 @@ export default function MiniChart({ data, isUp, className = '' }) {
     })
 
     const series = chart.addSeries(AreaSeries, {
-      lineColor:             isUp ? UP_LINE   : DOWN_LINE,
-      topColor:              isUp ? UP_FILL   : DOWN_FILL,
-      bottomColor:           TRANSPARENT,
-      lineWidth:             1.5,
-      priceLineVisible:      false,
-      lastValueVisible:      false,
+      lineColor:              isUp ? upLine : downLine,
+      topColor:               isUp ? upFill : downFill,
+      bottomColor:            'rgba(0,0,0,0)',
+      lineWidth:              1.5,
+      priceLineVisible:       false,
+      lastValueVisible:       false,
       crosshairMarkerVisible: false,
     })
+    seriesRef.current = series
 
     if (data?.length) {
       series.setData(data)
@@ -69,8 +80,19 @@ export default function MiniChart({ data, isUp, className = '' }) {
     return () => {
       ro.disconnect()
       chart.remove()
+      seriesRef.current = null
     }
-  }, [data, isUp])
+  }, [data]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // isUp 변경 시 차트 재생성 없이 시리즈 색상만 업데이트
+  useEffect(() => {
+    if (!seriesRef.current) return
+    const { upLine, downLine, upFill, downFill } = getChartColors()
+    seriesRef.current.applyOptions({
+      lineColor: isUp ? upLine : downLine,
+      topColor:  isUp ? upFill : downFill,
+    })
+  }, [isUp])
 
   return <div ref={ref} className={`overflow-hidden ${className}`} />
 }

--- a/src/components/widgets/BalanceWidget.jsx
+++ b/src/components/widgets/BalanceWidget.jsx
@@ -1,10 +1,41 @@
+import { useQuery } from '@tanstack/react-query'
 import LockedOverlay from '@/components/ui/LockedOverlay'
 import useAuthStore from '@/store/useAuthStore'
 import WidgetCard from './WidgetCard'
-import { BALANCE } from '@/mocks/home'
+import { balanceApi, useDomesticHoldings } from '@/api/balance'
+
+function fmt(n) {
+  return Number(n ?? 0).toLocaleString('ko-KR')
+}
+
+function useBalance(enabled) {
+  const { data: holdings = [] } = useDomesticHoldings({ enabled })
+  const { data: cashData } = useQuery({
+    queryKey: ['balance', 'cash'],
+    queryFn:  balanceApi.getCashBalances,
+    enabled,
+    staleTime: 30_000,
+  })
+
+  const cash      = cashData?.krwBalance ?? cashData?.balance ?? cashData?.depositBalance ?? 0
+  const invested  = holdings.reduce((s, h) => s + (h.avgPrice ?? h.avgBuyPrice ?? 0) * (h.holdingQuantity ?? h.availableQuantity ?? 0), 0)
+  const stockVal  = holdings.reduce((s, h) => s + (h.currentPrice ?? h.avgPrice ?? h.avgBuyPrice ?? 0) * (h.holdingQuantity ?? h.availableQuantity ?? 0), 0)
+  const total     = stockVal + cash
+  const profit    = stockVal - invested
+  const profitRate = invested > 0 ? (profit / invested) * 100 : 0
+
+  return {
+    total:      fmt(total),
+    profit:     (profit >= 0 ? '+' : '') + fmt(Math.abs(profit)),
+    profitRate: (profitRate >= 0 ? '+' : '') + profitRate.toFixed(2) + '%',
+    invested:   fmt(invested),
+    available:  fmt(cash),
+  }
+}
 
 export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, rowSpan = 1, onDelete }) {
   const { isAuthenticated, isRestoring } = useAuthStore()
+  const BALANCE = useBalance(isAuthenticated && !isRestoring)
 
   return (
     <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>

--- a/src/components/widgets/BalanceWidget.jsx
+++ b/src/components/widgets/BalanceWidget.jsx
@@ -9,13 +9,19 @@ function fmt(n) {
 }
 
 function useBalance(enabled) {
-  const { data: holdings = [] } = useDomesticHoldings({ enabled })
-  const { data: cashData } = useQuery({
+  const { data: holdings = [], isLoading: holdingsLoading } = useDomesticHoldings({ enabled })
+  const { data: cashData, isLoading: cashLoading } = useQuery({
     queryKey: ['balance', 'cash'],
     queryFn:  balanceApi.getCashBalances,
     enabled,
     staleTime: 30_000,
   })
+
+  const isLoading = enabled && (holdingsLoading || cashLoading)
+
+  if (isLoading) {
+    return { total: '-', profit: '-', profitRate: '-', invested: '-', available: '-', isLoading: true }
+  }
 
   const cash      = cashData?.krwBalance ?? cashData?.balance ?? cashData?.depositBalance ?? 0
   const invested  = holdings.reduce((s, h) => s + (h.avgPrice ?? h.avgBuyPrice ?? 0) * (h.holdingQuantity ?? h.availableQuantity ?? 0), 0)
@@ -30,6 +36,7 @@ function useBalance(enabled) {
     profitRate: (profitRate >= 0 ? '+' : '') + profitRate.toFixed(2) + '%',
     invested:   fmt(invested),
     available:  fmt(cash),
+    isLoading:  false,
   }
 }
 
@@ -50,7 +57,10 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
             <div className="text-[18px] font-bold leading-tight tracking-tight text-foreground mt-0.5">
               {BALANCE.total}
             </div>
-            <div className="text-[9px] font-semibold text-up mt-0.5">▲ {BALANCE.profit} ({BALANCE.profitRate})</div>
+            {BALANCE.isLoading
+              ? <div className="text-[9px] text-foreground-disabled mt-0.5">-</div>
+              : <div className="text-[9px] font-semibold text-up mt-0.5">▲ {BALANCE.profit} ({BALANCE.profitRate})</div>
+            }
           </div>
           <div className="h-px bg-stroke-subtle shrink-0" />
           <div className="flex gap-2 flex-1 items-start">
@@ -74,7 +84,10 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
               <div className="text-[22px] font-bold leading-tight tracking-tight text-foreground mt-0.5">
                 {BALANCE.total}
               </div>
-              <div className="text-[10px] font-semibold text-up mt-0.5">▲ {BALANCE.profit} ({BALANCE.profitRate})</div>
+              {BALANCE.isLoading
+                ? <div className="text-[10px] text-foreground-disabled mt-0.5">-</div>
+                : <div className="text-[10px] font-semibold text-up mt-0.5">▲ {BALANCE.profit} ({BALANCE.profitRate})</div>
+              }
             </div>
             <div className="flex gap-6 shrink-0">
               <div>
@@ -104,7 +117,10 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
             <div className="text-[22px] font-bold leading-tight tracking-tight text-foreground mt-0.5">
               {BALANCE.total}<span className="text-[12px] font-medium text-foreground-tertiary ml-0.5">원</span>
             </div>
-            <div className="text-[12px] font-semibold text-up mt-0.5">▲ {BALANCE.profit} ({BALANCE.profitRate})</div>
+            {BALANCE.isLoading
+              ? <div className="text-[12px] text-foreground-disabled mt-0.5">-</div>
+              : <div className="text-[12px] font-semibold text-up mt-0.5">▲ {BALANCE.profit} ({BALANCE.profitRate})</div>
+            }
           </div>
           <div className="grid grid-cols-2 gap-2 shrink-0">
             {[
@@ -132,7 +148,10 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
           <div className="text-[18px] font-bold leading-tight tracking-tight text-foreground">
             {BALANCE.total}
           </div>
-          <div className="text-[11px] font-semibold text-up mt-1">▲ {BALANCE.profit} ({BALANCE.profitRate})</div>
+          {BALANCE.isLoading
+            ? <div className="text-[11px] text-foreground-disabled mt-1">-</div>
+            : <div className="text-[11px] font-semibold text-up mt-1">▲ {BALANCE.profit} ({BALANCE.profitRate})</div>
+          }
         </div>
       )}
 

--- a/src/components/widgets/BalanceWidget.jsx
+++ b/src/components/widgets/BalanceWidget.jsx
@@ -20,7 +20,7 @@ function useBalance(enabled) {
   const isLoading = enabled && (holdingsLoading || cashLoading)
 
   if (isLoading) {
-    return { total: '-', profit: '-', profitRate: '-', invested: '-', available: '-', isLoading: true }
+    return { total: '-', profit: '-', profitRate: '-', invested: '-', available: '-', isProfit: true, isLoading: true }
   }
 
   const cash      = cashData?.krwBalance ?? cashData?.balance ?? cashData?.depositBalance ?? 0
@@ -32,10 +32,11 @@ function useBalance(enabled) {
 
   return {
     total:      fmt(total),
-    profit:     (profit >= 0 ? '+' : '') + fmt(Math.abs(profit)),
+    profit:     (profit >= 0 ? '+' : '-') + fmt(Math.abs(profit)),
     profitRate: (profitRate >= 0 ? '+' : '') + profitRate.toFixed(2) + '%',
     invested:   fmt(invested),
     available:  fmt(cash),
+    isProfit:   profit >= 0,
     isLoading:  false,
   }
 }
@@ -59,14 +60,14 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
             </div>
             {BALANCE.isLoading
               ? <div className="text-[9px] text-foreground-disabled mt-0.5">-</div>
-              : <div className="text-[9px] font-semibold text-up mt-0.5">▲ {BALANCE.profit} ({BALANCE.profitRate})</div>
+              : <div className={`text-[9px] font-semibold mt-0.5 ${BALANCE.isProfit ? 'text-up' : 'text-down'}`}>{BALANCE.isProfit ? '▲' : '▼'} {BALANCE.profit} ({BALANCE.profitRate})</div>
             }
           </div>
           <div className="h-px bg-stroke-subtle shrink-0" />
           <div className="flex gap-2 flex-1 items-start">
             {[
               { label: '투자원금', val: BALANCE.invested, color: 'text-foreground' },
-              { label: '평가손익', val: BALANCE.profit,   color: 'text-up' },
+              { label: '평가손익', val: BALANCE.profit,   color: BALANCE.isProfit ? 'text-up' : 'text-down' },
               { label: '주문가능', val: BALANCE.available, color: 'text-foreground' },
             ].map(({ label, val, color }) => (
               <div key={label} className="flex-1 min-w-0">
@@ -86,7 +87,7 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
               </div>
               {BALANCE.isLoading
                 ? <div className="text-[10px] text-foreground-disabled mt-0.5">-</div>
-                : <div className="text-[10px] font-semibold text-up mt-0.5">▲ {BALANCE.profit} ({BALANCE.profitRate})</div>
+                : <div className={`text-[10px] font-semibold mt-0.5 ${BALANCE.isProfit ? 'text-up' : 'text-down'}`}>{BALANCE.isProfit ? '▲' : '▼'} {BALANCE.profit} ({BALANCE.profitRate})</div>
               }
             </div>
             <div className="flex gap-6 shrink-0">
@@ -119,15 +120,15 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
             </div>
             {BALANCE.isLoading
               ? <div className="text-[12px] text-foreground-disabled mt-0.5">-</div>
-              : <div className="text-[12px] font-semibold text-up mt-0.5">▲ {BALANCE.profit} ({BALANCE.profitRate})</div>
+              : <div className={`text-[12px] font-semibold mt-0.5 ${BALANCE.isProfit ? 'text-up' : 'text-down'}`}>{BALANCE.isProfit ? '▲' : '▼'} {BALANCE.profit} ({BALANCE.profitRate})</div>
             }
           </div>
           <div className="grid grid-cols-2 gap-2 shrink-0">
             {[
-              { label: '투자원금', val: BALANCE.invested, color: 'text-foreground' },
-              { label: '평가손익', val: BALANCE.profit,    color: 'text-up' },
-              { label: '당일손익', val: '+342,000',        color: 'text-up' },
-              { label: '수익률',   val: BALANCE.profitRate, color: 'text-up' },
+              { label: '투자원금', val: BALANCE.invested,    color: 'text-foreground' },
+              { label: '평가손익', val: BALANCE.profit,      color: BALANCE.isProfit ? 'text-up' : 'text-down' },
+              { label: '당일손익', val: '+342,000',          color: 'text-up' },
+              { label: '수익률',   val: BALANCE.profitRate,  color: BALANCE.isProfit ? 'text-up' : 'text-down' },
             ].map(({ label, val, color }) => (
               <div key={label} className="bg-background rounded-xl px-3 py-2">
                 <div className="text-[9px] text-foreground-disabled">{label}</div>
@@ -150,7 +151,7 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
           </div>
           {BALANCE.isLoading
             ? <div className="text-[11px] text-foreground-disabled mt-1">-</div>
-            : <div className="text-[11px] font-semibold text-up mt-1">▲ {BALANCE.profit} ({BALANCE.profitRate})</div>
+            : <div className={`text-[11px] font-semibold mt-1 ${BALANCE.isProfit ? 'text-up' : 'text-down'}`}>{BALANCE.isProfit ? '▲' : '▼'} {BALANCE.profit} ({BALANCE.profitRate})</div>
           }
         </div>
       )}

--- a/src/components/widgets/ExchangeConfigModal.jsx
+++ b/src/components/widgets/ExchangeConfigModal.jsx
@@ -1,0 +1,88 @@
+import { useState } from 'react'
+import { X } from 'lucide-react'
+
+const ALL_CURRENCIES = [
+  { code: 'USD', label: 'USD / KRW', flag: '🇺🇸' },
+  { code: 'JPY', label: 'JPY / KRW', flag: '🇯🇵' },
+  { code: 'EUR', label: 'EUR / KRW', flag: '🇪🇺' },
+]
+
+const VARIANT_MAX = {
+  'exchange-sm':   1,
+  'exchange-wide': 2,
+  'exchange-3x1':  3,
+  'exchange-2x2':  3,
+}
+
+export default function ExchangeConfigModal({ variant, currentCurrencies, onSave, onClose }) {
+  const max = VARIANT_MAX[variant] ?? 3
+  const [selected, setSelected] = useState(currentCurrencies)
+
+  function toggle(code) {
+    setSelected((prev) => {
+      if (prev.includes(code)) return prev.filter((c) => c !== code)
+      if (prev.length >= max) return prev
+      return [...prev, code]
+    })
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={onClose}
+    >
+      <div
+        className="bg-surface rounded-2xl shadow-xl w-[280px] p-5"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <span className="text-[13px] font-bold text-foreground">표시할 통화 선택</span>
+          <button onClick={onClose} className="text-foreground-disabled hover:text-foreground transition-colors">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <p className="text-[10px] text-foreground-disabled mb-3">최대 {max}개 선택 가능</p>
+
+        <div className="flex flex-col gap-2 mb-5">
+          {ALL_CURRENCIES.map(({ code, label, flag }) => {
+            const isChecked = selected.includes(code)
+            const isDisabled = !isChecked && selected.length >= max
+            return (
+              <label
+                key={code}
+                className={`flex items-center gap-3 px-3 py-2.5 rounded-xl cursor-pointer transition-colors ${
+                  isChecked
+                    ? 'bg-primary-light border border-primary-border'
+                    : isDisabled
+                      ? 'opacity-40 cursor-not-allowed'
+                      : 'bg-background hover:bg-surface-subtle border border-transparent'
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  checked={isChecked}
+                  disabled={isDisabled}
+                  onChange={() => toggle(code)}
+                  className="accent-primary w-3.5 h-3.5"
+                />
+                <span className="text-[14px]">{flag}</span>
+                <span className={`text-[12px] font-semibold ${isChecked ? 'text-primary' : 'text-foreground'}`}>
+                  {label}
+                </span>
+              </label>
+            )
+          })}
+        </div>
+
+        <button
+          disabled={selected.length === 0}
+          onClick={() => onSave(selected)}
+          className="w-full py-2 rounded-xl bg-primary text-white text-[12px] font-semibold hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          저장
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/widgets/ExchangeWidget.jsx
+++ b/src/components/widgets/ExchangeWidget.jsx
@@ -1,24 +1,28 @@
+import { useState } from 'react'
+import { Settings2 } from 'lucide-react'
 import LockedOverlay from '@/components/ui/LockedOverlay'
 import useAuthStore from '@/store/useAuthStore'
 import useCurrencyRate from '@/hooks/useCurrencyRate'
 import WidgetCard from './WidgetCard'
+import ExchangeConfigModal from './ExchangeConfigModal'
+import useWidgetStore from '@/store/useWidgetStore'
+import { useDashboardSave } from '@/hooks/useDashboardSync'
 
-const WIDE_CHART_DATA = [
-  { area: 'M0,3 L25,10 L50,17 L75,22 L100,27 L100,30 L0,30 Z',  line: '0,3 25,10 50,17 75,22 100,27'  },
-  { area: 'M0,27 L33,20 L66,12 L100,3 L100,30 L0,30 Z',          line: '0,27 33,20 66,12 100,3'         },
-]
 
-const WIDE_3X1_CHART_DATA = [
-  { area: 'M0,3 L25,10 L50,17 L75,22 L100,27 L100,30 L0,30 Z',  line: '0,3 25,10 50,17 75,22 100,27'  },
-  { area: 'M0,27 L33,20 L66,12 L100,3 L100,30 L0,30 Z',          line: '0,27 33,20 66,12 100,3'         },
-  { area: 'M0,3 L33,12 L66,20 L100,27 L100,30 L0,30 Z',          line: '0,3 33,12 66,20 100,27'         },
-]
-
-const CURRENCIES = [
+const ALL_CURRENCIES = [
   { flag: '🇺🇸', pair: 'USD / KRW', code: 'USD' },
   { flag: '🇯🇵', pair: 'JPY / KRW', code: 'JPY' },
   { flag: '🇪🇺', pair: 'EUR / KRW', code: 'EUR' },
 ]
+
+const DEFAULT_CURRENCIES = {
+  'exchange-sm':   ['USD'],
+  'exchange-wide': ['USD', 'JPY'],
+  'exchange-3x1':  ['USD', 'JPY', 'EUR'],
+  'exchange-2x2':  ['USD', 'JPY', 'EUR'],
+}
+
+const LIVE_BY_CODE = { USD: 0, JPY: 1, EUR: 2 }
 
 function formatRate(value) {
   if (value == null) return '—'
@@ -46,157 +50,186 @@ function RateDisplay({ live, rateClassName = 'text-[15px]' }) {
   )
 }
 
-export default function ExchangeWidget({ variant = 'exchange-sm', colSpan = 1, rowSpan = 1, onDelete }) {
+export default function ExchangeWidget({ instanceId, variant = 'exchange-sm', colSpan = 1, rowSpan = 1, onDelete, config = {} }) {
   const { isAuthenticated, isRestoring } = useAuthStore()
+  const updateWidgetConfig = useWidgetStore((s) => s.updateWidgetConfig)
+  const { mutate: saveDashboard } = useDashboardSave()
+  const [isConfigOpen, setIsConfigOpen] = useState(false)
 
   const liveUsd = useCurrencyRate('USD')
   const liveJpy = useCurrencyRate('JPY')
   const liveEur = useCurrencyRate('EUR')
+  const allLive = [liveUsd, liveJpy, liveEur]
 
-  const liveRates = [liveUsd, liveJpy, liveEur]
+  const selectedCodes = config.currencies ?? DEFAULT_CURRENCIES[variant] ?? DEFAULT_CURRENCIES['exchange-sm']
+  const currencies = selectedCodes.map((code) => ({
+    ...ALL_CURRENCIES.find((c) => c.code === code),
+    live: allLive[LIVE_BY_CODE[code]],
+  }))
+
+  function handleSave(newCurrencies) {
+    updateWidgetConfig(instanceId, { currencies: newCurrencies })
+    saveDashboard()
+    setIsConfigOpen(false)
+  }
+
+  const configModal = isConfigOpen && (
+    <ExchangeConfigModal
+      variant={variant}
+      currentCurrencies={selectedCodes}
+      onSave={handleSave}
+      onClose={() => setIsConfigOpen(false)}
+    />
+  )
+
+  const settingsBtn = (
+    <button
+      onClick={(e) => { e.stopPropagation(); setIsConfigOpen(true) }}
+      className="p-0.5 rounded text-foreground-disabled hover:text-foreground transition-colors"
+    >
+      <Settings2 className="w-3 h-3" />
+    </button>
+  )
 
   if (variant === 'exchange-3x1') {
-    const cols = [
-      { ...CURRENCIES[0], live: liveRates[0], rateSize: 'text-[20px]', flex: '1.2', pr: 'pr-3', pl: '' },
-      { ...CURRENCIES[1], live: liveRates[1], rateSize: 'text-[16px]', flex: '1',   pr: 'pr-2.5', pl: 'pl-2.5' },
-      { ...CURRENCIES[2], live: liveRates[2], rateSize: 'text-[16px]', flex: '1',   pr: '',    pl: 'pl-2.5' },
-    ]
+    const flexValues = ['1.2', '1', '1']
+    const paddings   = [{ pr: 'pr-3', pl: '' }, { pr: 'pr-2.5', pl: 'pl-2.5' }, { pr: '', pl: 'pl-2.5' }]
+    const rateSize   = ['text-[20px]', 'text-[16px]', 'text-[16px]']
     return (
-      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-        <div className="mb-1 shrink-0">
-          <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
-        </div>
-        <div className="flex flex-1 min-h-0 divide-x divide-stroke">
-          {cols.map(({ pair, live, rateSize, flex, pr, pl }, i) => {
-            const isUp = (live?.change ?? 0) > 0
-            const color = isUp ? 'var(--color-up)' : 'var(--color-down)'
-            const fill  = isUp ? 'var(--color-up-fill)' : 'var(--color-down-fill)'
-            const { area, line } = WIDE_3X1_CHART_DATA[i]
-            return (
-              <div key={pair} className={`flex flex-col justify-between ${pr} ${pl}`} style={{ flex }}>
-                <div className="text-center">
-                  <div className="text-[9px] text-foreground-disabled">{pair}</div>
-                  <div className={`${rateSize} font-bold text-foreground leading-tight`}>{formatRate(live?.rate)}</div>
-                  {live && (
-                    <div className={`text-[9px] ${isUp ? 'text-up' : 'text-down'}`}>
-                      {isUp ? '▲' : '▼'} {Math.abs(live.change)}
-                    </div>
-                  )}
+      <>
+        <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+          <div className="flex items-center justify-between mb-1 shrink-0">
+            <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
+            {settingsBtn}
+          </div>
+          <div className="flex flex-1 min-h-0 divide-x divide-stroke">
+            {currencies.map(({ pair, live }, i) => {
+              const isUp = (live?.change ?? 0) > 0
+              const { pr, pl } = paddings[i] ?? { pr: '', pl: 'pl-2.5' }
+              return (
+                <div key={pair} className={`flex flex-col justify-center ${pr} ${pl}`} style={{ flex: flexValues[i] ?? '1' }}>
+                  <div className="text-center">
+                    <div className="text-[9px] text-foreground-disabled">{pair}</div>
+                    <div className={`${rateSize[i] ?? 'text-[16px]'} font-bold text-foreground leading-tight`}>{formatRate(live?.rate)}</div>
+                    {live && (
+                      <div className={`text-[9px] ${isUp ? 'text-up' : 'text-down'}`}>
+                        {isUp ? '▲' : '▼'} {Math.abs(live.change)}
+                      </div>
+                    )}
+                  </div>
                 </div>
-                <div className="h-[18px] w-full shrink-0">
-                  <svg viewBox="0 0 100 30" preserveAspectRatio="none" style={{ width: '100%', height: '100%', display: 'block' }}>
-                    <path d={area} fill={fill} />
-                    <polyline points={line} fill="none" stroke={color} strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
-                  </svg>
-                </div>
-              </div>
-            )
-          })}
-        </div>
-        {!isAuthenticated && <LockedOverlay message="환율 정보를 보려면" />}
-      </WidgetCard>
+              )
+            })}
+          </div>
+          {!isAuthenticated && <LockedOverlay message="환율 정보를 보려면" />}
+        </WidgetCard>
+        {configModal}
+      </>
     )
   }
 
   if (variant === 'exchange-wide') {
-    const cols = [
-      { ...CURRENCIES[0], live: liveRates[0], rateSize: 'text-[20px]', flex: '1.2', pr: 'pr-3', pl: '' },
-      { ...CURRENCIES[1], live: liveRates[1], rateSize: 'text-[16px]', flex: '1',   pr: '',    pl: 'pl-3' },
-    ]
     return (
-      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-        <div className="mb-1 shrink-0">
-          <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
-        </div>
-        <div className="flex flex-1 min-h-0 divide-x divide-stroke">
-          {cols.map(({ pair, live, rateSize, flex, pr, pl }, i) => {
-            const isUp = (live?.change ?? 0) > 0
-            const color = isUp ? 'var(--color-up)' : 'var(--color-down)'
-            const fill  = isUp ? 'var(--color-up-fill)' : 'var(--color-down-fill)'
-            const { area, line } = WIDE_CHART_DATA[i]
-            return (
-              <div key={pair} className={`flex flex-col justify-between ${pr} ${pl}`} style={{ flex }}>
-                <div className="text-center">
-                  <div className="text-[9px] text-foreground-disabled">{pair}</div>
-                  <div className={`${rateSize} font-bold text-foreground leading-tight`}>{formatRate(live?.rate)}</div>
-                  {live && (
-                    <div className={`text-[9px] ${isUp ? 'text-up' : 'text-down'}`}>
-                      {isUp ? '▲' : '▼'} {Math.abs(live.change)}
-                    </div>
-                  )}
+      <>
+        <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+          <div className="flex items-center justify-between mb-1 shrink-0">
+            <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
+            {settingsBtn}
+          </div>
+          <div className="flex flex-1 min-h-0 divide-x divide-stroke">
+            {currencies.map(({ pair, live }, i) => {
+              const isUp = (live?.change ?? 0) > 0
+              const rateSize = i === 0 ? 'text-[20px]' : 'text-[16px]'
+              const pr = i === 0 ? 'pr-3' : ''
+              const pl = i > 0 ? 'pl-3' : ''
+              const flex = i === 0 ? '1.2' : '1'
+              return (
+                <div key={pair} className={`flex flex-col justify-center ${pr} ${pl}`} style={{ flex }}>
+                  <div className="text-center">
+                    <div className="text-[9px] text-foreground-disabled">{pair}</div>
+                    <div className={`${rateSize} font-bold text-foreground leading-tight`}>{formatRate(live?.rate)}</div>
+                    {live && (
+                      <div className={`text-[9px] ${isUp ? 'text-up' : 'text-down'}`}>
+                        {isUp ? '▲' : '▼'} {Math.abs(live.change)}
+                      </div>
+                    )}
+                  </div>
                 </div>
-                <div className="h-[18px] w-full shrink-0">
-                  <svg viewBox="0 0 100 30" preserveAspectRatio="none" style={{ width: '100%', height: '100%', display: 'block' }}>
-                    <path d={area} fill={fill} />
-                    <polyline points={line} fill="none" stroke={color} strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
-                  </svg>
-                </div>
-              </div>
-            )
-          })}
-        </div>
-        {!isRestoring && !isAuthenticated && <LockedOverlay message="환율 정보를 보려면" />}
-      </WidgetCard>
+              )
+            })}
+          </div>
+          {!isRestoring && !isAuthenticated && <LockedOverlay message="환율 정보를 보려면" />}
+        </WidgetCard>
+        {configModal}
+      </>
     )
   }
 
   if (variant === 'exchange-2x2') {
+    const primary = currencies[0]
+    const rest    = currencies.slice(1)
     return (
-      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-        <div className="mb-1 shrink-0">
-          <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
-        </div>
-        <div className="shrink-0">
-          <div className="text-[9px] text-foreground-disabled">USD / KRW</div>
-          <RateDisplay live={liveUsd} rateClassName="text-[22px]" />
-        </div>
-        <div className="h-10 bg-background rounded-xl flex items-end px-1.5 pb-1 gap-px my-2 shrink-0">
-          {[60, 58, 62, 55, 58, 52, 56, 50, 54, 48, 52, 46].map((h, i) => (
-            <div key={i} className="flex-1 bg-down/40 rounded-sm" style={{ height: `${h}%` }} />
-          ))}
-        </div>
-        <div className="flex-1 flex flex-col gap-2 min-h-0 overflow-y-auto">
-          {CURRENCIES.slice(1).map(({ flag, pair, code }, i) => {
-            const live = liveRates[i + 1]
-            const isUp = (live?.change ?? 0) > 0
-            return (
-              <div key={pair} className="flex items-center justify-between px-1">
-                <div className="flex items-center gap-2">
-                  <span className="text-[14px]">{flag}</span>
-                  <span className="text-[10px] text-foreground-secondary">{pair}</span>
+      <>
+        <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+          <div className="flex items-center justify-between mb-1 shrink-0">
+            <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
+            {settingsBtn}
+          </div>
+          <div className="shrink-0">
+            <div className="text-[9px] text-foreground-disabled">{primary?.pair ?? 'USD / KRW'}</div>
+            <RateDisplay live={primary?.live} rateClassName="text-[22px]" />
+          </div>
+
+          <div className="flex-1 flex flex-col gap-2 min-h-0 overflow-y-auto">
+            {rest.map(({ flag, pair, live }) => {
+              const isUp = (live?.change ?? 0) > 0
+              return (
+                <div key={pair} className="flex items-center justify-between px-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[14px]">{flag}</span>
+                    <span className="text-[10px] text-foreground-secondary">{pair}</span>
+                  </div>
+                  <div className="text-right">
+                    <span className="text-[12px] font-semibold text-foreground">{formatRate(live?.rate)}</span>
+                    {live && (
+                      <span className={`text-[9px] ml-1.5 ${isUp ? 'text-up' : 'text-down'}`}>
+                        {isUp ? '▲' : '▼'} {Math.abs(live.change)}
+                      </span>
+                    )}
+                  </div>
                 </div>
-                <div className="text-right">
-                  <span className="text-[12px] font-semibold text-foreground">{formatRate(live?.rate)}</span>
-                  {live && (
-                    <span className={`text-[9px] ml-1.5 ${isUp ? 'text-up' : 'text-down'}`}>
-                      {isUp ? '▲' : '▼'} {Math.abs(live.change)}
-                    </span>
-                  )}
-                </div>
-              </div>
-            )
-          })}
-        </div>
-        <button
-          onClick={(e) => e.stopPropagation()}
-          className="w-full py-1.5 rounded-xl bg-primary-light text-primary text-[10px] font-bold hover:bg-primary-dim transition-colors duration-[150ms] mt-2 shrink-0"
-        >
-          환전하기 →
-        </button>
-        {!isRestoring && !isAuthenticated && <LockedOverlay message="환율 정보를 보려면" />}
-      </WidgetCard>
+              )
+            })}
+          </div>
+          <button
+            onClick={(e) => e.stopPropagation()}
+            className="w-full py-1.5 rounded-xl bg-primary-light text-primary text-[10px] font-bold hover:bg-primary-dim transition-colors duration-[150ms] mt-2 shrink-0"
+          >
+            환전하기 →
+          </button>
+          {!isRestoring && !isAuthenticated && <LockedOverlay message="환율 정보를 보려면" />}
+        </WidgetCard>
+        {configModal}
+      </>
     )
   }
 
   /* exchange-sm (default) */
+  const primary = currencies[0]
   return (
-    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-      <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase shrink-0">환율</span>
-      <div className="flex-1 flex flex-col justify-center min-h-0">
-        <div className="text-[9px] text-foreground-disabled">USD / KRW</div>
-        <RateDisplay live={liveUsd} rateClassName="text-[18px]" />
-      </div>
-      {!isRestoring && !isAuthenticated && <LockedOverlay message="환율 정보를 보려면" />}
-    </WidgetCard>
+    <>
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+        <div className="flex items-center justify-between shrink-0">
+          <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
+          {settingsBtn}
+        </div>
+        <div className="flex-1 flex flex-col justify-center min-h-0">
+          <div className="text-[9px] text-foreground-disabled">{primary?.pair ?? 'USD / KRW'}</div>
+          <RateDisplay live={primary?.live} rateClassName="text-[18px]" />
+        </div>
+        {!isRestoring && !isAuthenticated && <LockedOverlay message="환율 정보를 보려면" />}
+      </WidgetCard>
+      {configModal}
+    </>
   )
 }

--- a/src/components/widgets/IndexConfigModal.jsx
+++ b/src/components/widgets/IndexConfigModal.jsx
@@ -1,0 +1,92 @@
+import { useState } from 'react'
+import { X } from 'lucide-react'
+
+const ALL_INDICES = [
+  { code: '001',      label: 'KOSPI' },
+  { code: '101',      label: 'KOSDAQ' },
+  { code: 'NAS@IXIC', label: 'NASDAQ' },
+  { code: 'SPI@SPX',  label: 'S&P 500' },
+]
+
+const VARIANT_MAX = {
+  'index-sm':   1,
+  'index-wide': 2,
+  'index-3x1':  3,
+  'index-2x2':  3,
+}
+
+export default function IndexConfigModal({ variant, currentIndices, onSave, onClose }) {
+  const max = VARIANT_MAX[variant] ?? 3
+  const [selected, setSelected] = useState(currentIndices)
+
+  function toggle(code) {
+    setSelected((prev) => {
+      if (prev.includes(code)) {
+        return prev.filter((c) => c !== code)
+      }
+      if (prev.length >= max) return prev
+      return [...prev, code]
+    })
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={onClose}
+    >
+      <div
+        className="bg-surface rounded-2xl shadow-xl w-[280px] p-5"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <span className="text-[13px] font-bold text-foreground">표시할 지수 선택</span>
+          <button onClick={onClose} className="text-foreground-disabled hover:text-foreground transition-colors">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <p className="text-[10px] text-foreground-disabled mb-3">
+          최대 {max}개 선택 가능
+        </p>
+
+        <div className="flex flex-col gap-2 mb-5">
+          {ALL_INDICES.map(({ code, label }) => {
+            const isChecked = selected.includes(code)
+            const isDisabled = !isChecked && selected.length >= max
+            return (
+              <label
+                key={code}
+                className={`flex items-center gap-3 px-3 py-2.5 rounded-xl cursor-pointer transition-colors ${
+                  isChecked
+                    ? 'bg-primary-light border border-primary-border'
+                    : isDisabled
+                      ? 'opacity-40 cursor-not-allowed'
+                      : 'bg-background hover:bg-surface-subtle border border-transparent'
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  checked={isChecked}
+                  disabled={isDisabled}
+                  onChange={() => toggle(code)}
+                  className="accent-primary w-3.5 h-3.5"
+                />
+                <span className={`text-[12px] font-semibold ${isChecked ? 'text-primary' : 'text-foreground'}`}>
+                  {label}
+                </span>
+              </label>
+            )
+          })}
+        </div>
+
+        <button
+          disabled={selected.length === 0}
+          onClick={() => onSave(selected)}
+          className="w-full py-2 rounded-xl bg-primary text-white text-[12px] font-semibold hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          저장
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/widgets/IndexWidget.jsx
+++ b/src/components/widgets/IndexWidget.jsx
@@ -1,156 +1,193 @@
+import { useState } from 'react'
+import { Settings2 } from 'lucide-react'
 import PriceChange from '@/components/ui/PriceChange'
 import WidgetCard from './WidgetCard'
-import { cn } from '@/lib/cn'
+import IndexConfigModal from './IndexConfigModal'
 import useMarketIndices from '@/features/market/useMarketIndices'
+import useWidgetStore from '@/store/useWidgetStore'
+import { useDashboardSave } from '@/hooks/useDashboardSync'
 
 const INDEX_META = {
   '001':      { key: 'kospi',  label: 'KOSPI',   order: 0 },
-  '301':      { key: 'kosdaq', label: 'KOSDAQ',  order: 1 },
+  '101':      { key: 'kosdaq', label: 'KOSDAQ',  order: 1 },
   'NAS@IXIC': { key: 'nasdaq', label: 'NASDAQ',  order: 2 },
   'SPI@SPX':  { key: 'sp500',  label: 'S&P 500', order: 3 },
 }
 
-function useIndices() {
-  const { indices: raw } = useMarketIndices()
-  return raw
-    .map((idx) => ({
-      key:    INDEX_META[idx.code]?.key   ?? idx.code,
-      label:  INDEX_META[idx.code]?.label ?? idx.code,
-      value:  Number(idx.price).toLocaleString('ko-KR'),
-      change: idx.changeRate ?? 0,
-      order:  INDEX_META[idx.code]?.order ?? 99,
-    }))
-    .sort((a, b) => a.order - b.order)
+const DEFAULT_INDICES = {
+  'index-sm':   ['001'],
+  'index-wide': ['001', '101'],
+  'index-3x1':  ['001', '101', 'NAS@IXIC'],
+  'index-2x2':  ['001', '101', 'NAS@IXIC'],
 }
 
-const BARS = [50, 55, 48, 60, 52, 58, 54, 62]
+function useIndices(selectedCodes) {
+  const { indices: raw } = useMarketIndices()
+  const byCode = Object.fromEntries(raw.map((idx) => [idx.code, idx]))
+  return selectedCodes.map((code) => {
+    const idx  = byCode[code]
+    const meta = INDEX_META[code]
+    return {
+      code,
+      key:    meta?.key   ?? code,
+      label:  meta?.label ?? code,
+      value:  idx ? Number(idx.price).toLocaleString('ko-KR') : '-',
+      change: idx?.changeRate ?? null,
+    }
+  })
+}
 
-const WIDE_PATHS = [
-  { area: 'M0,27 L25,21 L50,14 L75,8 L100,3 L100,30 L0,30 Z',  line: '0,27 25,21 50,14 75,8 100,3'  },
-  { area: 'M0,3 L33,12 L66,20 L100,27 L100,30 L0,30 Z',         line: '0,3 33,12 66,20 100,27'        },
-]
 
-export default function IndexWidget({ variant = 'index-wide', colSpan = 2, rowSpan = 1, onDelete }) {
-  const indices = useIndices()
+function SettingsButton({ onClick }) {
+  return (
+    <button
+      onClick={(e) => { e.stopPropagation(); onClick() }}
+      className="p-0.5 rounded text-foreground-disabled hover:text-foreground transition-colors"
+    >
+      <Settings2 className="w-3 h-3" />
+    </button>
+  )
+}
+
+export default function IndexWidget({ instanceId, variant = 'index-wide', colSpan = 2, rowSpan = 1, onDelete, config = {} }) {
+  const updateWidgetConfig = useWidgetStore((s) => s.updateWidgetConfig)
+  const { mutate: saveDashboard } = useDashboardSave()
+  const [isConfigOpen, setIsConfigOpen] = useState(false)
+
+  const selectedCodes = config.indices ?? DEFAULT_INDICES[variant] ?? DEFAULT_INDICES['index-wide']
+  const indices = useIndices(selectedCodes)
+
+  function handleSave(newIndices) {
+    updateWidgetConfig(instanceId, { indices: newIndices })
+    saveDashboard()
+    setIsConfigOpen(false)
+  }
 
   if (variant === 'index-sm') {
-    const kospi = indices[0] ?? { key: 'kospi', label: 'KOSPI', value: '-', change: 0 }
-    const isUp = kospi.change > 0
-    const color = isUp ? 'var(--color-up)' : 'var(--color-down)'
-    const fill  = isUp ? 'var(--color-up-fill)' : 'var(--color-down-fill)'
+    const shown = indices[0] ?? { key: 'kospi', label: 'KOSPI', value: '-', change: null }
     return (
-      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-        <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase shrink-0">주요 지수</span>
-        <div className="flex-1 flex flex-col justify-start items-center text-center min-h-0 pt-1">
-          <div className="text-[9px] text-foreground-disabled">{kospi.label}</div>
-          <div className="text-[18px] font-bold text-foreground leading-tight">{kospi.value}</div>
-          <PriceChange value={kospi.change} className="text-[9px]" />
-        </div>
-        <div className="h-[22px] w-full shrink-0">
-          <svg viewBox="0 0 100 30" preserveAspectRatio="none" style={{ width: '100%', height: '100%', display: 'block' }}>
-            <path d="M0,27 L25,21 L50,14 L75,8 L100,3 L100,30 L0,30 Z" fill={fill} />
-            <polyline points="0,27 25,21 50,14 75,8 100,3" fill="none" stroke={color} strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
-          </svg>
-        </div>
-      </WidgetCard>
+      <>
+        <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+          <div className="flex items-center justify-between shrink-0">
+            <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">주요 지수</span>
+            <SettingsButton onClick={() => setIsConfigOpen(true)} />
+          </div>
+          <div className="flex-1 flex flex-col justify-center items-center text-center min-h-0">
+            <div className="text-[9px] text-foreground-disabled">{shown.label}</div>
+            <div className="text-[18px] font-bold text-foreground leading-tight">{shown.value}</div>
+            {shown.change != null
+              ? <PriceChange value={shown.change} className="text-[9px]" />
+              : <span className="text-[9px] text-foreground-disabled">-</span>
+            }
+          </div>
+        </WidgetCard>
+        {isConfigOpen && (
+          <IndexConfigModal
+            variant={variant}
+            currentIndices={selectedCodes}
+            onSave={handleSave}
+            onClose={() => setIsConfigOpen(false)}
+          />
+        )}
+      </>
     )
   }
 
   if (variant === 'index-3x1') {
-    const indices3 = indices.slice(0, 3)
-    const PATHS = [
-      { area: 'M0,27 L25,21 L50,14 L75,8 L100,3 L100,30 L0,30 Z',  line: '0,27 25,21 50,14 75,8 100,3'  },
-      { area: 'M0,3 L25,10 L50,17 L75,22 L100,27 L100,30 L0,30 Z',  line: '0,3 25,10 50,17 75,22 100,27' },
-      { area: 'M0,27 L25,21 L50,14 L75,8 L100,3 L100,30 L0,30 Z',  line: '0,27 25,21 50,14 75,8 100,3'  },
-    ]
     return (
-      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-        <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase shrink-0">주요 지수</span>
-        <div className="flex flex-1 min-h-0 divide-x divide-stroke mt-1">
-          {indices3.map((idx, i) => {
-            const isUp = idx.change > 0
-            const { area, line } = PATHS[i]
-            const color = isUp ? 'var(--color-up)' : 'var(--color-down)'
-            const fill  = isUp ? 'var(--color-up-fill)' : 'var(--color-down-fill)'
-            return (
-              <div key={idx.key} className="flex-1 flex flex-col items-center px-2">
-                <div className="flex-1 flex flex-col justify-start items-center text-center pt-1">
-                  <div className="text-[9px] text-foreground-disabled">{idx.label}</div>
-                  <div className="text-[17px] font-bold text-foreground leading-tight">{idx.value}</div>
-                  <PriceChange value={idx.change} className="text-[10px]" />
-                </div>
-                <div className="h-[22px] w-full shrink-0">
-                  <svg viewBox="0 0 100 30" preserveAspectRatio="none" style={{ width: '100%', height: '100%', display: 'block' }}>
-                    <path d={area} fill={fill} />
-                    <polyline points={line} fill="none" stroke={color} strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
-                  </svg>
-                </div>
+      <>
+        <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+          <div className="flex items-center justify-between shrink-0">
+            <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">주요 지수</span>
+            <SettingsButton onClick={() => setIsConfigOpen(true)} />
+          </div>
+          <div className="flex flex-1 min-h-0 divide-x divide-stroke mt-1">
+            {indices.map((idx) => (
+              <div key={idx.key} className="flex-1 flex flex-col justify-center items-center text-center px-2">
+                <div className="text-[9px] text-foreground-disabled">{idx.label}</div>
+                <div className="text-[17px] font-bold text-foreground leading-tight">{idx.value}</div>
+                {idx.change != null
+                  ? <PriceChange value={idx.change} className="text-[10px]" />
+                  : <span className="text-[10px] text-foreground-disabled">-</span>
+                }
               </div>
-            )
-          })}
-        </div>
-      </WidgetCard>
+            ))}
+          </div>
+        </WidgetCard>
+        {isConfigOpen && (
+          <IndexConfigModal
+            variant={variant}
+            currentIndices={selectedCodes}
+            onSave={handleSave}
+            onClose={() => setIsConfigOpen(false)}
+          />
+        )}
+      </>
     )
   }
 
   if (variant === 'index-2x2') {
     return (
-      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-        <div className="flex items-center justify-between mb-2 shrink-0">
-          <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">주요 지수</span>
-        </div>
-        <div className="flex flex-col flex-1 gap-3">
-          {indices.slice(0, 3).map((idx) => (
-            <div key={idx.key} className="flex items-center gap-3">
-              <div className="flex-1 min-w-0">
+      <>
+        <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+          <div className="flex items-center justify-between mb-2 shrink-0">
+            <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">주요 지수</span>
+            <SettingsButton onClick={() => setIsConfigOpen(true)} />
+          </div>
+          <div className="flex flex-col flex-1 justify-center gap-3">
+            {indices.map((idx) => (
+              <div key={idx.key} className="flex-1 min-w-0">
                 <div className="text-[9px] text-foreground-disabled">{idx.label}</div>
                 <div className="text-[15px] font-bold text-foreground leading-tight">{idx.value}</div>
-                <PriceChange value={idx.change} className="text-[10px]" />
+                {idx.change != null
+                  ? <PriceChange value={idx.change} className="text-[10px]" />
+                  : <span className="text-[10px] text-foreground-disabled">-</span>
+                }
               </div>
-              <div className="flex items-end gap-px h-8 shrink-0">
-                {BARS.map((h, i) => (
-                  <div
-                    key={i}
-                    className={cn('w-1.5 rounded-sm', idx.change > 0 ? 'bg-up/50' : 'bg-down/50')}
-                    style={{ height: `${h}%` }}
-                  />
-                ))}
-              </div>
+            ))}
+          </div>
+        </WidgetCard>
+        {isConfigOpen && (
+          <IndexConfigModal
+            variant={variant}
+            currentIndices={selectedCodes}
+            onSave={handleSave}
+            onClose={() => setIsConfigOpen(false)}
+          />
+        )}
+      </>
+    )
+  }
+
+  /* index-wide (default) */
+  return (
+    <>
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+        <div className="flex items-center justify-between shrink-0">
+          <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">주요 지수</span>
+          <SettingsButton onClick={() => setIsConfigOpen(true)} />
+        </div>
+        <div className="flex flex-1 min-h-0 divide-x divide-stroke mt-1">
+          {indices.map((idx) => (
+            <div key={idx.key} className="flex-1 flex flex-col justify-center items-center text-center px-3 py-1">
+              <div className="text-[9px] text-foreground-disabled">{idx.label}</div>
+              <div className="text-[16px] font-bold text-foreground leading-tight">{idx.value}</div>
+              {idx.change != null
+                ? <PriceChange value={idx.change} className="text-[9px]" />
+                : <span className="text-[9px] text-foreground-disabled">-</span>
+              }
             </div>
           ))}
         </div>
       </WidgetCard>
-    )
-  }
-
-  /* index-wide (default) — 2×1: 2컬럼 SVG 라인 차트 */
-  const indices2 = indices.slice(0, 2)
-  return (
-    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-      <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase shrink-0">주요 지수</span>
-      <div className="flex flex-1 min-h-0 divide-x divide-stroke mt-1">
-        {indices2.map((idx, i) => {
-          const isUp = idx.change > 0
-          const { area, line } = WIDE_PATHS[i]
-          const color = isUp ? 'var(--color-up)' : 'var(--color-down)'
-          const fill  = isUp ? 'var(--color-up-fill)' : 'var(--color-down-fill)'
-          return (
-            <div key={idx.key} className="flex-1 flex flex-col justify-between items-center px-3 py-1">
-              <div className="text-center">
-                <div className="text-[9px] text-foreground-disabled">{idx.label}</div>
-                <div className="text-[16px] font-bold text-foreground leading-tight">{idx.value}</div>
-                <PriceChange value={idx.change} className="text-[9px]" />
-              </div>
-              <div className="h-[20px] w-full shrink-0">
-                <svg viewBox="0 0 100 30" preserveAspectRatio="none" style={{ width: '100%', height: '100%', display: 'block' }}>
-                  <path d={area} fill={fill} />
-                  <polyline points={line} fill="none" stroke={color} strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
-                </svg>
-              </div>
-            </div>
-          )
-        })}
-      </div>
-    </WidgetCard>
+      {isConfigOpen && (
+        <IndexConfigModal
+          variant={variant}
+          currentIndices={selectedCodes}
+          onSave={handleSave}
+          onClose={() => setIsConfigOpen(false)}
+        />
+      )}
+    </>
   )
 }

--- a/src/components/widgets/IndexWidget.jsx
+++ b/src/components/widgets/IndexWidget.jsx
@@ -1,7 +1,27 @@
 import PriceChange from '@/components/ui/PriceChange'
 import WidgetCard from './WidgetCard'
-import { HOME_INDICES } from '@/mocks/home'
 import { cn } from '@/lib/cn'
+import useMarketIndices from '@/features/market/useMarketIndices'
+
+const INDEX_META = {
+  '001':      { key: 'kospi',  label: 'KOSPI',   order: 0 },
+  '301':      { key: 'kosdaq', label: 'KOSDAQ',  order: 1 },
+  'NAS@IXIC': { key: 'nasdaq', label: 'NASDAQ',  order: 2 },
+  'SPI@SPX':  { key: 'sp500',  label: 'S&P 500', order: 3 },
+}
+
+function useIndices() {
+  const { indices: raw } = useMarketIndices()
+  return raw
+    .map((idx) => ({
+      key:    INDEX_META[idx.code]?.key   ?? idx.code,
+      label:  INDEX_META[idx.code]?.label ?? idx.code,
+      value:  Number(idx.price).toLocaleString('ko-KR'),
+      change: idx.changeRate ?? 0,
+      order:  INDEX_META[idx.code]?.order ?? 99,
+    }))
+    .sort((a, b) => a.order - b.order)
+}
 
 const BARS = [50, 55, 48, 60, 52, 58, 54, 62]
 
@@ -11,8 +31,10 @@ const WIDE_PATHS = [
 ]
 
 export default function IndexWidget({ variant = 'index-wide', colSpan = 2, rowSpan = 1, onDelete }) {
+  const indices = useIndices()
+
   if (variant === 'index-sm') {
-    const kospi = HOME_INDICES[0]
+    const kospi = indices[0] ?? { key: 'kospi', label: 'KOSPI', value: '-', change: 0 }
     const isUp = kospi.change > 0
     const color = isUp ? 'var(--color-up)' : 'var(--color-down)'
     const fill  = isUp ? 'var(--color-up-fill)' : 'var(--color-down-fill)'
@@ -35,7 +57,7 @@ export default function IndexWidget({ variant = 'index-wide', colSpan = 2, rowSp
   }
 
   if (variant === 'index-3x1') {
-    const indices = HOME_INDICES.slice(0, 3)
+    const indices3 = indices.slice(0, 3)
     const PATHS = [
       { area: 'M0,27 L25,21 L50,14 L75,8 L100,3 L100,30 L0,30 Z',  line: '0,27 25,21 50,14 75,8 100,3'  },
       { area: 'M0,3 L25,10 L50,17 L75,22 L100,27 L100,30 L0,30 Z',  line: '0,3 25,10 50,17 75,22 100,27' },
@@ -45,7 +67,7 @@ export default function IndexWidget({ variant = 'index-wide', colSpan = 2, rowSp
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
         <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase shrink-0">주요 지수</span>
         <div className="flex flex-1 min-h-0 divide-x divide-stroke mt-1">
-          {indices.map((idx, i) => {
+          {indices3.map((idx, i) => {
             const isUp = idx.change > 0
             const { area, line } = PATHS[i]
             const color = isUp ? 'var(--color-up)' : 'var(--color-down)'
@@ -78,7 +100,7 @@ export default function IndexWidget({ variant = 'index-wide', colSpan = 2, rowSp
           <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">주요 지수</span>
         </div>
         <div className="flex flex-col flex-1 gap-3">
-          {HOME_INDICES.slice(0, 3).map((idx) => (
+          {indices.slice(0, 3).map((idx) => (
             <div key={idx.key} className="flex items-center gap-3">
               <div className="flex-1 min-w-0">
                 <div className="text-[9px] text-foreground-disabled">{idx.label}</div>
@@ -102,12 +124,12 @@ export default function IndexWidget({ variant = 'index-wide', colSpan = 2, rowSp
   }
 
   /* index-wide (default) — 2×1: 2컬럼 SVG 라인 차트 */
-  const indices = HOME_INDICES.slice(0, 2)
+  const indices2 = indices.slice(0, 2)
   return (
     <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
       <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase shrink-0">주요 지수</span>
       <div className="flex flex-1 min-h-0 divide-x divide-stroke mt-1">
-        {indices.map((idx, i) => {
+        {indices2.map((idx, i) => {
           const isUp = idx.change > 0
           const { area, line } = WIDE_PATHS[i]
           const color = isUp ? 'var(--color-up)' : 'var(--color-down)'

--- a/src/components/widgets/PortfolioWidget.jsx
+++ b/src/components/widgets/PortfolioWidget.jsx
@@ -1,16 +1,83 @@
+import { useMemo } from 'react'
 import LockedOverlay from '@/components/ui/LockedOverlay'
 import useAuthStore from '@/store/useAuthStore'
 import WidgetCard from './WidgetCard'
-import { PORTFOLIO } from '@/mocks/home'
+import { useDomesticHoldings } from '@/api/balance'
 
-const CONIC_STOPS = PORTFOLIO.items.reduce((acc, item, i) => {
-  const start = PORTFOLIO.items.slice(0, i).reduce((s, x) => s + x.ratio, 0)
-  acc.push(`${item.color} ${start}% ${start + item.ratio}%`)
-  return acc
-}, []).join(', ')
+const CHART_COLORS = [
+  'var(--color-chart-1)',
+  'var(--color-chart-2)',
+  'var(--color-chart-3)',
+  'var(--color-chart-4)',
+]
+
+function usePortfolio(enabled) {
+  const { data: holdings = [], isLoading } = useDomesticHoldings({ enabled })
+
+  return useMemo(() => {
+    if (isLoading) return { items: [], returnRate: null, isLoading: true }
+
+    const withValues = holdings
+      .map((h) => {
+        const qty = h.holdingQuantity ?? h.availableQuantity ?? 0
+        const curPrice = h.currentPrice ?? h.avgPrice ?? h.avgBuyPrice ?? 0
+        const avgPrice = h.avgPrice ?? h.avgBuyPrice ?? 0
+        return {
+          name: h.stockName ?? h.stockCode,
+          currentValue: curPrice * qty,
+          investedValue: avgPrice * qty,
+        }
+      })
+      .filter((h) => h.currentValue > 0)
+      .sort((a, b) => b.currentValue - a.currentValue)
+
+    const total = withValues.reduce((s, h) => s + h.currentValue, 0)
+    const totalInvested = withValues.reduce((s, h) => s + h.investedValue, 0)
+
+    if (total === 0) return { items: [], returnRate: null, isLoading: false }
+
+    const top = withValues.slice(0, 3)
+    const rest = withValues.slice(3)
+
+    const items = top.map((h, i) => ({
+      name: h.name,
+      ratio: Math.round((h.currentValue / total) * 100),
+      color: CHART_COLORS[i],
+    }))
+
+    if (rest.length > 0) {
+      items.push({
+        name: '기타',
+        ratio: 100 - items.reduce((s, item) => s + item.ratio, 0),
+        color: CHART_COLORS[3],
+      })
+    } else {
+      const sum = items.reduce((s, item) => s + item.ratio, 0)
+      if (items.length > 0) items[items.length - 1].ratio += (100 - sum)
+    }
+
+    const returnRate = totalInvested > 0
+      ? ((total - totalInvested) / totalInvested) * 100
+      : 0
+
+    return { items, returnRate, isLoading: false }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [holdings, isLoading])
+}
 
 export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1, rowSpan = 1, onDelete }) {
   const { isAuthenticated, isRestoring } = useAuthStore()
+  const portfolio = usePortfolio(isAuthenticated && !isRestoring)
+
+  const conicStops = portfolio.items.reduce((acc, item, i) => {
+    const start = portfolio.items.slice(0, i).reduce((s, x) => s + x.ratio, 0)
+    acc.push(`${item.color} ${start}% ${start + item.ratio}%`)
+    return acc
+  }, []).join(', ')
+
+  const returnRateStr = portfolio.returnRate != null
+    ? `${portfolio.returnRate >= 0 ? '+' : ''}${portfolio.returnRate.toFixed(1)}%`
+    : '-'
 
   return (
     <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
@@ -18,10 +85,10 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
         <>
           <div className="flex items-center justify-between mb-1 shrink-0">
             <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 비중</span>
-            <span className="text-[10px] font-semibold text-up">{PORTFOLIO.returnRate}</span>
+            <span className="text-[10px] font-semibold text-up">{returnRateStr}</span>
           </div>
           <div className="flex flex-col gap-2 flex-1 min-h-0">
-            {PORTFOLIO.items.slice(0, 3).map((item) => (
+            {portfolio.items.slice(0, 3).map((item) => (
               <div key={item.name}>
                 <div className="flex justify-between mb-0.5">
                   <span className="text-[10px] text-foreground-secondary">{item.name}</span>
@@ -43,16 +110,16 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
             <div className="flex items-center gap-3 shrink-0">
               <div
                 className="w-16 h-16 rounded-full shrink-0"
-                style={{ background: `conic-gradient(${CONIC_STOPS})` }}
+                style={{ background: `conic-gradient(${conicStops})` }}
               />
               <div>
                 <div className="text-[9px] text-foreground-disabled">총 수익률</div>
-                <div className="text-[22px] font-bold text-up leading-tight">{PORTFOLIO.returnRate}</div>
+                <div className="text-[22px] font-bold text-up leading-tight">{returnRateStr}</div>
                 <div className="text-[9px] text-foreground-disabled mt-0.5">+4,280,000원</div>
               </div>
             </div>
             <div className="flex flex-col gap-2.5 flex-1">
-              {PORTFOLIO.items.map((item) => (
+              {portfolio.items.map((item) => (
                 <div key={item.name}>
                   <div className="flex justify-between mb-0.5">
                     <span className="text-[10px] text-foreground-tertiary">{item.name}</span>
@@ -71,15 +138,15 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
         <>
           <div className="flex items-center justify-between mb-1 shrink-0">
             <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 비중</span>
-            <span className="text-[10px] font-semibold text-up">{PORTFOLIO.returnRate}</span>
+            <span className="text-[10px] font-semibold text-up">{returnRateStr}</span>
           </div>
           <div className="flex items-center gap-2.5 flex-1 min-h-0">
             <div
               className="w-14 h-14 rounded-full shrink-0"
-              style={{ background: `conic-gradient(${CONIC_STOPS})` }}
+              style={{ background: `conic-gradient(${conicStops})` }}
             />
             <div className="flex flex-col gap-1">
-              {PORTFOLIO.items.map((item) => (
+              {portfolio.items.map((item) => (
                 <div key={item.name} className="flex items-center gap-1">
                   <div className="w-1.5 h-1.5 rounded-full shrink-0" style={{ background: item.color }} />
                   <span className="text-[10px] text-foreground-secondary">{item.name}</span>

--- a/src/components/widgets/PortfolioWidget.jsx
+++ b/src/components/widgets/PortfolioWidget.jsx
@@ -9,6 +9,7 @@ const CHART_COLORS = [
   'var(--color-chart-2)',
   'var(--color-chart-3)',
   'var(--color-chart-4)',
+  'var(--color-chart-5)',
 ]
 
 function usePortfolio(enabled) {
@@ -78,6 +79,7 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
   const returnRateStr = portfolio.returnRate != null
     ? `${portfolio.returnRate >= 0 ? '+' : ''}${portfolio.returnRate.toFixed(1)}%`
     : '-'
+  const returnRateColor = (portfolio.returnRate ?? 0) >= 0 ? 'text-up' : 'text-down'
 
   return (
     <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
@@ -85,7 +87,7 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
         <>
           <div className="flex items-center justify-between mb-1 shrink-0">
             <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 비중</span>
-            <span className="text-[10px] font-semibold text-up">{returnRateStr}</span>
+            <span className={`text-[10px] font-semibold ${returnRateColor}`}>{returnRateStr}</span>
           </div>
           <div className="flex flex-col gap-2 flex-1 min-h-0">
             {portfolio.items.slice(0, 3).map((item) => (
@@ -114,7 +116,7 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
               />
               <div>
                 <div className="text-[9px] text-foreground-disabled">총 수익률</div>
-                <div className="text-[22px] font-bold text-up leading-tight">{returnRateStr}</div>
+                <div className={`text-[22px] font-bold leading-tight ${returnRateColor}`}>{returnRateStr}</div>
                 <div className="text-[9px] text-foreground-disabled mt-0.5">+4,280,000원</div>
               </div>
             </div>
@@ -138,7 +140,7 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
         <>
           <div className="flex items-center justify-between mb-1 shrink-0">
             <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 비중</span>
-            <span className="text-[10px] font-semibold text-up">{returnRateStr}</span>
+            <span className={`text-[10px] font-semibold ${returnRateColor}`}>{returnRateStr}</span>
           </div>
           <div className="flex items-center gap-2.5 flex-1 min-h-0">
             <div

--- a/src/components/widgets/RankingWidget.jsx
+++ b/src/components/widgets/RankingWidget.jsx
@@ -2,19 +2,19 @@ import { useState } from 'react'
 import PriceChange from '@/components/ui/PriceChange'
 import TabChip from '@/components/ui/TabChip'
 import WidgetCard from './WidgetCard'
-import { RANKING } from '@/mocks/home'
+import useMarketRanking from '@/features/market/useMarketRanking'
 
 const TABS = ['거래대금', '급상승', '거래량']
 
-const RANKING_EXTENDED = [
-  ...RANKING,
-  { rank: 6,  name: '카카오',        label: 'K',   color: 'yellow',  price: '44,150',  change:  0.38, volume: '0.4조' },
-  { rank: 7,  name: 'NAVER',         label: 'N',   color: 'green',   price: '210,000', change: -0.92, volume: '0.3조' },
-]
-
+const TAB_TO_SORT = {
+  '거래대금': 'volume_value',
+  '급상승':   'rising',
+  '거래량':   'volume',
+}
 
 export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, rowSpan = 1, onDelete }) {
   const [activeTab, setActiveTab] = useState('거래대금')
+  const { stocks } = useMarketRanking(TAB_TO_SORT[activeTab], '')
 
   if (variant === 'ranking-lg') {
     return (
@@ -34,9 +34,9 @@ export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, r
           </div>
         </div>
         <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-0.5">
-          {RANKING_EXTENDED.map((stock) => (
+          {stocks.map((stock) => (
             <div
-              key={stock.rank}
+              key={stock.id ?? stock.rank}
               className="flex items-center justify-between px-1 py-1 hover:bg-surface-subtle rounded-lg transition-colors cursor-pointer"
             >
               <div className="flex items-center gap-1.5">
@@ -71,9 +71,9 @@ export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, r
         </div>
       </div>
       <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-0.5">
-        {RANKING.map((stock) => (
+        {stocks.map((stock) => (
           <div
-            key={stock.rank}
+            key={stock.id ?? stock.rank}
             className="flex items-center justify-between px-1.5 py-1.5 rounded-xl hover:bg-surface-subtle transition-colors cursor-pointer"
           >
             <div className="flex items-center gap-1.5">

--- a/src/components/widgets/RankingWidget.jsx
+++ b/src/components/widgets/RankingWidget.jsx
@@ -13,7 +13,14 @@ const TAB_TO_SORT = {
 }
 
 export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, rowSpan = 1, onDelete }) {
-  const [activeTab, setActiveTab] = useState('거래대금')
+  const [activeTab, setActiveTab] = useState(
+    () => localStorage.getItem('rankingWidget.activeTab') ?? '거래대금'
+  )
+
+  function handleTabChange(tab) {
+    setActiveTab(tab)
+    localStorage.setItem('rankingWidget.activeTab', tab)
+  }
   const { stocks } = useMarketRanking(TAB_TO_SORT[activeTab], '')
 
   if (variant === 'ranking-lg') {
@@ -26,7 +33,7 @@ export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, r
               <TabChip
                 key={tab}
                 isActive={activeTab === tab}
-                onClick={(e) => { e.stopPropagation(); setActiveTab(tab) }}
+                onClick={(e) => { e.stopPropagation(); handleTabChange(tab) }}
               >
                 {tab}
               </TabChip>
@@ -63,7 +70,7 @@ export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, r
             <TabChip
               key={tab}
               isActive={activeTab === tab}
-              onClick={(e) => { e.stopPropagation(); setActiveTab(tab) }}
+              onClick={(e) => { e.stopPropagation(); handleTabChange(tab) }}
             >
               {tab}
             </TabChip>

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -55,8 +55,8 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
     refetchInterval: 10_000,
   })
 
-  const endDate   = formatApiDate(new Date())
-  const startDate = formatApiDate(new Date(Date.now() - 30 * 24 * 60 * 60 * 1000))
+  const endDate   = useMemo(() => formatApiDate(new Date()), [])
+  const startDate = useMemo(() => formatApiDate(new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)), [])
 
   const { data: chartRaw } = useQuery({
     queryKey: ['stock', 'chart', 'DAILY', stockCode, startDate, endDate],

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -1,15 +1,44 @@
 import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import StockAvatar from '@/components/ui/StockAvatar'
 import PriceChange from '@/components/ui/PriceChange'
 import WidgetCard from './WidgetCard'
 import { HOME_STOCKS } from '@/mocks/home'
+import { marketApi } from '@/api/market'
+
+// config.stockId(레거시) → 종목코드 매핑
+const STOCK_CODE_MAP = {
+  samsung: '005930',
+  skhynix: '000660',
+}
 
 const PERIODS = ['1일', '1주', '1달', '3달']
 
 export default function StockChartWidget({ variant = 'stock-sm', colSpan = 1, rowSpan = 1, onDelete, config = {} }) {
   const [activePeriod, setActivePeriod] = useState('1일')
-  const stockId = config.stockId ?? 'samsung'
-  const stock = HOME_STOCKS.find((s) => s.id === stockId) ?? HOME_STOCKS[0]
+
+  const stockId   = config.stockId ?? 'samsung'
+  const stockCode = config.stockCode ?? STOCK_CODE_MAP[stockId]
+  const stockMeta = HOME_STOCKS.find((s) => s.id === stockId) ?? HOME_STOCKS[0]
+
+  const { data: priceData } = useQuery({
+    queryKey: ['stock', 'price', stockCode],
+    queryFn:  () => marketApi.getCurrentPrice(stockCode),
+    enabled:  !!stockCode,
+    staleTime: 5_000,
+    refetchInterval: 10_000,
+  })
+
+  const stock = {
+    ...stockMeta,
+    price:     priceData?.currentPrice != null
+                 ? Number(priceData.currentPrice).toLocaleString('ko-KR')
+                 : stockMeta.price,
+    change:    priceData?.changeRate    ?? stockMeta.change,
+    changeAmt: priceData?.changeAmount != null
+                 ? Math.abs(Number(priceData.changeAmount)).toLocaleString('ko-KR')
+                 : stockMeta.changeAmt,
+  }
   const isUp = stock.change > 0
 
   if (variant === 'stock-wide') {

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -1,10 +1,17 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
+import { Settings2 } from 'lucide-react'
 import StockAvatar from '@/components/ui/StockAvatar'
 import PriceChange from '@/components/ui/PriceChange'
+import MiniChart from '@/components/ui/MiniChart'
 import WidgetCard from './WidgetCard'
+import StockSelectModal from './StockSelectModal'
 import { HOME_STOCKS } from '@/mocks/home'
 import { marketApi } from '@/api/market'
+import useWidgetStore from '@/store/useWidgetStore'
+import { useDashboardSave } from '@/hooks/useDashboardSync'
+import { normalizeDailySeries } from '@/features/invest/domestic/normalize'
+import { formatApiDate } from '@/features/invest/formatters'
 
 // config.stockId(레거시) → 종목코드 매핑
 const STOCK_CODE_MAP = {
@@ -14,12 +21,31 @@ const STOCK_CODE_MAP = {
 
 const PERIODS = ['1일', '1주', '1달', '3달']
 
-export default function StockChartWidget({ variant = 'stock-sm', colSpan = 1, rowSpan = 1, onDelete, config = {} }) {
+export default function StockChartWidget({ instanceId, variant = 'stock-sm', colSpan = 1, rowSpan = 1, onDelete, config = {} }) {
   const [activePeriod, setActivePeriod] = useState('1일')
+  const [isConfigOpen, setIsConfigOpen] = useState(false)
+  const updateWidgetConfig = useWidgetStore((s) => s.updateWidgetConfig)
+  const { mutate: saveDashboard } = useDashboardSave()
 
   const stockId   = config.stockId ?? 'samsung'
   const stockCode = config.stockCode ?? STOCK_CODE_MAP[stockId]
+  const stockName = config.stockName ?? null
   const stockMeta = HOME_STOCKS.find((s) => s.id === stockId) ?? HOME_STOCKS[0]
+
+  function handleStockSave({ stockCode: newCode, stockName: newName }) {
+    updateWidgetConfig(instanceId, { stockCode: newCode, stockName: newName, stockId: undefined })
+    saveDashboard()
+    setIsConfigOpen(false)
+  }
+
+  const settingsBtn = (
+    <button
+      onClick={(e) => { e.stopPropagation(); setIsConfigOpen(true) }}
+      className="p-0.5 rounded text-foreground-disabled hover:text-foreground transition-colors"
+    >
+      <Settings2 className="w-3 h-3" />
+    </button>
+  )
 
   const { data: priceData } = useQuery({
     queryKey: ['stock', 'price', stockCode],
@@ -29,146 +55,191 @@ export default function StockChartWidget({ variant = 'stock-sm', colSpan = 1, ro
     refetchInterval: 10_000,
   })
 
+  const endDate   = formatApiDate(new Date())
+  const startDate = formatApiDate(new Date(Date.now() - 30 * 24 * 60 * 60 * 1000))
+
+  const { data: chartRaw } = useQuery({
+    queryKey: ['stock', 'chart', 'DAILY', stockCode, startDate, endDate],
+    queryFn:  () => marketApi.getChart(stockCode, { period: 'DAILY', startDate, endDate }),
+    enabled:  !!stockCode,
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const miniChartData = useMemo(() => {
+    const series = normalizeDailySeries(chartRaw?.data)
+    return series.map((p) => ({ time: Math.floor(p.timestamp / 1000), value: p.close }))
+  }, [chartRaw])
+
+  const hasPrice = priceData != null
   const stock = {
     ...stockMeta,
+    name:      stockName ?? stockMeta.name,
+    code:      stockCode ?? stockMeta.code,
     price:     priceData?.currentPrice != null
                  ? Number(priceData.currentPrice).toLocaleString('ko-KR')
-                 : stockMeta.price,
-    change:    priceData?.changeRate    ?? stockMeta.change,
+                 : '-',
+    change:    priceData?.changeRate ?? 0,
     changeAmt: priceData?.changeAmount != null
                  ? Math.abs(Number(priceData.changeAmount)).toLocaleString('ko-KR')
-                 : stockMeta.changeAmt,
+                 : '-',
   }
   const isUp = stock.change > 0
 
+  const selectModal = isConfigOpen && (
+    <StockSelectModal
+      currentCode={stockCode}
+      currentName={stock.name}
+      onSave={handleStockSave}
+      onClose={() => setIsConfigOpen(false)}
+    />
+  )
+
   if (variant === 'stock-wide') {
     return (
-      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-        <div className="flex h-full gap-2.5 min-h-0">
-          <div className="flex flex-col justify-between shrink-0">
-            <div>
-              <div className="text-[11px] font-bold text-foreground leading-none">{stock.name}</div>
-              <div className="text-[9px] text-foreground-disabled">{stock.code} · {stock.market}</div>
-            </div>
-            <div>
-              <div className={`text-[18px] font-bold leading-tight text-foreground`}>{stock.price}</div>
-              <div className={`text-[10px] ${isUp ? 'text-up' : 'text-down'}`}>
-                {isUp ? '▲' : '▼'} {stock.changeAmt}원 ({isUp ? '+' : ''}{stock.change}%)
+      <>
+        <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+          <div className="flex h-full gap-2.5 min-h-0">
+            <div className="flex flex-col justify-between shrink-0">
+              <div>
+                <div className="flex items-center gap-1">
+                  <div className="text-[11px] font-bold text-foreground leading-none">{stock.name}</div>
+                  {settingsBtn}
+                </div>
+                <div className="text-[9px] text-foreground-disabled mt-0.5">{stock.code} · {stock.market}</div>
+              </div>
+              <div>
+                <div className={`text-[18px] font-bold leading-tight text-foreground`}>{stock.price}</div>
+                {hasPrice
+                  ? <div className={`text-[10px] ${isUp ? 'text-up' : 'text-down'}`}>
+                      {isUp ? '▲' : '▼'} {stock.changeAmt}원 ({isUp ? '+' : ''}{stock.change}%)
+                    </div>
+                  : <div className="text-[10px] text-foreground-disabled">-</div>
+                }
               </div>
             </div>
+            <MiniChart data={miniChartData} isUp={isUp} className="flex-1 min-h-0" />
           </div>
-          <div className="flex-1 min-h-0 flex items-end gap-px pb-1 pt-2">
-            {[35,48,42,55,48,62,55,70,60,78,68,88].map((h, i) => (
-              <div key={i} className={`flex-1 rounded-sm ${isUp ? 'bg-up/50' : 'bg-down/50'}`} style={{ height: `${h}%` }} />
-            ))}
-          </div>
-        </div>
-      </WidgetCard>
+        </WidgetCard>
+        {selectModal}
+      </>
     )
   }
 
   if (variant === 'stock-3x2') {
     return (
-      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-        <div className="flex items-start justify-between mb-1.5 shrink-0">
-          <div className="flex items-center gap-2">
-            <StockAvatar name={stock.label} color={stock.color} size="sm" />
-            <div>
-              <div className="text-[13px] font-bold text-foreground">{stock.name}</div>
-              <div className="text-[9px] text-foreground-disabled">{stock.code} · {stock.market} · 반도체</div>
+      <>
+        <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+          <div className="flex items-start justify-between mb-1.5 shrink-0">
+            <div className="flex items-center gap-2">
+              <StockAvatar name={stock.label} color={stock.color} size="sm" />
+              <div>
+                <div className="flex items-center gap-1">
+                  <div className="text-[13px] font-bold text-foreground">{stock.name}</div>
+                  {settingsBtn}
+                </div>
+                <div className="text-[9px] text-foreground-disabled">{stock.code} · {stock.market}</div>
+              </div>
+            </div>
+            <div className="text-right">
+              <div className={`text-[20px] font-bold leading-tight text-foreground`}>{stock.price}</div>
+              <PriceChange value={stock.change} className="text-[10px]" />
             </div>
           </div>
-          <div className="text-right">
-            <div className={`text-[20px] font-bold leading-tight text-foreground`}>{stock.price}</div>
-            <PriceChange value={stock.change} className="text-[10px]" />
+          <div className="flex gap-1.5 shrink-0 mb-1.5">
+            {PERIODS.map((p) => (
+              <button
+                key={p}
+                onClick={(e) => { e.stopPropagation(); setActivePeriod(p) }}
+                className={`text-[9px] px-1.5 py-0.5 rounded font-medium transition-colors duration-[150ms] ${activePeriod === p ? 'bg-primary-light text-primary' : 'text-foreground-disabled hover:text-foreground'}`}
+              >
+                {p}
+              </button>
+            ))}
           </div>
-        </div>
-        <div className="flex gap-1.5 shrink-0 mb-1.5">
-          {PERIODS.map((p) => (
-            <button
-              key={p}
-              onClick={(e) => { e.stopPropagation(); setActivePeriod(p) }}
-              className={`text-[9px] px-1.5 py-0.5 rounded font-medium transition-colors duration-[150ms] ${activePeriod === p ? 'bg-primary-light text-primary' : 'text-foreground-disabled hover:text-foreground'}`}
-            >
-              {p}
-            </button>
-          ))}
-        </div>
-        <div className="flex-1 min-h-0 bg-background rounded-xl flex items-end px-2 pb-2 pt-2 gap-px">
-          {[28,35,32,44,48,54,58,65,70,76,82,88,92,96].map((h, i) => (
-            <div key={i} className={`flex-1 rounded-sm ${isUp ? 'bg-up/50' : 'bg-down/50'}`} style={{ height: `${h}%` }} />
-          ))}
-        </div>
-        <div className="flex justify-between shrink-0 mt-1.5">
-          {[
-            { label: '시가',  val: stock.open },
-            { label: '고가',  val: stock.high },
-            { label: '저가',  val: stock.low  },
-            { label: '거래량', val: '12.4M'   },
-            { label: '시총',  val: '450조'    },
-          ].map(({ label, val }) => (
-            <div key={label} className="text-center">
-              <div className="text-[8px] text-foreground-disabled">{label}</div>
-              <div className="text-[10px] font-semibold text-foreground">{val}</div>
-            </div>
-          ))}
-        </div>
-      </WidgetCard>
+          <MiniChart data={miniChartData} isUp={isUp} className="flex-1 min-h-0 rounded-xl" />
+          <div className="flex justify-between shrink-0 mt-1.5">
+            {[
+              { label: '시가',  val: stock.open },
+              { label: '고가',  val: stock.high },
+              { label: '저가',  val: stock.low  },
+              { label: '거래량', val: '12.4M'   },
+              { label: '시총',  val: '450조'    },
+            ].map(({ label, val }) => (
+              <div key={label} className="text-center">
+                <div className="text-[8px] text-foreground-disabled">{label}</div>
+                <div className="text-[10px] font-semibold text-foreground">{val}</div>
+              </div>
+            ))}
+          </div>
+        </WidgetCard>
+        {selectModal}
+      </>
     )
   }
 
   if (variant === 'stock-2x2') {
     return (
-      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-        <div className="flex items-start justify-between mb-1.5 shrink-0">
-          <div className="flex items-center gap-2">
-            <StockAvatar name={stock.label} color={stock.color} size="sm" />
-            <div>
-              <div className="text-[13px] font-bold text-foreground">{stock.name}</div>
-              <div className="text-[9px] text-foreground-disabled">{stock.code}</div>
+      <>
+        <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+          <div className="flex items-start justify-between mb-1.5 shrink-0">
+            <div className="flex items-center gap-2">
+              <StockAvatar name={stock.label} color={stock.color} size="sm" />
+              <div>
+                <div className="flex items-center gap-1">
+                  <div className="text-[13px] font-bold text-foreground">{stock.name}</div>
+                  {settingsBtn}
+                </div>
+                <div className="text-[9px] text-foreground-disabled">{stock.code}</div>
+              </div>
+            </div>
+            <div className="text-right">
+              <div className={`text-[18px] font-bold leading-tight text-foreground`}>{stock.price}</div>
+              <PriceChange value={stock.change} className="text-[10px]" />
             </div>
           </div>
-          <div className="text-right">
-            <div className={`text-[18px] font-bold leading-tight text-foreground`}>{stock.price}</div>
-            <PriceChange value={stock.change} className="text-[10px]" />
+          <MiniChart data={miniChartData} isUp={isUp} className="flex-1 min-h-0 rounded-xl my-1.5" />
+          <div className="flex justify-between shrink-0">
+            {[
+              { label: '시가', val: stock.open },
+              { label: '고가', val: stock.high },
+              { label: '저가', val: stock.low },
+            ].map(({ label, val }) => (
+              <div key={label} className="text-center">
+                <div className="text-[9px] text-foreground-disabled">{label}</div>
+                <div className="text-[11px] font-semibold text-foreground">{val}</div>
+              </div>
+            ))}
           </div>
-        </div>
-        <div className="flex-1 min-h-0 bg-background rounded-xl flex items-end px-2 pb-2 pt-2 gap-px my-1.5">
-          {[38, 52, 44, 58, 48, 62, 50, 68, 56, 72, 60, 78, 65, 82, 70, 88, 75, 90, 78, 85].map((h, i) => (
-            <div key={i} className={`flex-1 rounded-sm ${isUp ? 'bg-up/50' : 'bg-down/50'}`} style={{ height: `${h}%` }} />
-          ))}
-        </div>
-        <div className="flex justify-between shrink-0">
-          {[
-            { label: '시가', val: stock.open },
-            { label: '고가', val: stock.high },
-            { label: '저가', val: stock.low },
-          ].map(({ label, val }) => (
-            <div key={label} className="text-center">
-              <div className="text-[9px] text-foreground-disabled">{label}</div>
-              <div className="text-[11px] font-semibold text-foreground">{val}</div>
-            </div>
-          ))}
-        </div>
-      </WidgetCard>
+        </WidgetCard>
+        {selectModal}
+      </>
     )
   }
 
   /* stock-sm (default) */
   return (
-    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-      <div className="flex items-center justify-between shrink-0">
-        <span className="text-[12px] font-bold text-foreground leading-none">{stock.name}</span>
-        <span className="text-[9px] text-foreground-disabled">{stock.code}</span>
-      </div>
-      <div className="flex-1 flex flex-col justify-end min-h-0">
-        <div className="text-[18px] font-bold leading-tight tracking-tight text-foreground">
-          {stock.price}
+    <>
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+        <div className="flex items-center justify-between shrink-0">
+          <span className="text-[12px] font-bold text-foreground leading-none">{stock.name}</span>
+          <div className="flex items-center gap-1">
+            <span className="text-[9px] text-foreground-disabled">{stock.code}</span>
+            {settingsBtn}
+          </div>
         </div>
-        <div className={`text-[10px] mt-0.5 ${isUp ? 'text-up' : 'text-down'}`}>
-          {isUp ? '▲' : '▼'} {stock.changeAmt}원 ({isUp ? '+' : ''}{stock.change}%)
+        <div className="flex-1 flex flex-col justify-end min-h-0">
+          <div className="text-[18px] font-bold leading-tight tracking-tight text-foreground">
+            {stock.price}
+          </div>
+          {hasPrice
+            ? <div className={`text-[10px] mt-0.5 ${isUp ? 'text-up' : 'text-down'}`}>
+                {isUp ? '▲' : '▼'} {stock.changeAmt}원 ({isUp ? '+' : ''}{stock.change}%)
+              </div>
+            : <div className="text-[10px] mt-0.5 text-foreground-disabled">-</div>
+          }
         </div>
-      </div>
-    </WidgetCard>
+      </WidgetCard>
+      {selectModal}
+    </>
   )
 }

--- a/src/components/widgets/StockSelectModal.jsx
+++ b/src/components/widgets/StockSelectModal.jsx
@@ -1,0 +1,83 @@
+import { useState, useEffect } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { X, Search } from 'lucide-react'
+import { marketApi } from '@/api/market'
+
+export default function StockSelectModal({ currentCode, currentName, onSave, onClose }) {
+  const [keyword, setKeyword] = useState('')
+  const [debouncedKeyword, setDebouncedKeyword] = useState('')
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedKeyword(keyword), 300)
+    return () => clearTimeout(timer)
+  }, [keyword])
+
+  const { data: results = [], isFetching } = useQuery({
+    queryKey: ['stock', 'search', debouncedKeyword],
+    queryFn: () => marketApi.searchStocks(debouncedKeyword),
+    enabled: debouncedKeyword.trim().length >= 1,
+    staleTime: 30_000,
+  })
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={onClose}
+    >
+      <div
+        className="bg-surface rounded-2xl shadow-xl w-[320px] p-5"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <span className="text-[13px] font-bold text-foreground">종목 선택</span>
+          <button onClick={onClose} className="text-foreground-disabled hover:text-foreground transition-colors">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="relative mb-3">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-foreground-disabled" />
+          <input
+            autoFocus
+            type="text"
+            value={keyword}
+            onChange={(e) => setKeyword(e.target.value)}
+            placeholder="종목명 또는 코드 검색"
+            className="w-full pl-8 pr-3 py-2 text-[12px] bg-background border border-stroke rounded-xl outline-none focus:border-primary transition-colors"
+          />
+        </div>
+
+        <div className="flex flex-col gap-0.5 max-h-[240px] overflow-y-auto">
+          {keyword.trim().length === 0 && currentCode && (
+            <div className="px-3 py-2.5 rounded-xl bg-primary-light border border-primary-border">
+              <div className="flex items-center justify-between">
+                <span className="text-[12px] font-semibold text-primary">{currentName ?? currentCode}</span>
+                <span className="text-[10px] text-primary/70">{currentCode}</span>
+              </div>
+              <div className="text-[9px] text-primary/60 mt-0.5">현재 선택</div>
+            </div>
+          )}
+
+          {isFetching && (
+            <div className="text-[11px] text-foreground-disabled text-center py-4">검색 중...</div>
+          )}
+
+          {!isFetching && debouncedKeyword.trim().length >= 1 && results.length === 0 && (
+            <div className="text-[11px] text-foreground-disabled text-center py-4">검색 결과 없음</div>
+          )}
+
+          {results.map((stock) => (
+            <button
+              key={stock.stockCode}
+              onClick={() => onSave({ stockCode: stock.stockCode, stockName: stock.stockName })}
+              className="flex items-center justify-between px-3 py-2.5 rounded-xl hover:bg-surface-subtle transition-colors text-left"
+            >
+              <span className="text-[12px] font-semibold text-foreground">{stock.stockName}</span>
+              <span className="text-[10px] text-foreground-disabled">{stock.stockCode}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/market/useMarketIndices.js
+++ b/src/features/market/useMarketIndices.js
@@ -6,7 +6,7 @@ import { subscribeTopic } from '@/lib/stomp'
 // 백엔드 code → WebSocket topic 매핑
 const INDEX_TOPICS = {
   '001':      '/topic/index/domestic/001',
-  '301':      '/topic/index/domestic/301',
+  '101':      '/topic/index/domestic/101',
   'SPI@SPX':  '/topic/index/foreign/SPI@SPX',
   'NAS@IXIC': '/topic/index/foreign/NAS@IXIC',
   USD:        '/topic/currency/USD',

--- a/src/hooks/useDashboardSync.js
+++ b/src/hooks/useDashboardSync.js
@@ -1,0 +1,49 @@
+import { useEffect } from 'react'
+import { useQuery, useMutation } from '@tanstack/react-query'
+import useAuthStore from '@/store/useAuthStore'
+import useWidgetStore from '@/store/useWidgetStore'
+import { dashboardApi } from '@/api/dashboard'
+import { toApiPayload } from '@/store/widgetApi'
+
+/**
+ * 로그인 상태에 따라 서버에서 대시보드 레이아웃을 불러와 store에 반영.
+ * AppShell에서 한 번 호출.
+ *
+ * - 로그인 시:  GET /api/dashboards/me → loadFromServer()
+ * - 로그아웃 시: store를 INITIAL 레이아웃으로 초기화
+ */
+export function useDashboardLoad() {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
+  const isLoaded = useWidgetStore((s) => s.isLoaded)
+  const loadFromServer = useWidgetStore((s) => s.loadFromServer)
+  const resetLayout = useWidgetStore((s) => s.resetLayout)
+
+  // 로그아웃 시 레이아웃 초기화 → 재로그인 시 서버에서 새로 불러올 수 있도록
+  useEffect(() => {
+    if (!isAuthenticated) resetLayout()
+  }, [isAuthenticated, resetLayout])
+
+  const { data } = useQuery({
+    queryKey: ['dashboard', 'me'],
+    queryFn: dashboardApi.getMyDashboard,
+    enabled: isAuthenticated && !isLoaded,
+    staleTime: Infinity,
+  })
+
+  useEffect(() => {
+    if (data) loadFromServer(data)
+  }, [data, loadFromServer])
+}
+
+/**
+ * 대시보드 레이아웃을 서버에 저장하는 mutation.
+ * 편집 모드 저장 버튼에서 호출.
+ *
+ * @returns useMutation result (mutate, isPending, isError 등)
+ */
+export function useDashboardSave() {
+  const pages = useWidgetStore((s) => s.pages)
+  return useMutation({
+    mutationFn: () => dashboardApi.saveMyDashboard(toApiPayload(pages)),
+  })
+}

--- a/src/hooks/useDashboardSync.js
+++ b/src/hooks/useDashboardSync.js
@@ -42,8 +42,11 @@ export function useDashboardLoad() {
  * @returns useMutation result (mutate, isPending, isError 등)
  */
 export function useDashboardSave() {
-  const pages = useWidgetStore((s) => s.pages)
   return useMutation({
-    mutationFn: () => dashboardApi.saveMyDashboard(toApiPayload(pages)),
+    // mutationFn 실행 시점에 최신 pages를 읽어 stale closure 방지
+    mutationFn: () => {
+      const pages = useWidgetStore.getState().pages
+      return dashboardApi.saveMyDashboard(toApiPayload(pages))
+    },
   })
 }

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -173,6 +173,7 @@ export default function HomePage() {
                 gridRow={w.gridRow}
               >
                 <Component
+                  instanceId={w.instanceId}
                   variant={w.variantId}
                   colSpan={w.colSpan}
                   rowSpan={w.rowSpan}

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -210,7 +210,7 @@ const useWidgetStore = create((set) => ({
   // 빈 배열이면 INITIAL 레이아웃 유지.
   loadFromServer: (apiData) =>
     set(() => {
-      const pages = fromApiResponse(apiData)
+      const pages = fromApiResponse(Array.isArray(apiData) ? apiData : apiData.pages ?? [])
       if (pages.length === 0) return { isLoaded: true }
       const currentPage = pages[0]
       return {

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -334,6 +334,14 @@ const useWidgetStore = create((set) => ({
       return _setCurrentWidgets(state, newWidgets)
     }),
 
+  updateWidgetConfig: (instanceId, config) =>
+    set((state) => {
+      const newWidgets = state.widgets.map((w) =>
+        w.instanceId === instanceId ? { ...w, config: { ...w.config, ...config } } : w,
+      )
+      return _setCurrentWidgets(state, newWidgets)
+    }),
+
   // 위젯을 지정 좌표로 이동 (빈 셀 drop)
   moveWidgetTo: (instanceId, gridCol, gridRow) =>
     set((state) => {

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { GRID_COLS, GRID_ROWS } from '@/lib/gridConstants'
+import { fromApiResponse } from './widgetApi'
 
 /* ── 충돌 판정 ──────────────────────────────────────────────
    모든 좌표는 1-indexed (CSS grid와 동일).
@@ -199,6 +200,37 @@ const useWidgetStore = create((set) => ({
 
   // top-level widgets: 항상 현재 페이지의 widgets를 미러링 (하위 호환)
   widgets: INITIAL_WIDGETS,
+
+  // ── 서버 로드 상태 ───────────────────────────────────────
+  // false: 아직 서버에서 불러오지 않음 (INITIAL 레이아웃 사용 중)
+  // true:  서버 데이터로 교체 완료
+  isLoaded: false,
+
+  // GET /api/dashboards/me 응답으로 store를 교체.
+  // 빈 배열이면 INITIAL 레이아웃 유지.
+  loadFromServer: (apiData) =>
+    set(() => {
+      const pages = fromApiResponse(apiData)
+      if (pages.length === 0) return { isLoaded: true }
+      const currentPage = pages[0]
+      return {
+        pages,
+        currentPageId: currentPage.id,
+        widgets:       currentPage.widgets,
+        isLoaded:      true,
+      }
+    }),
+
+  // 로그아웃 시 INITIAL 레이아웃으로 초기화.
+  // isLoaded를 false로 되돌려 재로그인 시 서버에서 새로 불러올 수 있게 함.
+  resetLayout: () =>
+    set({
+      pages:         INITIAL_PAGES,
+      currentPageId: 'page-1',
+      widgets:       INITIAL_WIDGETS,
+      isLoaded:      false,
+    }),
+
 
   // ── 페이지 전환 ─────────────────────────────────────────
   switchPage: (pageId) =>

--- a/src/store/widgetApi.js
+++ b/src/store/widgetApi.js
@@ -25,11 +25,13 @@ const DEFAULT_VARIANT = {
 /**
  * GET /api/dashboards/me 응답 → useWidgetStore.pages 형태로 변환
  *
- * @param {{ pages: Array }} data - 백엔드 응답 JSON
+ * 백엔드는 List<DashboardPageResponse> 를 배열로 직접 반환.
+ *
+ * @param {Array} data - 백엔드 응답 JSON (페이지 배열)
  * @returns {Array} useWidgetStore의 pages 배열
  */
 export function fromApiResponse(data) {
-  return data.pages.map((page) => ({
+  return data.map((page) => ({
     id:      String(page.dashboardId),
     name:    page.name,
     widgets: page.widgets.map((w) => {

--- a/src/store/widgetApi.js
+++ b/src/store/widgetApi.js
@@ -1,0 +1,80 @@
+/**
+ * 프론트(useWidgetStore) ↔ 백엔드(WidgetLayout DTO) 변환 레이어
+ *
+ * GET /api/dashboards/me  → fromApiResponse(data)  → pages
+ * pages                   → toApiPayload(pages)     → PUT /api/dashboards/me
+ */
+
+/**
+ * widgetType → 기본 variantId 매핑.
+ * GET 응답의 configJson에 variantId가 없을 때 폴백으로 사용.
+ */
+const DEFAULT_VARIANT = {
+  'index':           'index-3x1',
+  'balance':         'balance-sm',
+  'portfolio':       'portfolio-sm',
+  'exchange':        'exchange-sm',
+  'stock-chart':     'stock-3x2',
+  'ranking':         'ranking-lg',
+  'watchlist':       'watchlist-sm',
+  'market-overview': 'market-sm',
+  'trade-history':   'trade-wide',
+  'stock-news':      'stock-news-wide',
+}
+
+/**
+ * GET /api/dashboards/me 응답 → useWidgetStore.pages 형태로 변환
+ *
+ * @param {{ pages: Array }} data - 백엔드 응답 JSON
+ * @returns {Array} useWidgetStore의 pages 배열
+ */
+export function fromApiResponse(data) {
+  return data.pages.map((page) => ({
+    id:      String(page.dashboardId),
+    name:    page.name,
+    widgets: page.widgets.map((w) => {
+      const parsed = w.configJson ? JSON.parse(w.configJson) : {}
+      const { variantId, ...restConfig } = parsed
+      return {
+        instanceId:   crypto.randomUUID(),
+        widgetTypeId: w.widgetType,
+        variantId:    variantId ?? DEFAULT_VARIANT[w.widgetType] ?? w.widgetType,
+        gridCol:      w.positionX,
+        gridRow:      w.positionY,
+        colSpan:      w.width,
+        rowSpan:      w.height,
+        config:       Object.keys(restConfig).length > 0 ? restConfig : undefined,
+      }
+    }),
+  }))
+}
+
+/**
+ * useWidgetStore.pages → PUT /api/dashboards/me 요청 바디로 변환
+ *
+ * - page.id가 서버 발급 ID(숫자)면 dashboardId로 전송 (UPDATE)
+ * - 'page-1' 같은 프론트 임시 ID면 null로 전송 (INSERT)
+ *
+ * @param {Array} pages - useWidgetStore의 pages 배열
+ * @returns {{ pages: Array }} PUT 요청 바디
+ */
+export function toApiPayload(pages) {
+  return {
+    pages: pages.map((page, i) => {
+      const numericId = Number(page.id)
+      return {
+        dashboardId: Number.isFinite(numericId) ? numericId : null,
+        name:        page.name,
+        pageOrder:   i + 1,
+        widgets:     page.widgets.map((w) => ({
+          widgetType: w.widgetTypeId,
+          positionX:  w.gridCol,
+          positionY:  w.gridRow,
+          width:      w.colSpan,
+          height:     w.rowSpan,
+          configJson: JSON.stringify({ variantId: w.variantId, ...w.config }),
+        })),
+      }
+    }),
+  }
+}

--- a/src/store/widgetApi.js
+++ b/src/store/widgetApi.js
@@ -35,7 +35,10 @@ export function fromApiResponse(data) {
     id:      String(page.dashboardId),
     name:    page.name,
     widgets: page.widgets.map((w) => {
-      const parsed = w.configJson ? JSON.parse(w.configJson) : {}
+      let parsed = {}
+      if (w.configJson) {
+        try { parsed = JSON.parse(w.configJson) } catch { /* 잘못된 JSON은 빈 config로 처리 */ }
+      }
       const { variantId, ...restConfig } = parsed
       return {
         instanceId:   crypto.randomUUID(),


### PR DESCRIPTION
## 작업 내용

- **MiniChart 컴포넌트 추가** — `lightweight-charts` 기반 미니 area chart, 투명 배경, ResizeObserver 대응
- **StockChartWidget** — 실시간 주가 + 30일 일봉 차트 API 연결, `stock-wide` 레이아웃 수정, MiniChart 적용
- **IndexWidget** — 하드코딩 그래프 제거, 내용 중앙 정렬, 로딩 시 `-` 표시
- **ExchangeWidget** — 하드코딩 그래프 제거, 내용 중앙 정렬
- **PortfolioWidget** — `useDomesticHoldings` 실 API 연결, 동적 conic-gradient 도넛 차트
- **BalanceWidget** — 로딩 중 모든 수치 `'-'` 표시
- **RankingWidget** — 탭 상태 `localStorage` 유지
- **StockSelectModal** — 검색 300ms 디바운스, `stockName` 필드 수정 (한국어 종목명)
- **EditPanel WidgetSizeList** — 위젯 프리뷰 그래프 업데이트

## 확인 방법

- [ ] 홈 대시보드에서 주가 위젯에 미니차트가 표시되는지 확인
- [ ] 지수/환율 위젯에 그래프 없이 수치만 중앙 정렬로 표시되는지 확인
- [ ] 로그인 상태에서 포트폴리오 위젯에 실 보유 종목 비중이 표시되는지 확인
- [ ] 로그인 상태에서 잔고 위젯 로딩 중 `-` 표시 확인
- [ ] 실시간 순위 탭 선택 후 새로고침 시 유지되는지 확인
- [ ] 종목 검색 시 한국어 이름이 정상 표시되는지 확인

## 관련 이슈

closes #66