### PR TITLE
feat: 프로필/PIN 재설정, MarketPage UI 개선, 투자 탭 쿼리 최적화

### DIFF
--- a/src/api/account.js
+++ b/src/api/account.js
@@ -17,6 +17,8 @@ function request(path, method = 'GET', body = null) {
 export const accountApi = {
   getMyAccount: () => request('/me', 'GET'),
   changePin: (currentPin, newPin) => request('/me/pin', 'PATCH', { currentPin, newPin }),
+  requestPinReset: () => request('/pin/reset/request', 'POST'),
+  confirmPinReset: (token, newPin) => request('/pin/reset/confirm', 'POST', { token, newPin }),
   reset: (accountPin) => request('/reset', 'POST', { accountPin }),
   resetCashForClose: (accountPin) => request('/me/cash/reset', 'POST', { accountPin }),
   closeAccount: (accountPin) => request('', 'DELETE', { accountPin }),

--- a/src/api/market.js
+++ b/src/api/market.js
@@ -56,6 +56,7 @@ export const marketApi = {
   getOpinion: (stockCode) => get(`/stocks/${stockCode}/opinion`),
   getInvestor: (stockCode) => get(`/stocks/${stockCode}/investor`),
   getFinance: (stockCode) => get(`/stocks/${stockCode}/finance`),
+  getStockInfo: (stockCode) => get(`/stocks/${stockCode}/info`),
   searchStocks: (keyword) => get('/stocks/search', { keyword }),
 }
 

--- a/src/api/user.js
+++ b/src/api/user.js
@@ -14,6 +14,7 @@ function request(path, method = 'GET', body = null) {
 
 export const userApi = {
   getProfile: () => request('/me', 'GET'),
+  updateProfile: (name, phone) => request('/me', 'PATCH', { name, phone }),
   changePassword: (currentPassword, newPassword) =>
     request('/me/password', 'PATCH', { currentPassword, newPassword, newPasswordConfirm: newPassword }),
 }

--- a/src/components/invest/InvestBottomPanels.jsx
+++ b/src/components/invest/InvestBottomPanels.jsx
@@ -39,19 +39,18 @@ export default function InvestBottomPanels({
   investor,
   finance,
   detailLoading,
-  isLoading,
+  dailyLoading,
+  realtimeLoading,
   errorMessage,
   onLeftTabChange,
   onRightTabChange,
-  stockCode,
-  currentPrice,
 }) {
   return (
     <div className="flex h-[210px] shrink-0 overflow-hidden border-t-2 border-stroke bg-surface">
       <section className="flex min-w-0 flex-1 flex-col overflow-hidden border-r border-stroke">
         <SectionTabs items={LEFT_TABS} activeKey={leftTab} onChange={onLeftTabChange} />
-        {leftTab === 'daily' && <DailyPriceTable rows={dailyRows} isLoading={isLoading} errorMessage={errorMessage} />}
-        {leftTab === 'realtime' && <RealtimeTradeTable rows={realtimeRows} isLoading={isLoading} errorMessage={errorMessage} />}
+        {leftTab === 'daily' && <DailyPriceTable rows={dailyRows} isLoading={dailyLoading} errorMessage={errorMessage} />}
+        {leftTab === 'realtime' && <RealtimeTradeTable rows={realtimeRows} isLoading={realtimeLoading} errorMessage={errorMessage} />}
         {leftTab === 'opinion' && <OpinionTable data={opinion} isLoading={detailLoading} />}
         {leftTab === 'investor' && <InvestorTable data={investor} isLoading={detailLoading} />}
         {leftTab === 'finance' && <FinancePanel data={finance} isLoading={detailLoading} />}

--- a/src/components/invest/InvestOrderSection.jsx
+++ b/src/components/invest/InvestOrderSection.jsx
@@ -22,6 +22,7 @@ export default function InvestOrderSection({
   const [orderType, setOrderType] = useState('market')
   const [quantity, setQuantity] = useState(1)
   const [selectedPrice, setSelectedPrice] = useState(defaultPrice)
+  const [confirmedUnitPrice, setConfirmedUnitPrice] = useState(null)
 
   const [step, setStep] = useState('input') // 'input' | 'confirm'
   const [showPin, setShowPin] = useState(false)
@@ -30,7 +31,10 @@ export default function InvestOrderSection({
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const marketPrice = currentPrice ?? defaultPrice
-  const unitPrice = orderType === 'limit' ? selectedPrice : marketPrice
+  const liveUnitPrice = orderType === 'limit' ? selectedPrice : marketPrice
+  const unitPrice = step === 'confirm' && confirmedUnitPrice != null
+    ? confirmedUnitPrice
+    : liveUnitPrice
 
   const { data: buyableData } = useBuyableAmount({
     stockCode,
@@ -74,16 +78,19 @@ export default function InvestOrderSection({
   }
 
   function handleSideChange(nextSide) {
+    setConfirmedUnitPrice(null)
     setSide(nextSide)
     setQuantity((prev) => Math.min(prev, getMaxOrderQuantity(nextSide)))
   }
 
   function handleOrderTypeChange(nextOrderType) {
+    setConfirmedUnitPrice(null)
     setOrderType(nextOrderType)
     setQuantity((prev) => Math.min(prev, getMaxOrderQuantity(side, nextOrderType)))
   }
 
   function handleSelectPrice(price) {
+    setConfirmedUnitPrice(null)
     setSelectedPrice(price)
     setOrderType('limit')
     setQuantity((prev) => Math.min(prev, getMaxOrderQuantity(side, 'limit', price)))
@@ -105,6 +112,7 @@ export default function InvestOrderSection({
       setShowPin(false)
       setPin('')
       setPinError('')
+      setConfirmedUnitPrice(null)
       setQuantity(1)
       queryClient.invalidateQueries({ queryKey: ['balance'] })
       queryClient.invalidateQueries({ queryKey: ['orders'] })
@@ -152,6 +160,7 @@ export default function InvestOrderSection({
 
   // 뒤로 (confirm → input)
   function handleBack() {
+    setConfirmedUnitPrice(null)
     setStep('input')
     setShowPin(false)
     setPin('')
@@ -188,7 +197,10 @@ export default function InvestOrderSection({
         onQuantityDelta={handleQuantityDelta}
         onQuantityChange={handleQuantityChange}
         onPresetApply={handleQuantityPreset}
-        onSubmit={() => setStep('confirm')}
+        onSubmit={() => {
+          setConfirmedUnitPrice(liveUnitPrice)
+          setStep('confirm')
+        }}
         onConfirm={handleConfirm}
         onBack={handleBack}
         onPinChange={setPin}

--- a/src/components/invest/InvestOrderSection.jsx
+++ b/src/components/invest/InvestOrderSection.jsx
@@ -5,6 +5,7 @@ import InvestOrderPanel from '@/components/invest/InvestOrderPanel'
 import { useBuyableAmount, useDomesticHoldings } from '@/api/balance'
 import { orderApi, ORDER_SIDE, ORDER_KIND } from '@/api/order'
 import usePinAuth from '@/hooks/usePinAuth'
+import useAuthStore from '@/store/useAuthStore'
 
 export default function InvestOrderSection({
   stockCode,
@@ -17,6 +18,7 @@ export default function InvestOrderSection({
 }) {
   const queryClient = useQueryClient()
   const { isPinCached, verifyAndCachePin } = usePinAuth()
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
 
   const [side, setSide] = useState('buy')
   const [orderType, setOrderType] = useState('market')
@@ -40,9 +42,9 @@ export default function InvestOrderSection({
     stockCode,
     marketType,
     orderPrice: orderType === 'limit' ? selectedPrice : undefined,
-    enabled: side === 'buy',
+    enabled: isAuthenticated && side === 'buy',
   })
-  const { data: holdingsData } = useDomesticHoldings({ enabled: side === 'sell' })
+  const { data: holdingsData } = useDomesticHoldings({ enabled: isAuthenticated && side === 'sell' })
 
   const availableAmount = buyableData?.availableAmount ?? 0
   const maxBuyableQuantity = buyableData?.maxBuyableQuantity ?? Math.floor(availableAmount / Math.max(unitPrice, 1))

--- a/src/components/layout/AccountSettingsPanel.jsx
+++ b/src/components/layout/AccountSettingsPanel.jsx
@@ -1,13 +1,16 @@
-import { useState } from 'react'
-import { X, Lock, RotateCcw, Trash2, Key, LogOut } from 'lucide-react'
+import { useState, useEffect } from 'react'
+import { X, LogOut } from 'lucide-react'
+import SplashScreenFill from '@/components/ui/SplashScreenFill'
 import { useNavigate } from 'react-router-dom'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import useRightPanelStore from '@/store/useRightPanelStore'
 import useAuthStore from '@/store/useAuthStore'
-import { PasswordInput } from '@/components/ui/Input'
+import { Input, PasswordInput } from '@/components/ui/Input'
 import { userApi } from '@/api/user'
 import { accountApi } from '@/api/account'
 import { authApi } from '@/api/auth'
-import { changePasswordSchema, changePinSchema, resetAccountSchema, closeAccountSchema } from '@/lib/validationSchemas'
+import { changePasswordSchema, changePinSchema, resetAccountSchema, closeAccountSchema, updateProfileSchema } from '@/lib/validationSchemas'
+import { formatPhoneNumber } from '@/components/signup/phoneNumber'
 import AccountPinKeypad from '@/components/signup/AccountPinKeypad'
 import DecoyCursorOverlay from '@/components/signup/DecoyCursorOverlay'
 
@@ -50,49 +53,114 @@ function Header() {
 }
 
 function MenuTabs({ selectedMenuItem, onSelectMenuItem }) {
+  const tabs = [
+    { id: 'update-profile',          label: '프로필',      danger: false },
+    { id: 'change-account-password', label: '계정 비밀번호', danger: false },
+    { id: 'change-account-pin',      label: '계좌 비밀번호', danger: false },
+    { id: 'reset',                   label: '리셋',        danger: true  },
+    { id: 'close-account',           label: '계좌 해지',   danger: true  },
+  ]
+
   return (
     <div className="flex border-b border-stroke shrink-0 overflow-x-auto">
-      <button
-        onClick={() => onSelectMenuItem('change-account-password')}
-        className={`px-4 py-2 text-[12px] font-medium border-b-2 transition-colors whitespace-nowrap ${
-          selectedMenuItem === 'change-account-password'
-            ? 'text-primary border-b-primary'
-            : 'text-foreground-secondary border-b-transparent hover:text-foreground'
-        }`}
-      >
-        계정 비밀번호
-      </button>
-      <button
-        onClick={() => onSelectMenuItem('change-account-pin')}
-        className={`px-4 py-2 text-[12px] font-medium border-b-2 transition-colors whitespace-nowrap ${
-          selectedMenuItem === 'change-account-pin'
-            ? 'text-primary border-b-primary'
-            : 'text-foreground-secondary border-b-transparent hover:text-foreground'
-        }`}
-      >
-        계좌 비밀번호
-      </button>
-      <button
-        onClick={() => onSelectMenuItem('reset')}
-        className={`px-4 py-2 text-[12px] font-medium border-b-2 transition-colors whitespace-nowrap ${
-          selectedMenuItem === 'reset'
-            ? 'text-up border-b-up'
-            : 'text-foreground-secondary border-b-transparent hover:text-up'
-        }`}
-      >
-        리셋
-      </button>
-      <button
-        onClick={() => onSelectMenuItem('close-account')}
-        className={`px-4 py-2 text-[12px] font-medium border-b-2 transition-colors whitespace-nowrap ${
-          selectedMenuItem === 'close-account'
-            ? 'text-up border-b-up'
-            : 'text-foreground-secondary border-b-transparent hover:text-up'
-        }`}
-      >
-        계좌 해지
-      </button>
+      {tabs.map(({ id, label, danger }) => {
+        const active = selectedMenuItem === id
+        return (
+          <button
+            key={id}
+            onClick={() => onSelectMenuItem(id)}
+            className={`px-3 py-[10px] text-[12px] border-b-2 transition-colors whitespace-nowrap ${
+              active
+                ? danger
+                  ? 'font-bold text-up border-b-up'
+                  : 'font-bold text-primary border-b-primary'
+                : 'font-medium text-foreground-disabled border-b-transparent hover:text-foreground-secondary'
+            }`}
+          >
+            {label}
+          </button>
+        )
+      })}
     </div>
+  )
+}
+
+function UpdateProfileForm({ onSuccess }) {
+  const queryClient = useQueryClient()
+  const { data: profile, isLoading: isProfileLoading } = useQuery({
+    queryKey: ['user', 'profile'],
+    queryFn: () => userApi.getProfile(),
+    staleTime: 1000 * 60 * 5,
+  })
+
+  const [name, setName] = useState('')
+  const [phone, setPhone] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (profile) {
+      setName(profile.name ?? '')
+      setPhone(formatPhoneNumber(profile.phone ?? ''))
+    }
+  }, [profile])
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setError('')
+
+    const validation = updateProfileSchema.safeParse({ name, phone })
+    if (!validation.success) {
+      setError(validation.error.issues[0]?.message ?? '입력 값을 확인해주세요.')
+      return
+    }
+
+    setIsLoading(true)
+    try {
+      await userApi.updateProfile(name, phone)
+      queryClient.invalidateQueries({ queryKey: ['user', 'profile'] })
+      onSuccess('프로필이 수정되었습니다.')
+    } catch (err) {
+      setError(err?.message ?? '프로필 수정에 실패했습니다.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  if (isProfileLoading) {
+    return <p className="text-[12px] text-foreground-disabled">불러오는 중...</p>
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+      <div>
+        <label className="text-[11px] font-semibold text-foreground-secondary block mb-1.5">이름</label>
+        <Input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="이름"
+        />
+      </div>
+
+      <div>
+        <label className="text-[11px] font-semibold text-foreground-secondary block mb-1.5">전화번호</label>
+        <Input
+          value={phone}
+          onChange={(e) => setPhone(formatPhoneNumber(e.target.value))}
+          placeholder="010-0000-0000"
+        />
+      </div>
+
+      {error && <p className="text-[11px] text-up">{error}</p>}
+
+      <button
+        type="submit"
+        disabled={isLoading}
+        className="px-4 py-2 rounded-lg bg-primary text-white text-[12px] font-medium hover:bg-primary-hover transition-colors disabled:opacity-60 mt-2"
+      >
+        저장
+      </button>
+    </form>
   )
 }
 
@@ -114,7 +182,7 @@ function ChangePasswordForm({ onSuccess }) {
     })
 
     if (!validation.success) {
-      const fieldError = validation.error.errors[0]
+      const fieldError = validation.error.issues[0]
       setError(fieldError.message)
       return
     }
@@ -175,7 +243,7 @@ function ChangePasswordForm({ onSuccess }) {
         disabled={isLoading}
         className="px-4 py-2 rounded-lg bg-primary text-white text-[12px] font-medium hover:bg-primary-hover transition-colors disabled:opacity-60 mt-2"
       >
-        {isLoading ? '변경 중...' : '변경'}
+        변경
       </button>
     </form>
   )
@@ -239,6 +307,8 @@ function ChangePinForm({ onSuccess }) {
   const [error, setError] = useState('')
   const [activePinField, setActivePinField] = useState(null)
   const [isKeyboardOpen, setIsKeyboardOpen] = useState(false)
+  const [resetSent, setResetSent] = useState(false)
+  const [resetLoading, setResetLoading] = useState(false)
 
   const handleSubmit = async (e) => {
     e.preventDefault()
@@ -251,7 +321,7 @@ function ChangePinForm({ onSuccess }) {
     })
 
     if (!validation.success) {
-      const fieldError = validation.error.errors[0]
+      const fieldError = validation.error.issues[0]
       setError(fieldError.message)
       return
     }
@@ -294,6 +364,18 @@ function ChangePinForm({ onSuccess }) {
   function openKeyboard(fieldName) {
     setActivePinField(fieldName)
     setIsKeyboardOpen(true)
+  }
+
+  async function handleRequestPinReset() {
+    setResetLoading(true)
+    try {
+      await accountApi.requestPinReset()
+      setResetSent(true)
+    } catch (err) {
+      setError(err?.message ?? '이메일 발송에 실패했습니다.')
+    } finally {
+      setResetLoading(false)
+    }
   }
 
   return (
@@ -365,8 +447,23 @@ function ChangePinForm({ onSuccess }) {
         disabled={isLoading}
         className="px-4 py-2 rounded-lg bg-primary text-white text-[12px] font-medium hover:bg-primary-hover transition-colors disabled:opacity-60 mt-2"
       >
-        {isLoading ? '변경 중...' : '변경'}
+        변경
       </button>
+
+      <div className="mt-1 text-center">
+        {resetSent ? (
+          <p className="text-[11px] text-live">재설정 이메일을 전송했습니다. 이메일을 확인해주세요.</p>
+        ) : (
+          <button
+            type="button"
+            disabled={resetLoading}
+            onClick={handleRequestPinReset}
+            className="text-[11px] text-foreground-tertiary hover:text-primary transition-colors disabled:opacity-60"
+          >
+            {resetLoading ? '전송 중...' : '비밀번호를 잊으셨나요?'}
+          </button>
+        )}
+      </div>
     </form>
   )
 }
@@ -386,7 +483,7 @@ function ResetForm({ onSuccess }) {
     })
 
     if (!validation.success) {
-      const fieldError = validation.error.errors[0]
+      const fieldError = validation.error.issues[0]
       setError(fieldError.message)
       return
     }
@@ -442,7 +539,7 @@ function ResetForm({ onSuccess }) {
         disabled={isLoading}
         className="px-4 py-2 rounded-lg bg-up text-white text-[12px] font-medium hover:opacity-90 transition-colors disabled:opacity-60 mt-2"
       >
-        {isLoading ? '진행 중...' : '리셋'}
+        리셋
       </button>
     </form>
   )
@@ -477,7 +574,7 @@ function CloseAccountForm() {
     const validation = resetAccountSchema.safeParse({ accountPin: cashPin })
     if (!validation.success) {
       setCashKeyboardOpen(true)
-      setCashError(validation.error.errors[0].message)
+      setCashError(validation.error.issues[0].message)
       return
     }
     setCashLoading(true)
@@ -503,7 +600,7 @@ function CloseAccountForm() {
     const validation = closeAccountSchema.safeParse({ accountPin: closePin, agreed })
     if (!validation.success) {
       setCloseKeyboardOpen(true)
-      setCloseError(validation.error.errors[0].message)
+      setCloseError(validation.error.issues[0].message)
       return
     }
     setCloseLoading(true)
@@ -567,7 +664,7 @@ function CloseAccountForm() {
               disabled={cashLoading}
               className="px-4 py-2 rounded-lg bg-up text-white text-[12px] font-medium hover:opacity-90 transition-colors disabled:opacity-60"
             >
-              {cashLoading ? '처리 중...' : 'KRW·USD 현금 0원으로 초기화'}
+              KRW·USD 현금 0원으로 초기화
             </button>
           </>
         )}
@@ -614,7 +711,7 @@ function CloseAccountForm() {
               disabled={closeLoading || !agreed}
               className="px-4 py-2 rounded-lg bg-up text-white text-[12px] font-medium hover:opacity-90 transition-colors disabled:opacity-60"
             >
-              {closeLoading ? '처리 중...' : '계좌 해지'}
+              계좌 해지
             </button>
           </>
         )}
@@ -626,6 +723,10 @@ function CloseAccountForm() {
 function ContentArea({ selectedMenuItem, onSuccess }) {
   return (
     <div className="flex-1 flex flex-col p-4 overflow-y-auto">
+      {selectedMenuItem === 'update-profile' && (
+        <UpdateProfileForm onSuccess={onSuccess} />
+      )}
+
       {selectedMenuItem === 'change-account-password' && (
         <ChangePasswordForm onSuccess={onSuccess} />
       )}
@@ -652,27 +753,45 @@ function ContentArea({ selectedMenuItem, onSuccess }) {
 }
 
 export default function AccountSettingsPanel() {
-  const [selectedMenuItem, setSelectedMenuItem] = useState('change-account-password')
+  const [selectedMenuItem, setSelectedMenuItem] = useState('update-profile')
+  const [successStatus, setSuccessStatus] = useState(null) // null | 'animating' | 'success'
   const [successMessage, setSuccessMessage] = useState('')
 
   const handleSuccess = (message) => {
     setSuccessMessage(message)
-    setTimeout(() => setSuccessMessage(''), 3000)
+    setSuccessStatus('animating')
+    setTimeout(() => setSuccessStatus('success'), 1600)
+  }
+
+  const handleReset = () => {
+    setSuccessStatus(null)
+    setSuccessMessage('')
   }
 
   return (
     <div className="flex flex-col h-full">
       <Header />
 
-      {successMessage && (
-        <div className="px-4 py-2 bg-live/10 border-b border-live text-[11px] text-live">
-          {successMessage}
-        </div>
-      )}
-
       <MenuTabs selectedMenuItem={selectedMenuItem} onSelectMenuItem={setSelectedMenuItem} />
 
-      <ContentArea selectedMenuItem={selectedMenuItem} onSuccess={handleSuccess} />
+      {successStatus ? (
+        <div className="flex-1 flex flex-col items-center justify-center gap-5 p-6">
+          <SplashScreenFill inline animated={successStatus === 'animating'} />
+          {successStatus === 'success' && (
+            <>
+              <p className="text-[13px] font-semibold text-foreground tracking-tight">{successMessage}</p>
+              <button
+                onClick={handleReset}
+                className="px-5 py-2 rounded-lg bg-primary text-white text-[12px] font-medium hover:bg-primary-hover transition-colors"
+              >
+                확인
+              </button>
+            </>
+          )}
+        </div>
+      ) : (
+        <ContentArea selectedMenuItem={selectedMenuItem} onSuccess={handleSuccess} />
+      )}
     </div>
   )
 }

--- a/src/components/market/StockRow.jsx
+++ b/src/components/market/StockRow.jsx
@@ -12,6 +12,7 @@ export default function StockRow({ stock, showVolume = true, isWatched, onWatchT
   const navigate = useNavigate()
   const isTop = stock.rank === 1
   const grid = showVolume ? GRID_WITH_VOL : GRID_WITHOUT_VOL
+  const secondaryMetric = stock.secondaryMetric ?? { value: '—' }
 
   return (
     <div
@@ -60,16 +61,19 @@ export default function StockRow({ stock, showVolume = true, isWatched, onWatchT
       {/* 거래대금 / 거래량 / 시가총액 */}
       {showVolume && (
         <div className="text-right text-[12px] font-medium text-foreground-secondary">
-          {stock.volume ?? '—'}
+          {stock.metricValue ?? '—'}
         </div>
       )}
 
-      {/* 거래 비율 */}
+      {/* 보조 지표 */}
       <div className="pl-2">
-        {stock.buyRatio != null
-          ? <RatioBar buyRatio={stock.buyRatio} sellRatio={stock.sellRatio} />
-          : <span className="text-[11px] text-foreground-disabled select-none">—</span>
-        }
+        {secondaryMetric.buyRatio != null
+          ? <RatioBar buyRatio={secondaryMetric.buyRatio} sellRatio={secondaryMetric.sellRatio} />
+          : (
+            <div className="text-right text-[12px] font-medium text-foreground-secondary">
+              {secondaryMetric.value ?? '—'}
+            </div>
+          )}
       </div>
     </div>
   )

--- a/src/features/invest/domestic/useMarketData.js
+++ b/src/features/invest/domestic/useMarketData.js
@@ -99,7 +99,7 @@ function formatLocalDateTime(timestamp) {
   return `${yyyy}-${mm}-${dd}T${hh}:${mi}:${ss}`
 }
 
-export default function useDomesticMarketData(stockCode, { enabled }) {
+export default function useDomesticMarketData(stockCode, { enabled, activeDetailTab = 'daily' }) {
   const [selectedChartPeriod, setSelectedChartPeriod] = useState(
     () => localStorage.getItem('invest.chartPeriod') ?? 'MINUTE',
   )
@@ -149,21 +149,21 @@ export default function useDomesticMarketData(stockCode, { enabled }) {
   const opinionQuery = useQuery({
     queryKey: ['domestic', 'opinion', stockCode],
     queryFn: () => marketApi.getOpinion(stockCode),
-    enabled,
+    enabled: enabled && activeDetailTab === 'opinion',
     staleTime: STALE.detail,
   })
 
   const investorQuery = useQuery({
     queryKey: ['domestic', 'investor', stockCode],
     queryFn: () => marketApi.getInvestor(stockCode),
-    enabled,
+    enabled: enabled && activeDetailTab === 'investor',
     staleTime: STALE.detail,
   })
 
   const financeQuery = useQuery({
     queryKey: ['domestic', 'finance', stockCode],
     queryFn: () => marketApi.getFinance(stockCode),
-    enabled,
+    enabled: enabled && activeDetailTab === 'finance',
     staleTime: STALE.finance,
   })
 
@@ -243,11 +243,13 @@ export default function useDomesticMarketData(stockCode, { enabled }) {
     })
   }, [liveTrade, selectedMinuteInterval])
 
-  const customSeries = customChartQuery.data
-    ? (selectedChartPeriod === 'MINUTE'
-        ? normalizeMinuteSeries(customChartQuery.data?.data)
-        : normalizeDailySeries(customChartQuery.data?.data))
-    : []
+  const customSeries = useMemo(() => (
+    customChartQuery.data
+      ? (selectedChartPeriod === 'MINUTE'
+          ? normalizeMinuteSeries(customChartQuery.data?.data)
+          : normalizeDailySeries(customChartQuery.data?.data))
+      : []
+  ), [customChartQuery.data, selectedChartPeriod])
 
   const minuteSeriesWithLive = useMemo(
     () => applyLiveCandle(minuteSeries, liveCandle),
@@ -291,6 +293,10 @@ export default function useDomesticMarketData(stockCode, { enabled }) {
   const marketState = {
     isLoading: priceQuery.isLoading || dailyChartQuery.isLoading || minuteChartQuery.isLoading || orderBookQuery.isLoading,
     errorMessage: (priceQuery.error || dailyChartQuery.error || minuteChartQuery.error || orderBookQuery.error)?.message ?? '',
+    dailyLoading: dailyChartQuery.isLoading,
+    dailyErrorMessage: dailyChartQuery.error?.message ?? '',
+    minuteLoading: minuteChartQuery.isLoading,
+    minuteErrorMessage: minuteChartQuery.error?.message ?? '',
     priceData: livePrice ?? priceQuery.data ?? null,
     dailySeries: dailySeriesWithLive,
     minuteSeries: minuteSeriesWithLive,
@@ -304,7 +310,13 @@ export default function useDomesticMarketData(stockCode, { enabled }) {
   }
 
   const detailState = {
-    isLoading: opinionQuery.isLoading || investorQuery.isLoading || financeQuery.isLoading,
+    isLoading: activeDetailTab === 'opinion'
+      ? opinionQuery.isLoading
+      : activeDetailTab === 'investor'
+        ? investorQuery.isLoading
+        : activeDetailTab === 'finance'
+          ? financeQuery.isLoading
+          : false,
     opinion: opinionQuery.data ?? null,
     investor: investorQuery.data ?? null,
     finance: financeQuery.data ?? null,
@@ -314,10 +326,16 @@ export default function useDomesticMarketData(stockCode, { enabled }) {
   const orderBook = normalizeOrderBook(liveOrderBook) ?? normalizeOrderBook(marketState.orderBook)
 
   const previousClose = dailySeriesWithLive.at(-2)?.close ?? null
-  const dailyRows = buildDailyRows(dailySeriesWithLive)
-  const realtimeRows = liveTrades.length > 0
-    ? buildTickRows(liveTrades)
-    : buildRealtimeRows(getLatestMinuteSession(minuteSeriesWithLive), previousClose)
+  const dailyRows = useMemo(
+    () => buildDailyRows(dailySeriesWithLive),
+    [dailySeriesWithLive],
+  )
+  const realtimeRows = useMemo(
+    () => (liveTrades.length > 0
+      ? buildTickRows(liveTrades)
+      : buildRealtimeRows(getLatestMinuteSession(minuteSeriesWithLive), previousClose)),
+    [liveTrades, minuteSeriesWithLive, previousClose],
+  )
 
   useEffect(() => {
     localStorage.setItem('invest.chartPeriod', selectedChartPeriod)
@@ -409,6 +427,8 @@ export default function useDomesticMarketData(stockCode, { enabled }) {
     orderBook,
     dailyRows,
     realtimeRows,
+    dailyLoading: dailyChartQuery.isLoading,
+    realtimeLoading: minuteChartQuery.isLoading,
     setSelectedChartPeriod,
     handleMinuteIntervalChange,
   }

--- a/src/features/invest/foreign/useMarketData.js
+++ b/src/features/invest/foreign/useMarketData.js
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { foreignMarketApi } from '@/api/market'
 import { DAY_MS, DEFAULT_MINUTE_INTERVAL } from '@/features/invest/constants'
 import { formatApiDate } from '@/features/invest/formatters'
@@ -27,8 +27,13 @@ export default function useForeignMarketData(stockCode, exchcd, { enabled }) {
     () => Number(localStorage.getItem('invest.minuteInterval')) || DEFAULT_MINUTE_INTERVAL,
   )
 
-  const endDate = formatApiDate(new Date())
-  const startDate = formatApiDate(new Date(Date.now() - 180 * DAY_MS))
+  const { endDate, startDate } = useMemo(() => {
+    const end = new Date()
+    return {
+      endDate: formatApiDate(end),
+      startDate: formatApiDate(new Date(end.getTime() - 180 * DAY_MS)),
+    }
+  }, [])
 
   const priceQuery = useQuery({
     queryKey: ['foreign', 'price', stockCode, exchcd],
@@ -70,9 +75,13 @@ export default function useForeignMarketData(stockCode, exchcd, { enabled }) {
         return foreignMarketApi.getMinuteChart(stockCode, exchcd, { nmin: selectedMinuteInterval })
       }
       const config = getChartPeriodConfig(selectedChartPeriod)
-      const end = formatApiDate(new Date())
-      const start = formatApiDate(new Date(Date.now() - config.lookbackDays * DAY_MS))
-      return foreignMarketApi.getChart(stockCode, exchcd, { period: config.foreignApiPeriod, startDate: start, endDate: end })
+      const end = new Date()
+      const start = new Date(end.getTime() - config.lookbackDays * DAY_MS)
+      return foreignMarketApi.getChart(stockCode, exchcd, {
+        period: config.foreignApiPeriod,
+        startDate: formatApiDate(start),
+        endDate: formatApiDate(end),
+      })
     },
     enabled: needsCustomChart,
     staleTime: selectedChartPeriod === 'MINUTE' ? STALE.minuteChart : STALE.dailyChart,
@@ -88,17 +97,23 @@ export default function useForeignMarketData(stockCode, exchcd, { enabled }) {
   const marketState = {
     isLoading: priceQuery.isLoading || dailyChartQuery.isLoading || minuteChartQuery.isLoading || orderBookQuery.isLoading,
     errorMessage: (priceQuery.error || dailyChartQuery.error || minuteChartQuery.error || orderBookQuery.error)?.message ?? '',
+    dailyLoading: dailyChartQuery.isLoading,
+    dailyErrorMessage: dailyChartQuery.error?.message ?? '',
+    minuteLoading: minuteChartQuery.isLoading,
+    minuteErrorMessage: minuteChartQuery.error?.message ?? '',
     priceData,
     dailySeries,
     minuteSeries,
     orderBook: orderBookQuery.data ?? null,
   }
 
-  const customSeries = customChartQuery.data
-    ? (selectedChartPeriod === 'MINUTE'
-        ? normalizeForeignMinuteSeries(customChartQuery.data?.dataPoints)
-        : normalizeForeignDailySeries(customChartQuery.data?.dataPoints))
-    : []
+  const customSeries = useMemo(() => (
+    customChartQuery.data
+      ? (selectedChartPeriod === 'MINUTE'
+          ? normalizeForeignMinuteSeries(customChartQuery.data?.dataPoints)
+          : normalizeForeignDailySeries(customChartQuery.data?.dataPoints))
+      : []
+  ), [customChartQuery.data, selectedChartPeriod])
 
   const chartState = {
     isLoading: customChartQuery.isLoading,
@@ -110,8 +125,14 @@ export default function useForeignMarketData(stockCode, exchcd, { enabled }) {
   const orderBook = normalizeForeignOrderBook(liveOrderBook) ?? normalizeForeignOrderBook(marketState.orderBook)
 
   const previousClose = dailySeries.at(-2)?.close ?? null
-  const dailyRows = buildDailyRows(dailySeries)
-  const realtimeRows = buildRealtimeRows(getLatestMinuteSession(minuteSeries), previousClose)
+  const dailyRows = useMemo(
+    () => buildDailyRows(dailySeries),
+    [dailySeries],
+  )
+  const realtimeRows = useMemo(
+    () => buildRealtimeRows(getLatestMinuteSession(minuteSeries), previousClose),
+    [minuteSeries, previousClose],
+  )
 
   useEffect(() => {
     localStorage.setItem('invest.chartPeriod', selectedChartPeriod)
@@ -140,6 +161,8 @@ export default function useForeignMarketData(stockCode, exchcd, { enabled }) {
     orderBook,
     dailyRows,
     realtimeRows,
+    dailyLoading: dailyChartQuery.isLoading,
+    realtimeLoading: minuteChartQuery.isLoading,
     setSelectedChartPeriod,
     handleMinuteIntervalChange,
   }

--- a/src/features/invest/useInvestMarketData.js
+++ b/src/features/invest/useInvestMarketData.js
@@ -1,4 +1,6 @@
-import { getExchcd } from '@/api/market'
+import { useQuery } from '@tanstack/react-query'
+import { useMemo } from 'react'
+import { foreignMarketApi, getExchcd, marketApi } from '@/api/market'
 import { DEFAULT_MINUTE_INTERVAL } from '@/features/invest/constants'
 import {
   getRecentMinuteSessions,
@@ -7,13 +9,42 @@ import {
 import useDomesticMarketData from '@/features/invest/domestic/useMarketData'
 import useForeignMarketData from '@/features/invest/foreign/useMarketData'
 
-export default function useInvestMarketData(stockCode, locationState) {
-  const stockMeta = resolveStockMeta(stockCode, locationState)
-  const { isDomestic } = stockMeta
-  const exchcd = isDomestic ? null : getExchcd(stockMeta.exchangeCode)
+export default function useInvestMarketData(stockCode, locationState, { activeLeftTab = 'daily' } = {}) {
+  const baseStockMeta = resolveStockMeta(stockCode, locationState)
+  const { isDomestic } = baseStockMeta
+  const exchcd = isDomestic ? null : getExchcd(baseStockMeta.exchangeCode)
 
-  const domestic = useDomesticMarketData(stockCode, { enabled: isDomestic })
-  const foreign = useForeignMarketData(stockCode, exchcd, { enabled: !isDomestic })
+  const infoQuery = useQuery({
+    queryKey: isDomestic
+      ? ['domestic', 'info', stockCode]
+      : ['foreign', 'info', stockCode, exchcd],
+    queryFn: () => (isDomestic
+      ? marketApi.getStockInfo(stockCode)
+      : foreignMarketApi.getInfo(stockCode, exchcd)),
+    enabled: isDomestic || Boolean(exchcd),
+    staleTime: 1000 * 60 * 60 * 24,
+  })
+
+  const stockMeta = useMemo(() => {
+    if (isDomestic) {
+      return {
+        ...baseStockMeta,
+        market: infoQuery.data?.marketName ?? baseStockMeta.market,
+        sector: infoQuery.data?.sector ?? baseStockMeta.sector,
+      }
+    }
+
+    return {
+      ...baseStockMeta,
+      name: infoQuery.data?.korname ?? baseStockMeta.name,
+      nameEn: infoQuery.data?.engname ?? baseStockMeta.nameEn,
+      market: infoQuery.data?.exchangeName ?? baseStockMeta.market,
+      sector: infoQuery.data?.induname ?? baseStockMeta.sector,
+    }
+  }, [baseStockMeta, infoQuery.data, isDomestic])
+
+  const domestic = useDomesticMarketData(stockCode, { enabled: isDomestic, activeDetailTab: activeLeftTab })
+  const foreign = useForeignMarketData(stockCode, exchcd, { enabled: !isDomestic, activeDetailTab: activeLeftTab })
 
   const active = isDomestic ? domestic : foreign
   const { marketState, chartState, detailState, selectedChartPeriod, selectedMinuteInterval } = active
@@ -37,20 +68,40 @@ export default function useInvestMarketData(stockCode, locationState) {
     && selectedMinuteInterval === DEFAULT_MINUTE_INTERVAL)
     || selectedChartPeriod === 'DAILY'
 
-  const minuteChartSeries = getRecentMinuteSessions(
+  const minuteChartSeries = useMemo(() => getRecentMinuteSessions(
     selectedMinuteInterval === DEFAULT_MINUTE_INTERVAL
       ? marketState.minuteSeries
       : chartState.series,
-  )
-  const chartSeries = selectedChartPeriod === 'MINUTE'
-    ? minuteChartSeries
-    : selectedChartPeriod === 'DAILY'
-      ? marketState.dailySeries
-      : chartState.series
-  const resolvedChartSeries = active.chartSeries ?? chartSeries
+  ), [
+    chartState.series,
+    marketState.minuteSeries,
+    selectedMinuteInterval,
+  ])
 
-  const chartLoading = usesBaseChartData ? marketState.isLoading : chartState.isLoading
-  const chartErrorMessage = usesBaseChartData ? marketState.errorMessage : chartState.errorMessage
+  const fallbackChartSeries = useMemo(() => (
+    selectedChartPeriod === 'MINUTE'
+      ? minuteChartSeries
+      : selectedChartPeriod === 'DAILY'
+        ? marketState.dailySeries
+        : chartState.series
+  ), [
+    chartState.series,
+    marketState.dailySeries,
+    minuteChartSeries,
+    selectedChartPeriod,
+  ])
+  const resolvedChartSeries = active.chartSeries ?? fallbackChartSeries
+
+  const chartLoading = usesBaseChartData
+    ? selectedChartPeriod === 'DAILY'
+      ? marketState.dailyLoading
+      : marketState.minuteLoading
+    : chartState.isLoading
+  const chartErrorMessage = usesBaseChartData
+    ? selectedChartPeriod === 'DAILY'
+      ? marketState.dailyErrorMessage
+      : marketState.minuteErrorMessage
+    : chartState.errorMessage
 
   return {
     stockMeta,
@@ -75,6 +126,8 @@ export default function useInvestMarketData(stockCode, locationState) {
     investor: detailState.investor,
     finance: detailState.finance,
     detailLoading: detailState.isLoading,
+    dailyLoading: active.dailyLoading ?? marketState.dailyLoading ?? false,
+    realtimeLoading: active.realtimeLoading ?? marketState.minuteLoading ?? false,
     defaultSelectedPrice: currentPrice ?? stockMeta.price,
     availableAmount: stockMeta.availableAmount,
     onChartPeriodChange: active.setSelectedChartPeriod,

--- a/src/features/market/useMarketIndices.js
+++ b/src/features/market/useMarketIndices.js
@@ -1,7 +1,9 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { marketApi } from '@/api/market'
 import { subscribeTopic } from '@/lib/stomp'
+
+const DEBUG_MARKET_INDICES = import.meta.env.DEV
 
 // 백엔드 code → WebSocket topic 매핑
 const INDEX_TOPICS = {
@@ -10,6 +12,21 @@ const INDEX_TOPICS = {
   'SPI@SPX':  '/topic/index/foreign/SPI@SPX',
   'NAS@IXIC': '/topic/index/foreign/NAS@IXIC',
   USD:        '/topic/currency/USD',
+}
+
+function summarizeIndex(item) {
+  return {
+    code: item.code,
+    sign: item.sign,
+    price: item.price,
+    change: item.change,
+    changeRate: item.changeRate,
+  }
+}
+
+function logMarketIndices(event, payload) {
+  if (!DEBUG_MARKET_INDICES) return
+  console.debug(`[market:indices] ${event}`, payload)
 }
 
 function toNumberOrFallback(value, fallback) {
@@ -30,37 +47,68 @@ export default function useMarketIndices() {
 
   const { data: indices = [], isLoading } = useQuery({
     queryKey: ['market', 'indices'],
-    queryFn: marketApi.getIndices,
+    queryFn: async () => {
+      const response = await marketApi.getIndices()
+      logMarketIndices('REST response', response.map(summarizeIndex))
+      return response
+    },
     staleTime: 5 * 1000,
     refetchInterval: 10_000,
   })
 
-  useEffect(() => {
-    if (!indices.length) return
+  const subscriptionSignature = indices
+    .map((idx) => idx.code)
+    .filter((code) => INDEX_TOPICS[code])
+    .join('|')
 
-    const subscriptions = indices
-      .filter((idx) => INDEX_TOPICS[idx.code])
-      .map((idx) =>
-        subscribeTopic(INDEX_TOPICS[idx.code], (msg) => {
+  const subscriptionTargets = useMemo(() => (
+    subscriptionSignature
+      ? subscriptionSignature.split('|').map((code) => ({
+          code,
+          topic: INDEX_TOPICS[code],
+        }))
+      : []
+  ), [subscriptionSignature])
+
+  useEffect(() => {
+    if (!subscriptionTargets.length) return
+
+    logMarketIndices('WS subscribe', subscriptionTargets)
+
+    const subscriptions = subscriptionTargets
+      .map((target) =>
+        subscribeTopic(target.topic, (msg) => {
           const body = JSON.parse(msg.body)
           queryClient.setQueryData(['market', 'indices'], (prev) =>
             prev?.map((item) =>
-              item.code === idx.code
-                ? {
+              item.code === target.code
+                ? (() => {
+                    const nextItem = {
                     ...item,
                     sign: body.sign ?? item.sign,
                     price: toNumberOrFallback(body.jisu ?? body.price ?? body.pricejisu, item.price),
                     change: normalizeSignedValue(body.sign ?? item.sign, body.change, item.change),
                     changeRate: normalizeSignedValue(body.sign ?? item.sign, body.drate ?? body.uprate, item.changeRate),
-                  }
+                    }
+                    logMarketIndices('WS message', {
+                      code: target.code,
+                      topic: target.topic,
+                      raw: body,
+                      next: summarizeIndex(nextItem),
+                    })
+                    return nextItem
+                  })()
                 : item,
             ),
           )
         }),
       )
 
-    return () => subscriptions.forEach((s) => s?.unsubscribe())
-  }, [indices.length, queryClient])
+    return () => {
+      logMarketIndices('WS unsubscribe', subscriptionTargets)
+      subscriptions.forEach((s) => s?.unsubscribe())
+    }
+  }, [queryClient, subscriptionTargets])
 
   return { indices, isLoading }
 }

--- a/src/features/market/useMarketRanking.js
+++ b/src/features/market/useMarketRanking.js
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { marketApi } from '@/api/market'
 import { subscribeTopic } from '@/lib/stomp'
 
@@ -30,6 +30,12 @@ function formatVolume(shares) {
   return `${n.toLocaleString('ko-KR')}주`
 }
 
+function formatPercent(value) {
+  const n = Number(value)
+  if (!Number.isFinite(n)) return null
+  return `${n > 0 ? '+' : ''}${n.toFixed(2)}%`
+}
+
 // 프론트 sortFilter key → 백엔드 type 파라미터
 const TYPE_MAP = {
   volume_value: 'trading-value',
@@ -43,34 +49,59 @@ function normalizeItem(item, sortFilter) {
   const buyRatio = item.buyRatio != null ? item.buyRatio : null
   const sellRatio = buyRatio != null ? 100 - buyRatio : null
 
-  let volume = null
-  if (sortFilter === 'volume') {
-    volume = formatVolume(item.volume)
-  } else if (sortFilter === 'volume_value') {
-    volume = formatMoney(item.tradingValue)
-  } else if (sortFilter === 'market_cap') {
-    // marketCap은 억원 단위로 내려옴
-    volume = item.marketCap != null ? formatMoney(item.marketCap * 100_000_000) : null
-  }
+  const metricValue = sortFilter === 'volume'
+    ? formatVolume(item.volume)
+    : sortFilter === 'volume_value'
+      ? formatMoney(item.tradingValue)
+      : sortFilter === 'market_cap'
+        ? item.marketCap != null ? formatMoney(item.marketCap * 100_000_000) : null
+        : null
+
+  const secondaryMetric = sortFilter === 'volume_value'
+    ? {
+        label: '전일 거래대금',
+        value: item.prevTradingValue != null ? formatMoney(item.prevTradingValue) : '—',
+      }
+    : sortFilter === 'volume'
+      ? {
+          label: '전일 거래량',
+          value: item.prevVolume != null ? formatVolume(item.prevVolume) : '—',
+        }
+      : sortFilter === 'market_cap'
+        ? {
+            label: '시장점유율',
+            value: item.marketShareRate != null ? formatPercent(item.marketShareRate) : '—',
+          }
+        : {
+            label: '거래 비율',
+            value: buyRatio != null ? null : '—',
+            buyRatio,
+            sellRatio,
+          }
 
   return {
     id: item.stockCode,
     rank: item.rank,
     name: item.name,
+    stockNameEn: item.stockNameEn ?? null,
     label: item.name.slice(0, 2),
     color: pickColor(item.stockCode),
     price: `${Number(item.price).toLocaleString('ko-KR')}원`,
     change: item.changeRate,
-    volume,
+    metricValue,
+    secondaryMetric,
     consecutiveDays: item.consecutiveDays ?? null,
     buyRatio,
     sellRatio,
     stockCode: item.stockCode,
+    market: item.market ?? item.marketType ?? null,
+    exchangeCode: item.exchangeCode ?? null,
   }
 }
 
 export default function useMarketRanking(sortFilter, marketFilter) {
   const [livePrices, setLivePrices] = useState({})
+  const subscriptionsRef = useRef(new Map())
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['market', 'ranking', sortFilter, marketFilter],
@@ -79,17 +110,19 @@ export default function useMarketRanking(sortFilter, marketFilter) {
     staleTime: 0,
   })
 
-  const stockCodes = useMemo(
-    () => (data ?? []).map((item) => item.stockCode).filter(Boolean).join(','),
-    [data],
-  )
-
   useEffect(() => {
-    if (!stockCodes) return
+    const nextCodes = new Set((data ?? []).map((item) => item.stockCode).filter(Boolean))
+    const subscriptions = subscriptionsRef.current
 
-    const codes = stockCodes.split(',')
-    const subscriptions = codes.map((code) =>
-      subscribeTopic(`/topic/stock/trade/${code}`, (msg) => {
+    subscriptions.forEach((subscription, code) => {
+      if (nextCodes.has(code)) return
+      subscription.unsubscribe()
+      subscriptions.delete(code)
+    })
+
+    nextCodes.forEach((code) => {
+      if (subscriptions.has(code)) return
+      const subscription = subscribeTopic(`/topic/stock/trade/${code}`, (msg) => {
         const body = JSON.parse(msg.body)
         setLivePrices((prev) => ({
           ...prev,
@@ -98,11 +131,18 @@ export default function useMarketRanking(sortFilter, marketFilter) {
             change: Number(body.drate),
           },
         }))
-      }),
-    )
+      })
+      subscriptions.set(code, subscription)
+    })
+  }, [data])
 
-    return () => subscriptions.forEach((s) => s.unsubscribe())
-  }, [stockCodes])
+  useEffect(() => {
+    const subscriptions = subscriptionsRef.current
+    return () => {
+      subscriptions.forEach((subscription) => subscription.unsubscribe())
+      subscriptions.clear()
+    }
+  }, [])
 
   const stocks = useMemo(
     () =>

--- a/src/lib/stomp.js
+++ b/src/lib/stomp.js
@@ -2,27 +2,26 @@ import { Client } from '@stomp/stompjs'
 import useAuthStore from '@/store/useAuthStore'
 
 let client = null
-const pendingSubscriptions = []
+let subscriptionSeq = 0
+const activeSubscriptions = new Map()
+
+function subscribeEntry(stompClient, entry) {
+  if (!stompClient?.connected) return
+  entry.liveSubscription = stompClient.subscribe(entry.topic, entry.callback)
+}
 
 export function getStompClient() {
   if (client) return client
 
-  const token = useAuthStore.getState().accessToken
-
-  if (!token) {
-    console.warn('[STOMP] 토큰 없음 — 연결 생략')
-    return null
-  }
-
   client = new Client({
     brokerURL: `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.host}/ws`,
-    connectHeaders: { Authorization: `Bearer ${token}` },
+    connectHeaders: {},
     beforeConnect: () => {
       const freshToken = useAuthStore.getState().accessToken
       if (freshToken) {
         client.connectHeaders = { Authorization: `Bearer ${freshToken}` }
       } else {
-        client.deactivate()
+        client.connectHeaders = {}
       }
     },
     reconnectDelay: 3000,
@@ -33,8 +32,9 @@ export function getStompClient() {
     },
     onConnect: () => {
       console.log('[STOMP] 연결 성공')
-      pendingSubscriptions.forEach((fn) => fn())
-      pendingSubscriptions.length = 0
+      activeSubscriptions.forEach((entry) => {
+        subscribeEntry(client, entry)
+      })
     },
     onStompError: (frame) => {
       console.error('[STOMP] 에러:', frame.headers.message)
@@ -42,8 +42,16 @@ export function getStompClient() {
     onWebSocketError: (event) => {
       console.error('[STOMP] WebSocket 에러:', event)
     },
+    onWebSocketClose: () => {
+      activeSubscriptions.forEach((entry) => {
+        entry.liveSubscription = null
+      })
+    },
     onDisconnect: () => {
       console.log('[STOMP] 연결 종료')
+      activeSubscriptions.forEach((entry) => {
+        entry.liveSubscription = null
+      })
     },
   })
 
@@ -53,36 +61,28 @@ export function getStompClient() {
 
 export function subscribeTopic(topic, callback) {
   const stompClient = getStompClient()
+  const id = ++subscriptionSeq
+  const entry = { topic, callback, liveSubscription: null }
+  activeSubscriptions.set(id, entry)
 
-  if (!stompClient) return { unsubscribe: () => {} }
-
-  if (stompClient.connected) {
-    return stompClient.subscribe(topic, callback)
+  if (stompClient?.connected) {
+    subscribeEntry(stompClient, entry)
   }
-
-  let subscription = null
-  let cancelled = false
-
-  const pending = () => {
-    if (!cancelled) {
-      subscription = stompClient.subscribe(topic, callback)
-    }
-  }
-
-  pendingSubscriptions.push(pending)
 
   return {
     unsubscribe: () => {
-      cancelled = true
-      subscription?.unsubscribe()
-      const idx = pendingSubscriptions.indexOf(pending)
-      if (idx !== -1) pendingSubscriptions.splice(idx, 1)
+      const current = activeSubscriptions.get(id)
+      current?.liveSubscription?.unsubscribe()
+      activeSubscriptions.delete(id)
     },
   }
 }
 
 export function deactivateStompClient() {
   if (client) {
+    activeSubscriptions.forEach((entry) => {
+      entry.liveSubscription = null
+    })
     client.deactivate()
     client = null
   }

--- a/src/lib/validationSchemas.js
+++ b/src/lib/validationSchemas.js
@@ -50,3 +50,21 @@ export const closeAccountSchema = z.object({
     message: '약관에 동의해주세요.',
   }),
 })
+
+// Update profile form schema
+export const updateProfileSchema = z.object({
+  name: z.string().min(1, '이름을 입력해주세요.').max(50, '이름은 50자 이하여야 합니다.'),
+  phone: z.string().regex(/^$|^\d{2,3}-\d{3,4}-\d{4}$/, '올바른 연락처 형식을 입력하세요 (예: 010-1234-5678)'),
+})
+
+// PIN reset confirm schema
+export const pinResetSchema = z.object({
+  newPin: pinSchema,
+  confirmPin: z.string().length(4, 'PIN은 4자리 숫자여야 합니다.'),
+}).refine(
+  (data) => data.newPin === data.confirmPin,
+  {
+    message: '새 PIN이 일치하지 않습니다.',
+    path: ['confirmPin'],
+  }
+)

--- a/src/pages/InvestPage.jsx
+++ b/src/pages/InvestPage.jsx
@@ -10,6 +10,9 @@ export default function InvestPage() {
   const { stockCode: routeStockCode } = useParams()
   const { state: locationState } = useLocation()
   const stockCode = routeStockCode ?? INVEST_STOCK.code
+  const [leftTab, setLeftTab] = useState('daily')
+  const [rightTab, setRightTab] = useState('exec')
+
   const {
     stockMeta,
     currentPrice,
@@ -32,13 +35,12 @@ export default function InvestPage() {
     investor,
     finance,
     detailLoading,
+    dailyLoading,
+    realtimeLoading,
     onChartPeriodChange,
     onLoadMoreChartHistory,
     onMinuteIntervalChange,
-  } = useInvestMarketData(stockCode, locationState)
-
-  const [leftTab, setLeftTab] = useState('daily')
-  const [rightTab, setRightTab] = useState('exec')
+  } = useInvestMarketData(stockCode, locationState, { activeLeftTab: leftTab })
 
   return (
     <div className="h-full overflow-x-auto bg-surface">
@@ -85,12 +87,11 @@ export default function InvestPage() {
           investor={investor}
           finance={finance}
           detailLoading={detailLoading}
-          isLoading={marketLoading}
+          dailyLoading={dailyLoading}
+          realtimeLoading={realtimeLoading}
           errorMessage={marketErrorMessage}
           onLeftTabChange={setLeftTab}
           onRightTabChange={setRightTab}
-          stockCode={stockCode}
-          currentPrice={currentPrice}
         />
       </div>
     </div>

--- a/src/pages/MarketPage.jsx
+++ b/src/pages/MarketPage.jsx
@@ -13,13 +13,20 @@ const VOLUME_COL_LABEL = {
   market_cap:   '시가총액 순',
 }
 
+const SECONDARY_COL_LABEL = {
+  volume_value: '전일 거래대금',
+  volume: '전일 거래량',
+  rising: '거래 비율',
+  falling: '거래 비율',
+  market_cap: '시장점유율',
+}
+
 function MarketIndexBar() {
   const { indices } = useMarketIndices()
 
   return (
     <div className="flex items-center border-b border-stroke shrink-0 overflow-x-auto bg-surface">
       {indices.map((idx) => {
-        const isUp = idx.changeRate > 0
         return (
           <div
             key={idx.code}
@@ -70,7 +77,6 @@ const GRID_WITHOUT_VOL = 'grid-cols-[32px_36px_1fr_110px_80px_120px]'
 
 function StockTableHeader({ sortFilter }) {
   const showVolume = sortFilter in VOLUME_COL_LABEL
-  const isRankByChange = sortFilter === 'rising' || sortFilter === 'falling'
   const grid = showVolume ? GRID_WITH_VOL : GRID_WITHOUT_VOL
 
   return (
@@ -79,9 +85,9 @@ function StockTableHeader({ sortFilter }) {
       <div>순위</div>
       <div>종목명</div>
       <div className="text-right">현재가</div>
-      <div className="text-right">{isRankByChange ? '등락률 순' : '등락률'}</div>
+      <div className="text-right">등락률</div>
       {showVolume && <div className="text-right">{VOLUME_COL_LABEL[sortFilter]}</div>}
-      <div className="text-right">거래 비율</div>
+      <div className="text-right">{SECONDARY_COL_LABEL[sortFilter]}</div>
     </div>
   )
 }

--- a/src/pages/auth/PinResetPage.jsx
+++ b/src/pages/auth/PinResetPage.jsx
@@ -1,0 +1,218 @@
+import { useState } from 'react'
+import { useSearchParams, useNavigate } from 'react-router-dom'
+import { X, XCircle } from 'lucide-react'
+import { accountApi } from '@/api/account'
+import { pinResetSchema } from '@/lib/validationSchemas'
+import AccountPinKeypad from '@/components/signup/AccountPinKeypad'
+import SolLiteBrand from '@/components/ui/SolLiteBrand'
+import SplashScreenFill from '@/components/ui/SplashScreenFill'
+
+function PinDots({ value, active }) {
+  return (
+    <div className="flex justify-center gap-2.5">
+      {Array.from({ length: 4 }, (_, index) => {
+        const filled = index < value.length
+        return (
+          <div
+            key={index}
+            className={[
+              'flex h-11 w-11 items-center justify-center rounded-2xl border transition-colors',
+              active ? 'border-primary bg-primary-light' : 'border-stroke-input bg-surface-subtle',
+            ].join(' ')}
+          >
+            <div
+              className={[
+                'h-2.5 w-2.5 rounded-full transition-colors',
+                filled ? 'bg-primary' : active ? 'bg-primary/20' : 'bg-stroke-input',
+              ].join(' ')}
+            />
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export default function PinResetPage() {
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const token = searchParams.get('token')
+
+  const [newPin, setNewPin] = useState('')
+  const [confirmPin, setConfirmPin] = useState('')
+  const [activePinField, setActivePinField] = useState(null)
+  const [isKeyboardOpen, setIsKeyboardOpen] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [status, setStatus] = useState('form') // 'form' | 'animating' | 'success' | 'error'
+  const [error, setError] = useState('')
+
+  function handlePinChange(nextValue) {
+    const sanitized = nextValue.replace(/\D/g, '').slice(0, 4)
+    if (activePinField === 'newPin') setNewPin(sanitized)
+    else if (activePinField === 'confirmPin') setConfirmPin(sanitized)
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    setError('')
+
+    const validation = pinResetSchema.safeParse({ newPin, confirmPin })
+    if (!validation.success) {
+      setError(validation.error.issues[0]?.message ?? '입력 값을 확인해주세요.')
+      return
+    }
+
+    setIsLoading(true)
+    try {
+      await accountApi.confirmPinReset(token, newPin)
+      setStatus('animating')
+      setTimeout(() => setStatus('success'), 1600)
+    } catch (err) {
+      if (err?.code === 'TOKEN_EXPIRED' || err?.code === 'INVALID_TOKEN' || err?.code === 'TOKEN_ALREADY_USED') {
+        setStatus('error')
+      } else {
+        setError(err?.message ?? '계좌 비밀번호 재설정에 실패했습니다. 다시 시도해 주세요.')
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-5">
+      <div className="fixed inset-0 bg-black/40" onClick={() => navigate('/')} />
+
+      <div className="relative z-10 w-full max-w-[400px] bg-surface rounded-[6px] shadow-modal overflow-hidden animate-modal-in">
+        {/* 헤더 */}
+        <div className="flex items-center justify-between px-6 pt-[22px]">
+          <SolLiteBrand />
+          <button
+            onClick={() => navigate('/')}
+            aria-label="닫기"
+            className="text-foreground-disabled hover:text-foreground-tertiary p-1 transition-colors"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* 토큰 없음 */}
+        {!token && (
+          <div className="px-6 py-8 text-center">
+            <XCircle className="w-12 h-12 text-up mx-auto mb-4" />
+            <h2 className="text-xl font-extrabold text-foreground tracking-tight mb-2">유효하지 않은 링크</h2>
+            <p className="text-[13px] text-foreground-disabled leading-[1.8] mb-6">
+              계좌 비밀번호 재설정 링크가 올바르지 않습니다.
+            </p>
+            <button
+              onClick={() => navigate('/')}
+              className="w-full py-[13px] bg-surface-muted border border-stroke text-foreground-secondary rounded-[4px] text-sm font-semibold hover:bg-stroke-subtle transition-colors"
+            >
+              홈으로 돌아가기
+            </button>
+          </div>
+        )}
+
+        {token && status === 'form' && (
+          <form onSubmit={handleSubmit} className="px-6 pt-5 pb-[26px] flex flex-col gap-4">
+            <div>
+              <h2 className="text-xl font-extrabold text-foreground tracking-tight">계좌 비밀번호 재설정</h2>
+              <p className="text-[13px] text-foreground-disabled mt-1">새로 사용할 4자리 비밀번호를 입력해 주세요.</p>
+            </div>
+
+            <div className="flex flex-col gap-4 mt-1">
+              <div>
+                <label className="text-[11px] font-semibold text-foreground-secondary block mb-2">새 비밀번호 (4자리)</label>
+                <button
+                  type="button"
+                  onClick={() => { setActivePinField('newPin'); setIsKeyboardOpen(true) }}
+                  className="flex w-full justify-center bg-transparent py-1 focus:outline-none"
+                >
+                  <PinDots value={newPin} active={activePinField === 'newPin' && isKeyboardOpen} />
+                </button>
+                {activePinField === 'newPin' && (
+                  <AccountPinKeypad
+                    variant="desktop"
+                    isOpen={isKeyboardOpen}
+                    value={newPin}
+                    onChange={handlePinChange}
+                    onDone={() => setIsKeyboardOpen(false)}
+                    onClose={() => setIsKeyboardOpen(false)}
+                  />
+                )}
+              </div>
+
+              <div>
+                <label className="text-[11px] font-semibold text-foreground-secondary block mb-2">비밀번호 확인 (4자리)</label>
+                <button
+                  type="button"
+                  onClick={() => { setActivePinField('confirmPin'); setIsKeyboardOpen(true) }}
+                  className="flex w-full justify-center bg-transparent py-1 focus:outline-none"
+                >
+                  <PinDots value={confirmPin} active={activePinField === 'confirmPin' && isKeyboardOpen} />
+                </button>
+                {activePinField === 'confirmPin' && (
+                  <AccountPinKeypad
+                    variant="desktop"
+                    isOpen={isKeyboardOpen}
+                    value={confirmPin}
+                    onChange={handlePinChange}
+                    onDone={() => setIsKeyboardOpen(false)}
+                    onClose={() => setIsKeyboardOpen(false)}
+                  />
+                )}
+              </div>
+            </div>
+
+            {error && <p className="text-[11px] text-up">{error}</p>}
+
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="w-full py-[13px] bg-primary text-white rounded-[4px] text-sm font-bold hover:bg-primary-hover transition-colors duration-[150ms] disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              {isLoading ? '처리 중...' : '비밀번호 변경'}
+            </button>
+          </form>
+        )}
+
+        {token && (status === 'animating' || status === 'success') && (
+          <div className="px-6 py-8 text-center min-h-[280px] flex flex-col items-center justify-center">
+            <div className="mb-6">
+              <SplashScreenFill inline animated={status === 'animating'} />
+            </div>
+            {status === 'success' && (
+              <>
+                <h2 className="text-xl font-extrabold text-foreground tracking-tight mb-2">변경 완료</h2>
+                <p className="text-[13px] text-foreground-disabled leading-[1.8] mb-6">
+                  계좌 비밀번호가 변경되었습니다.
+                </p>
+                <button
+                  onClick={() => navigate('/')}
+                  className="w-full py-[13px] bg-primary text-white rounded-[4px] text-sm font-bold hover:bg-primary-hover transition-colors duration-[150ms]"
+                >
+                  홈으로 가기
+                </button>
+              </>
+            )}
+          </div>
+        )}
+
+        {token && status === 'error' && (
+          <div className="px-6 py-8 text-center">
+            <XCircle className="w-12 h-12 text-up mx-auto mb-4" />
+            <h2 className="text-xl font-extrabold text-foreground tracking-tight mb-2">링크 만료</h2>
+            <p className="text-[13px] text-foreground-disabled leading-[1.8] mb-6">
+              재설정 링크가 만료되었습니다.<br />계정 설정에서 다시 요청해 주세요.
+            </p>
+            <button
+              onClick={() => navigate('/')}
+              className="w-full py-[13px] bg-surface-muted border border-stroke text-foreground-secondary rounded-[4px] text-sm font-semibold hover:bg-stroke-subtle transition-colors"
+            >
+              홈으로 돌아가기
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/auth/PinResetPage.jsx
+++ b/src/pages/auth/PinResetPage.jsx
@@ -124,6 +124,7 @@ export default function PinResetPage() {
                 <label className="text-[11px] font-semibold text-foreground-secondary block mb-2">새 비밀번호 (4자리)</label>
                 <button
                   type="button"
+                  aria-label="새 비밀번호 입력"
                   onClick={() => { setActivePinField('newPin'); setIsKeyboardOpen(true) }}
                   className="flex w-full justify-center bg-transparent py-1 focus:outline-none"
                 >
@@ -145,6 +146,7 @@ export default function PinResetPage() {
                 <label className="text-[11px] font-semibold text-foreground-secondary block mb-2">비밀번호 확인 (4자리)</label>
                 <button
                   type="button"
+                  aria-label="비밀번호 확인 입력"
                   onClick={() => { setActivePinField('confirmPin'); setIsKeyboardOpen(true) }}
                   className="flex w-full justify-center bg-transparent py-1 focus:outline-none"
                 >

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -7,6 +7,7 @@ import AssetPage from '@/pages/AssetPage'
 import SignupPage from '@/pages/auth/SignupPage'
 import EmailVerifyPage from '@/pages/auth/EmailVerifyPage'
 import PasswordResetPage from '@/pages/auth/PasswordResetPage'
+import PinResetPage from '@/pages/auth/PinResetPage'
 
 export const router = createBrowserRouter([
   {
@@ -19,6 +20,7 @@ export const router = createBrowserRouter([
       { path: 'invest/:stockCode', element: <InvestPage /> },
       { path: 'asset',      element: <AssetPage /> },
       { path: 'password/reset', element: <PasswordResetPage /> },
+      { path: 'account/pin/reset', element: <PinResetPage /> },
     ],
   },
   { path: '/signup',            element: <SignupPage /> },


### PR DESCRIPTION
## 연관된 이슈

> -

## 작업 내용

### feat(settings): 프로필 수정 및 PIN 재설정 기능 추가
- `PATCH /api/users/me` 프로필 업데이트(이름, 연락처) 연결
- `POST /api/accounts/pin/reset/request` / `confirm` PIN 재설정 플로우 연결
- `AccountSettingsPanel` 탭 구조 개편: 프로필 | 계정 비밀번호 | 계좌 비밀번호 | 리셋 | 계좌 해지
- 탭 스타일 UnderlineTab으로 통일 (danger 탭은 red underline)
- 성공 UI를 SplashScreenFill 애니메이션 패턴으로 교체
- `PinResetPage` 신규 추가 — 이메일 링크(`/account/pin/reset?token=`) 진입 후 PIN 재설정
- Zod v4 대응: `.errors` → `.issues` 전체 교체

### feat(market): MarketPage UI 개선 및 실시간 구독 최적화
- 인덱스 바 폰트 크기 조정, 지수명 색상 `text-foreground-secondary` 적용
- 필터 바 UnderlineTab(국내/미국) + FilterChip(정렬) 구조로 개편
- 테이블 헤더 회색 배경 제거, 행 높이·글자 크기 통일
- 스크롤 영역 `px-4` 패딩 추가, 구분선 inset 처리
- `useMarketRanking`: `subscriptionsRef` 기반 구독 관리 전환 (필터 변경 시 diff unsubscribe)
- `volume` → `metricValue` / `secondaryMetric` 분리로 보조 지표 구조화

### perf(invest): 탭별 조건부 쿼리 및 메모이제이션 최적화
- 상세 탭(opinion/investor/finance) 활성 시에만 API 호출
- `dailyRows`, `realtimeRows`, `customSeries` `useMemo` 적용
- `dailyLoading` / `realtimeLoading` 분리로 로딩 상태 세분화
- 미인증 상태에서 buyable/holdings API 호출 차단

### 스크린샷 (선택)

## 체크리스트

- [x] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항(선택)

> `AccountSettingsPanel`의 PIN 재설정 플로우: 로그인 상태에서 이메일 발송 → 별도 페이지(`PinResetPage`)에서 완료하는 2-step 구조입니다. 백엔드 `EmailService`의 링크 URL과 맞춰서 `/account/pin/reset?token=` 경로로 라우팅했습니다.