### PR TITLE
feat(widget): 위젯 실데이터 연결 및 관심종목 추가/삭제 구현

### DIFF
--- a/src/components/layout/AppHeader.jsx
+++ b/src/components/layout/AppHeader.jsx
@@ -78,7 +78,6 @@ function EditModeActions() {
     saveDashboard(undefined, { onSuccess: saveLayout })
   }
 
-
   return (
     <div className="flex items-center gap-2">
       <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl bg-primary-light border border-primary-border">

--- a/src/components/layout/AppHeader.jsx
+++ b/src/components/layout/AppHeader.jsx
@@ -78,6 +78,7 @@ function EditModeActions() {
     saveDashboard(undefined, { onSuccess: saveLayout })
   }
 
+
   return (
     <div className="flex items-center gap-2">
       <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl bg-primary-light border border-primary-border">

--- a/src/components/layout/CurrencySync.jsx
+++ b/src/components/layout/CurrencySync.jsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import useStompSubscription from '@/hooks/useStompSubscription'
 import useCurrencyStore from '@/store/useCurrencyStore'
 
-const TRACKED = ['USD']
+const TRACKED = ['USD', 'JPY', 'EUR']
 
 function CurrencySubscriber({ code }) {
   const msg = useStompSubscription(`/topic/currency/${code}`)

--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -721,7 +721,6 @@ function PreviewContent({ type }) {
               { label: '고가',  val: '75,800' },
               { label: '저가',  val: '73,900' },
               { label: '거래량', val: '12.4M'  },
-              { label: '시총',  val: '450조'  },
             ].map(({ label, val }) => (
               <div key={label} className="text-center">
                 <div className="text-[7px] text-foreground-disabled">{label}</div>

--- a/src/components/widgets/BalanceWidget.jsx
+++ b/src/components/widgets/BalanceWidget.jsx
@@ -23,6 +23,7 @@ function useBalance(enabled) {
     return { total: '-', profit: '-', profitRate: '-', invested: '-', available: '-', isProfit: true, isLoading: true }
   }
 
+
   const cash      = cashData?.krwBalance ?? cashData?.balance ?? cashData?.depositBalance ?? 0
   const invested  = holdings.reduce((s, h) => s + (h.avgPrice ?? h.avgBuyPrice ?? 0) * (h.holdingQuantity ?? h.availableQuantity ?? 0), 0)
   const stockVal  = holdings.reduce((s, h) => s + (h.currentPrice ?? h.avgPrice ?? h.avgBuyPrice ?? 0) * (h.holdingQuantity ?? h.availableQuantity ?? 0), 0)

--- a/src/components/widgets/BalanceWidget.jsx
+++ b/src/components/widgets/BalanceWidget.jsx
@@ -23,8 +23,10 @@ function useBalance(enabled) {
     return { total: '-', profit: '-', profitRate: '-', invested: '-', available: '-', isProfit: true, isLoading: true }
   }
 
-
-  const cash      = cashData?.krwBalance ?? cashData?.balance ?? cashData?.depositBalance ?? 0
+  const krwEntry  = Array.isArray(cashData)
+    ? (cashData.find((c) => c.currencyCode === 'KRW') ?? cashData[0])
+    : cashData
+  const cash      = krwEntry?.totalAmount ?? krwEntry?.availableAmount ?? 0
   const invested  = holdings.reduce((s, h) => s + (h.avgPrice ?? h.avgBuyPrice ?? 0) * (h.holdingQuantity ?? h.availableQuantity ?? 0), 0)
   const stockVal  = holdings.reduce((s, h) => s + (h.currentPrice ?? h.avgPrice ?? h.avgBuyPrice ?? 0) * (h.holdingQuantity ?? h.availableQuantity ?? 0), 0)
   const total     = stockVal + cash
@@ -36,7 +38,7 @@ function useBalance(enabled) {
     profit:     (profit >= 0 ? '+' : '-') + fmt(Math.abs(profit)),
     profitRate: (profitRate >= 0 ? '+' : '') + profitRate.toFixed(2) + '%',
     invested:   fmt(invested),
-    available:  fmt(cash),
+    available:  fmt(krwEntry?.availableAmount ?? cash),
     isProfit:   profit >= 0,
     isLoading:  false,
   }

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -47,7 +47,6 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
     </button>
   )
 
-
   const { data: priceData } = useQuery({
     queryKey: ['stock', 'price', stockCode],
     queryFn:  () => marketApi.getCurrentPrice(stockCode),

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -21,19 +21,26 @@ const STOCK_CODE_MAP = {
 
 const PERIODS = ['1일', '1주', '1달', '3달']
 
+function fmtVolume(v) {
+  if (v == null) return '-'
+  if (v >= 100_000_000) return `${(v / 100_000_000).toFixed(1)}억`
+  if (v >= 10_000) return `${Math.round(v / 10_000).toLocaleString('ko-KR')}만`
+  return v.toLocaleString('ko-KR')
+}
+
 export default function StockChartWidget({ instanceId, variant = 'stock-sm', colSpan = 1, rowSpan = 1, onDelete, config = {} }) {
   const [activePeriod, setActivePeriod] = useState('1일')
   const [isConfigOpen, setIsConfigOpen] = useState(false)
   const updateWidgetConfig = useWidgetStore((s) => s.updateWidgetConfig)
   const { mutate: saveDashboard } = useDashboardSave()
 
-  const stockId   = config.stockId ?? 'samsung'
-  const stockCode = config.stockCode ?? STOCK_CODE_MAP[stockId]
-  const stockName = config.stockName ?? null
-  const stockMeta = HOME_STOCKS.find((s) => s.id === stockId) ?? HOME_STOCKS[0]
+  const stockId      = config.stockId ?? 'samsung'
+  const stockCode    = config.stockCode ?? STOCK_CODE_MAP[stockId]
+  const stockName    = config.stockName ?? null
+  const stockMeta    = HOME_STOCKS.find((s) => s.id === stockId) ?? HOME_STOCKS[0]
 
-  function handleStockSave({ stockCode: newCode, stockName: newName }) {
-    updateWidgetConfig(instanceId, { stockCode: newCode, stockName: newName, stockId: undefined })
+  function handleStockSave({ stockCode: newCode, stockName: newName, marketType: newMarket }) {
+    updateWidgetConfig(instanceId, { stockCode: newCode, stockName: newName, marketType: newMarket, stockId: undefined })
     saveDashboard()
     setIsConfigOpen(false)
   }
@@ -65,9 +72,12 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
     staleTime: 5 * 60 * 1000,
   })
 
-  const miniChartData = useMemo(() => {
+  const { miniChartData, latestCandle } = useMemo(() => {
     const series = normalizeDailySeries(chartRaw?.data)
-    return series.map((p) => ({ time: Math.floor(p.timestamp / 1000), value: p.close }))
+    return {
+      miniChartData: series.map((p) => ({ time: Math.floor(p.timestamp / 1000), value: p.close })),
+      latestCandle:  series[series.length - 1] ?? null,
+    }
   }, [chartRaw])
 
   const hasPrice = priceData != null
@@ -82,6 +92,13 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
     changeAmt: priceData?.changeAmount != null
                  ? Math.abs(Number(priceData.changeAmount)).toLocaleString('ko-KR')
                  : '-',
+    open:       latestCandle ? Number(latestCandle.open).toLocaleString('ko-KR') : '-',
+    high:       latestCandle ? Number(latestCandle.high).toLocaleString('ko-KR') : '-',
+    low:        latestCandle ? Number(latestCandle.low).toLocaleString('ko-KR')  : '-',
+    volume:     priceData?.volume != null
+                  ? fmtVolume(priceData.volume)
+                  : latestCandle ? fmtVolume(latestCandle.volume) : '-',
+    marketType: config.marketType ?? stockMeta.market ?? null,
   }
   const isUp = stock.change > 0
 
@@ -105,7 +122,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
                   <div className="text-[11px] font-bold text-foreground leading-none">{stock.name}</div>
                   {settingsBtn}
                 </div>
-                <div className="text-[9px] text-foreground-disabled mt-0.5">{stock.code} · {stock.market}</div>
+                <div className="text-[9px] text-foreground-disabled mt-0.5">{stock.code}{stock.marketType ? ` · ${stock.marketType}` : ''}</div>
               </div>
               <div>
                 <div className={`text-[18px] font-bold leading-tight text-foreground`}>{stock.price}</div>
@@ -131,13 +148,13 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
         <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
           <div className="flex items-start justify-between mb-1.5 shrink-0">
             <div className="flex items-center gap-2">
-              <StockAvatar name={stock.label} color={stock.color} size="sm" />
+              <StockAvatar name={stock.name} stockCode={stock.code} marketType={stock.marketType} color={stock.color} size="sm" />
               <div>
                 <div className="flex items-center gap-1">
                   <div className="text-[13px] font-bold text-foreground">{stock.name}</div>
                   {settingsBtn}
                 </div>
-                <div className="text-[9px] text-foreground-disabled">{stock.code} · {stock.market}</div>
+                <div className="text-[9px] text-foreground-disabled">{stock.code}{stock.marketType ? ` · ${stock.marketType}` : ''}</div>
               </div>
             </div>
             <div className="text-right">
@@ -162,8 +179,8 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
               { label: '시가',  val: stock.open },
               { label: '고가',  val: stock.high },
               { label: '저가',  val: stock.low  },
-              { label: '거래량', val: '12.4M'   },
-              { label: '시총',  val: '450조'    },
+              { label: '거래량', val: stock.volume },
+              { label: '시총',  val: '-'        },
             ].map(({ label, val }) => (
               <div key={label} className="text-center">
                 <div className="text-[8px] text-foreground-disabled">{label}</div>
@@ -183,7 +200,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
         <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
           <div className="flex items-start justify-between mb-1.5 shrink-0">
             <div className="flex items-center gap-2">
-              <StockAvatar name={stock.label} color={stock.color} size="sm" />
+              <StockAvatar name={stock.name} stockCode={stock.code} marketType={stock.marketType} color={stock.color} size="sm" />
               <div>
                 <div className="flex items-center gap-1">
                   <div className="text-[13px] font-bold text-foreground">{stock.name}</div>

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -47,6 +47,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
     </button>
   )
 
+
   const { data: priceData } = useQuery({
     queryKey: ['stock', 'price', stockCode],
     queryFn:  () => marketApi.getCurrentPrice(stockCode),

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useEffect, useMemo, useState } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Settings2 } from 'lucide-react'
 import StockAvatar from '@/components/ui/StockAvatar'
 import PriceChange from '@/components/ui/PriceChange'
@@ -10,7 +10,7 @@ import { HOME_STOCKS } from '@/mocks/home'
 import { marketApi } from '@/api/market'
 import useWidgetStore from '@/store/useWidgetStore'
 import { useDashboardSave } from '@/hooks/useDashboardSync'
-import { normalizeDailySeries } from '@/features/invest/domestic/normalize'
+import { normalizeDailySeries, normalizeMinuteSeries } from '@/features/invest/domestic/normalize'
 import { formatApiDate } from '@/features/invest/formatters'
 
 // config.stockId(레거시) → 종목코드 매핑
@@ -21,12 +21,20 @@ const STOCK_CODE_MAP = {
 
 const PERIODS = ['1일', '1주', '1달', '3달']
 
+const PERIOD_CONFIG = {
+  '1일': { type: 'minute', ncnt: 5              },
+  '1주': { type: 'daily',  period: 'DAILY',   days: 7   },
+  '1달': { type: 'daily',  period: 'DAILY',   days: 30  },
+  '3달': { type: 'daily',  period: 'WEEKLY',  days: 90  },
+}
+
 function fmtVolume(v) {
   if (v == null) return '-'
   if (v >= 100_000_000) return `${(v / 100_000_000).toFixed(1)}억`
   if (v >= 10_000) return `${Math.round(v / 10_000).toLocaleString('ko-KR')}만`
   return v.toLocaleString('ko-KR')
 }
+
 
 export default function StockChartWidget({ instanceId, variant = 'stock-sm', colSpan = 1, rowSpan = 1, onDelete, config = {} }) {
   const [activePeriod, setActivePeriod] = useState('1일')
@@ -62,23 +70,63 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
     refetchInterval: 10_000,
   })
 
+  const queryClient = useQueryClient()
+
+  // 위젯 마운트 시 모든 기간 데이터를 백그라운드 prefetch
+  useEffect(() => {
+    if (!stockCode) return
+    const end = formatApiDate(new Date())
+    Object.values(PERIOD_CONFIG).forEach((cfg) => {
+      if (cfg.type === 'minute') {
+        queryClient.prefetchQuery({
+          queryKey: ['stock', 'minute-chart', stockCode, cfg.ncnt],
+          queryFn:  () => marketApi.getMinuteChart(stockCode, { ncnt: cfg.ncnt }),
+          staleTime: 60_000,
+        })
+      } else {
+        const start = formatApiDate(new Date(Date.now() - cfg.days * 24 * 60 * 60 * 1000))
+        queryClient.prefetchQuery({
+          queryKey: ['stock', 'chart', cfg.period, stockCode, start, end],
+          queryFn:  () => marketApi.getChart(stockCode, { period: cfg.period, startDate: start, endDate: end }),
+          staleTime: 5 * 60 * 1000,
+        })
+      }
+    })
+  }, [stockCode, queryClient])
+
+  const periodCfg = PERIOD_CONFIG[activePeriod]
+  const isMinute  = periodCfg.type === 'minute'
+
   const endDate   = useMemo(() => formatApiDate(new Date()), [])
-  const startDate = useMemo(() => formatApiDate(new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)), [])
+  const startDate = useMemo(
+    () => isMinute ? null : formatApiDate(new Date(Date.now() - periodCfg.days * 24 * 60 * 60 * 1000)),
+    [isMinute, periodCfg.days]
+  )
+
+  const { data: minuteRaw } = useQuery({
+    queryKey: ['stock', 'minute-chart', stockCode, periodCfg.ncnt],
+    queryFn:  () => marketApi.getMinuteChart(stockCode, { ncnt: periodCfg.ncnt }),
+    enabled:  !!stockCode && isMinute,
+    staleTime: 60_000,
+    refetchInterval: 60_000,
+  })
 
   const { data: chartRaw } = useQuery({
-    queryKey: ['stock', 'chart', 'DAILY', stockCode, startDate, endDate],
-    queryFn:  () => marketApi.getChart(stockCode, { period: 'DAILY', startDate, endDate }),
-    enabled:  !!stockCode,
+    queryKey: ['stock', 'chart', periodCfg.period, stockCode, startDate, endDate],
+    queryFn:  () => marketApi.getChart(stockCode, { period: periodCfg.period, startDate, endDate }),
+    enabled:  !!stockCode && !isMinute,
     staleTime: 5 * 60 * 1000,
   })
 
   const { miniChartData, latestCandle } = useMemo(() => {
-    const series = normalizeDailySeries(chartRaw?.data)
+    const series = isMinute
+      ? normalizeMinuteSeries(minuteRaw?.data ?? minuteRaw)
+      : normalizeDailySeries(chartRaw?.data)
     return {
       miniChartData: series.map((p) => ({ time: Math.floor(p.timestamp / 1000), value: p.close })),
       latestCandle:  series[series.length - 1] ?? null,
     }
-  }, [chartRaw])
+  }, [isMinute, minuteRaw, chartRaw])
 
   const hasPrice = priceData != null
   const stock = {
@@ -180,7 +228,6 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
               { label: '고가',  val: stock.high },
               { label: '저가',  val: stock.low  },
               { label: '거래량', val: stock.volume },
-              { label: '시총',  val: '-'        },
             ].map(({ label, val }) => (
               <div key={label} className="text-center">
                 <div className="text-[8px] text-foreground-disabled">{label}</div>

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -123,7 +123,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
       ? normalizeMinuteSeries(minuteRaw?.data ?? minuteRaw)
       : normalizeDailySeries(chartRaw?.data)
     return {
-      miniChartData: series.map((p) => ({ time: Math.floor(p.timestamp / 1000), value: p.close })),
+      miniChartData: series.map((p, i) => ({ time: i, value: p.close })),
       latestCandle:  series[series.length - 1] ?? null,
     }
   }, [isMinute, minuteRaw, chartRaw])

--- a/src/components/widgets/StockSelectModal.jsx
+++ b/src/components/widgets/StockSelectModal.jsx
@@ -69,7 +69,7 @@ export default function StockSelectModal({ currentCode, currentName, onSave, onC
           {results.map((stock) => (
             <button
               key={stock.stockCode}
-              onClick={() => onSave({ stockCode: stock.stockCode, stockName: stock.stockName })}
+              onClick={() => onSave({ stockCode: stock.stockCode, stockName: stock.stockName, marketType: stock.marketType })}
               className="flex items-center justify-between px-3 py-2.5 rounded-xl hover:bg-surface-subtle transition-colors text-left"
             >
               <span className="text-[12px] font-semibold text-foreground">{stock.stockName}</span>

--- a/src/components/widgets/TradeHistoryWidget.jsx
+++ b/src/components/widgets/TradeHistoryWidget.jsx
@@ -1,45 +1,98 @@
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import LockedOverlay from '@/components/ui/LockedOverlay'
+import useAuthStore from '@/store/useAuthStore'
 import WidgetCard from './WidgetCard'
 import { cn } from '@/lib/cn'
-
-const TRADES = [
-  { name: '삼성전자',       type: '매수', qty: '10주', price: '754,000',  date: '3.18' },
-  { name: 'SK하이닉스',     type: '매도', qty: '5주',  price: '977,500',  date: '3.17' },
-  { name: 'LG에너지솔루션', type: '매수', qty: '3주',  price: '1,146,000',date: '3.16' },
-  { name: 'NAVER',          type: '매도', qty: '2주',  price: '420,000',  date: '3.15' },
-  { name: '현대차',         type: '매수', qty: '7주',  price: '1,435,000',date: '3.14' },
-]
+import { orderApi } from '@/api/order'
 
 const WEEK_DAYS = ['일', '월', '화', '수', '목', '금', '토']
-const WEEK_CELLS = [
-  { d: 16, trades: null },
-  { d: 17, trades: [{ s: '현대차',  buy: true  }] },
-  { d: 18, trades: [{ s: '삼성',    buy: true  }, { s: 'NAVER', buy: false }] },
-  { d: 19, trades: [{ s: 'LG에너',  buy: true  }] },
-  { d: 20, trades: [{ s: 'SK하이',  buy: false }] },
-  { d: 21, trades: [{ s: '삼성',    buy: true  }, { s: 'SK',    buy: false }] },
-  { d: 22, trades: null },
-]
 
-const MONTH_CELLS = [
-  null, null, null, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
-  15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, null,
-]
-const TRADE_MAP = {
-  3:  [{ s: '삼성', t: true  }, { s: 'SK하이', t: false }],
-  7:  [{ s: '현대차', t: true }],
-  12: [{ s: 'LG에너', t: true  }, { s: 'NAVER',  t: false }],
-  18: [{ s: '삼성',   t: true  }, { s: 'SK',     t: false }],
-  25: [{ s: '포스코',  t: false }],
+function fmtPrice(n) {
+  return Number(n ?? 0).toLocaleString('ko-KR')
+}
+
+function fmtDate(dateStr) {
+  if (!dateStr) return ''
+  const d = new Date(dateStr)
+  return `${d.getMonth() + 1}.${d.getDate()}`
+}
+
+function dateKey(d) {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function buildTradeMap(orders) {
+  const map = {}
+  orders.forEach((o) => {
+    const raw = o.executedAt ?? o.requestedAt
+    if (!raw) return
+    const k = dateKey(new Date(raw))
+    if (!map[k]) map[k] = []
+    map[k].push({ s: o.stockName, buy: o.orderSide === 'BUY' })
+  })
+  return map
+}
+
+function buildMonthCells(year, month) {
+  const firstDay = new Date(year, month, 1).getDay()
+  const days = new Date(year, month + 1, 0).getDate()
+  const cells = [...Array(firstDay).fill(null), ...Array.from({ length: days }, (_, i) => i + 1)]
+  while (cells.length % 7 !== 0) cells.push(null)
+  return cells
+}
+
+function buildWeekCells(date) {
+  const start = new Date(date)
+  start.setDate(date.getDate() - date.getDay())
+  return Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(start)
+    d.setDate(start.getDate() + i)
+    return { d: d.getDate(), key: dateKey(d) }
+  })
+}
+
+function useFilledOrders(enabled) {
+  const { data = [] } = useQuery({
+    queryKey: ['orders', 'FILLED'],
+    queryFn: () => orderApi.getOrders('FILLED'),
+    enabled,
+    staleTime: 30_000,
+  })
+  return data
 }
 
 export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1, rowSpan = 1, onDelete }) {
+  const { isAuthenticated, isRestoring } = useAuthStore()
+  const orders = useFilledOrders(isAuthenticated && !isRestoring)
+
+  const now = useMemo(() => new Date(), [])
+  const year = now.getFullYear()
+  const month = now.getMonth()
+  const monthLabel = `${year}년 ${month + 1}월`
+
+  const tradeMap   = useMemo(() => buildTradeMap(orders), [orders])
+  const monthCells = useMemo(() => buildMonthCells(year, month), [year, month])
+  const weekCells  = useMemo(() => buildWeekCells(now), [now])
+
+  const recentTrades = useMemo(() =>
+    orders.slice(0, 10).map((o) => ({
+      name:  o.stockName,
+      type:  o.orderSide === 'BUY' ? '매수' : '매도',
+      qty:   `${o.filledQuantity ?? o.orderQuantity}주`,
+      price: fmtPrice(o.orderPrice),
+      date:  fmtDate(o.executedAt ?? o.requestedAt),
+    })),
+    [orders]
+  )
+
   /* ── trade-3x2: 캘린더 + 목록 3×2 ── */
   if (variant === 'trade-3x2') {
     return (
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
         <div className="flex items-center justify-between mb-2 shrink-0">
           <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">거래내역</span>
-          <span className="text-[9px] text-foreground-disabled">2026년 3월</span>
+          <span className="text-[9px] text-foreground-disabled">{monthLabel}</span>
         </div>
         <div className="flex flex-1 min-h-0 gap-4">
           {/* 좌: 캘린더 */}
@@ -50,8 +103,9 @@ export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1
               ))}
             </div>
             <div className="grid grid-cols-7 gap-0.5 flex-1 min-h-0">
-              {MONTH_CELLS.map((d, i) => {
-                const trades = d ? TRADE_MAP[d] : null
+              {monthCells.map((d, i) => {
+                const k = d ? `${year}-${String(month + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}` : null
+                const trades = k ? (tradeMap[k] ?? null) : null
                 return (
                   <div key={i} className="flex flex-col items-start rounded p-0.5">
                     <span className={cn('text-[9px] leading-none mb-px', d ? 'text-foreground' : 'invisible')}>
@@ -59,7 +113,7 @@ export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1
                     </span>
                     {trades && trades.slice(0, 2).map((tr, j) => (
                       <div key={j} className="flex items-center gap-px w-full">
-                        <div className={cn('w-0.5 rounded-full shrink-0 self-stretch', tr.t ? 'bg-up' : 'bg-down')} />
+                        <div className={cn('w-0.5 rounded-full shrink-0 self-stretch', tr.buy ? 'bg-up' : 'bg-down')} />
                         <span className="text-[7px] leading-snug truncate text-foreground">{tr.s}</span>
                       </div>
                     ))}
@@ -72,7 +126,7 @@ export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1
           <div className="flex flex-col min-h-0 border-l border-stroke pl-4 shrink-0 w-[40%]">
             <span className="text-[9px] font-semibold text-foreground-disabled mb-1 shrink-0">거래 내역</span>
             <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-1.5">
-              {TRADES.map(({ name, type, qty, price, date }) => (
+              {recentTrades.length > 0 ? recentTrades.map(({ name, type, qty, price, date }) => (
                 <div key={`${name}-${date}`} className="flex items-center justify-between">
                   <div className="flex items-center gap-1.5 min-w-0">
                     <span className={cn(
@@ -88,10 +142,13 @@ export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1
                     <span className="text-[8px] text-foreground-disabled">{qty} · {date}</span>
                   </div>
                 </div>
-              ))}
+              )) : (
+                <div className="flex-1 flex items-center justify-center text-[9px] text-foreground-disabled">거래내역 없음</div>
+              )}
             </div>
           </div>
         </div>
+        {!isRestoring && !isAuthenticated && <LockedOverlay message="거래내역을 보려면" />}
       </WidgetCard>
     )
   }
@@ -102,7 +159,7 @@ export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
         <div className="flex items-center justify-between mb-2 shrink-0">
           <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">거래내역</span>
-          <span className="text-[9px] text-foreground-disabled">2026년 3월</span>
+          <span className="text-[9px] text-foreground-disabled">{monthLabel}</span>
         </div>
         <div className="grid grid-cols-7 gap-0.5 shrink-0 mb-1">
           {WEEK_DAYS.map((d) => (
@@ -110,18 +167,22 @@ export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1
           ))}
         </div>
         <div className="grid grid-cols-7 gap-0.5 flex-1 min-h-0">
-          {WEEK_CELLS.map(({ d, trades }, i) => (
-            <div key={i} className="flex flex-col items-start rounded-lg p-1 bg-background/50">
-              <span className="text-[9px] leading-none mb-1 text-foreground">{d}</span>
-              {trades && trades.map((tr, j) => (
-                <div key={j} className="flex items-center gap-0.5 w-full mb-0.5">
-                  <div className={cn('w-0.5 rounded-full shrink-0 self-stretch', tr.buy ? 'bg-up' : 'bg-down')} />
-                  <span className="text-[8px] leading-snug truncate text-foreground">{tr.s}</span>
-                </div>
-              ))}
-            </div>
-          ))}
+          {weekCells.map(({ d, key }, i) => {
+            const trades = tradeMap[key] ?? null
+            return (
+              <div key={i} className="flex flex-col items-start rounded-lg p-1 bg-background/50">
+                <span className="text-[9px] leading-none mb-1 text-foreground">{d}</span>
+                {trades && trades.map((tr, j) => (
+                  <div key={j} className="flex items-center gap-0.5 w-full mb-0.5">
+                    <div className={cn('w-0.5 rounded-full shrink-0 self-stretch', tr.buy ? 'bg-up' : 'bg-down')} />
+                    <span className="text-[8px] leading-snug truncate text-foreground">{tr.s}</span>
+                  </div>
+                ))}
+              </div>
+            )
+          })}
         </div>
+        {!isRestoring && !isAuthenticated && <LockedOverlay message="거래내역을 보려면" />}
       </WidgetCard>
     )
   }
@@ -132,7 +193,7 @@ export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
         <div className="flex items-center justify-between mb-2 shrink-0">
           <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">거래내역</span>
-          <span className="text-[9px] text-foreground-disabled">2026년 3월</span>
+          <span className="text-[9px] text-foreground-disabled">{monthLabel}</span>
         </div>
         <div className="grid grid-cols-7 gap-0.5 shrink-0 mb-1">
           {WEEK_DAYS.map((d) => (
@@ -140,8 +201,9 @@ export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1
           ))}
         </div>
         <div className="grid grid-cols-7 gap-0.5 flex-1 min-h-0">
-          {MONTH_CELLS.map((d, i) => {
-            const trades = d ? TRADE_MAP[d] : null
+          {monthCells.map((d, i) => {
+            const k = d ? `${year}-${String(month + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}` : null
+            const trades = k ? (tradeMap[k] ?? null) : null
             return (
               <div key={i} className="flex flex-col items-start rounded p-0.5">
                 <span className={cn('text-[9px] leading-none mb-px', d ? 'text-foreground' : 'invisible')}>
@@ -149,7 +211,7 @@ export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1
                 </span>
                 {trades && trades.slice(0, 2).map((tr, j) => (
                   <div key={j} className="flex items-center gap-px w-full">
-                    <div className={cn('w-0.5 rounded-full shrink-0 self-stretch', tr.t ? 'bg-up' : 'bg-down')} />
+                    <div className={cn('w-0.5 rounded-full shrink-0 self-stretch', tr.buy ? 'bg-up' : 'bg-down')} />
                     <span className="text-[7px] leading-snug truncate text-foreground">{tr.s}</span>
                   </div>
                 ))}
@@ -157,6 +219,7 @@ export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1
             )
           })}
         </div>
+        {!isRestoring && !isAuthenticated && <LockedOverlay message="거래내역을 보려면" />}
       </WidgetCard>
     )
   }
@@ -168,7 +231,7 @@ export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1
         <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">거래내역</span>
       </div>
       <div className="flex-1 flex flex-col gap-1.5 min-h-0 overflow-y-auto">
-        {TRADES.map(({ name, type, qty, date }) => (
+        {recentTrades.length > 0 ? recentTrades.map(({ name, type, qty, date }) => (
           <div key={`${name}-${date}`} className="flex items-center justify-between">
             <div className="flex items-center gap-1.5 min-w-0">
               <span className={cn(
@@ -184,8 +247,11 @@ export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1
               <span className="text-[8px] text-foreground-disabled">{date}</span>
             </div>
           </div>
-        ))}
+        )) : (
+          <div className="flex-1 flex items-center justify-center text-[9px] text-foreground-disabled">거래내역 없음</div>
+        )}
       </div>
+      {!isRestoring && !isAuthenticated && <LockedOverlay message="거래내역을 보려면" />}
     </WidgetCard>
   )
 }

--- a/src/components/widgets/TradeHistoryWidget.jsx
+++ b/src/components/widgets/TradeHistoryWidget.jsx
@@ -14,7 +14,7 @@ function fmtPrice(n) {
 
 function fmtDate(dateStr) {
   if (!dateStr) return ''
-  const d = new Date(dateStr)
+  const d = new Date(dateStr.length === 10 ? dateStr + 'T00:00:00' : dateStr)
   return `${d.getMonth() + 1}.${d.getDate()}`
 }
 
@@ -27,7 +27,8 @@ function buildTradeMap(orders) {
   orders.forEach((o) => {
     const raw = o.executedAt ?? o.requestedAt
     if (!raw) return
-    const k = dateKey(new Date(raw))
+    const d = new Date(raw.length === 10 ? raw + 'T00:00:00' : raw)
+    const k = dateKey(d)
     if (!map[k]) map[k] = []
     map[k].push({ s: o.stockName, buy: o.orderSide === 'BUY' })
   })
@@ -53,27 +54,27 @@ function buildWeekCells(date) {
 }
 
 function useFilledOrders(enabled) {
-  const { data = [] } = useQuery({
+  const { data = [], isLoading } = useQuery({
     queryKey: ['orders', 'FILLED'],
     queryFn: () => orderApi.getOrders('FILLED'),
     enabled,
     staleTime: 30_000,
   })
-  return data
+  return { data, isLoading }
 }
 
 export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1, rowSpan = 1, onDelete }) {
   const { isAuthenticated, isRestoring } = useAuthStore()
-  const orders = useFilledOrders(isAuthenticated && !isRestoring)
+  const { data: orders, isLoading } = useFilledOrders(isAuthenticated && !isRestoring)
 
-  const now = useMemo(() => new Date(), [])
+  const now = new Date()
   const year = now.getFullYear()
   const month = now.getMonth()
   const monthLabel = `${year}년 ${month + 1}월`
 
   const tradeMap   = useMemo(() => buildTradeMap(orders), [orders])
   const monthCells = useMemo(() => buildMonthCells(year, month), [year, month])
-  const weekCells  = useMemo(() => buildWeekCells(now), [now])
+  const weekCells  = useMemo(() => buildWeekCells(now), [year, month, now.getDate()])
 
   const recentTrades = useMemo(() =>
     orders.slice(0, 10).map((o) => ({
@@ -104,7 +105,7 @@ export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1
             </div>
             <div className="grid grid-cols-7 gap-0.5 flex-1 min-h-0">
               {monthCells.map((d, i) => {
-                const k = d ? `${year}-${String(month + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}` : null
+                const k = d ? dateKey(new Date(year, month, d)) : null
                 const trades = k ? (tradeMap[k] ?? null) : null
                 return (
                   <div key={i} className="flex flex-col items-start rounded p-0.5">
@@ -126,7 +127,9 @@ export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1
           <div className="flex flex-col min-h-0 border-l border-stroke pl-4 shrink-0 w-[40%]">
             <span className="text-[9px] font-semibold text-foreground-disabled mb-1 shrink-0">거래 내역</span>
             <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-1.5">
-              {recentTrades.length > 0 ? recentTrades.map(({ name, type, qty, price, date }) => (
+              {isLoading
+                ? <div className="text-[9px] text-foreground-disabled">불러오는 중...</div>
+                : recentTrades.length > 0 ? recentTrades.map(({ name, type, qty, price, date }) => (
                 <div key={`${name}-${date}`} className="flex items-center justify-between">
                   <div className="flex items-center gap-1.5 min-w-0">
                     <span className={cn(
@@ -231,7 +234,9 @@ export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1
         <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">거래내역</span>
       </div>
       <div className="flex-1 flex flex-col gap-1.5 min-h-0 overflow-y-auto">
-        {recentTrades.length > 0 ? recentTrades.map(({ name, type, qty, date }) => (
+        {isLoading
+          ? <div className="text-[9px] text-foreground-disabled">불러오는 중...</div>
+          : recentTrades.length > 0 ? recentTrades.map(({ name, type, qty, date }) => (
           <div key={`${name}-${date}`} className="flex items-center justify-between">
             <div className="flex items-center gap-1.5 min-w-0">
               <span className={cn(

--- a/src/components/widgets/WatchlistWidget.jsx
+++ b/src/components/widgets/WatchlistWidget.jsx
@@ -1,74 +1,130 @@
+import { useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { X } from 'lucide-react'
 import PriceChange from '@/components/ui/PriceChange'
-import WidgetCard from './WidgetCard'
-import { useWatchlist } from '@/api/watchlist'
+import LockedOverlay from '@/components/ui/LockedOverlay'
 import useAuthStore from '@/store/useAuthStore'
+import WidgetCard from './WidgetCard'
+import StockSelectModal from './StockSelectModal'
+import { useWatchlist, watchlistApi } from '@/api/watchlist'
+
+function fmtPrice(n) {
+  return `₩${Number(n ?? 0).toLocaleString('ko-KR')}`
+}
+
+function useWatchlistMutations() {
+  const queryClient = useQueryClient()
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: ['watchlist'] })
+
+  const add = useMutation({
+    mutationFn: (stockCode) => watchlistApi.addToWatchlist(stockCode),
+    onSuccess: invalidate,
+  })
+
+  const remove = useMutation({
+    mutationFn: (stockCode) => watchlistApi.removeFromWatchlist(stockCode),
+    onSuccess: invalidate,
+  })
+
+  return { add, remove }
+}
 
 export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1, rowSpan = 1, onDelete }) {
-  const { isAuthenticated } = useAuthStore()
-  const { data = [], isLoading, isError } = useWatchlist({ enabled: isAuthenticated })
-  const items = data.slice(0, 5)
+  const { isAuthenticated, isRestoring } = useAuthStore()
+  const { data: items = [] } = useWatchlist({ enabled: isAuthenticated && !isRestoring })
+  const { add, remove } = useWatchlistMutations()
+  const [isAddOpen, setIsAddOpen] = useState(false)
 
-  const emptyMessage = !isAuthenticated
-    ? '로그인 후 이용 가능합니다'
-    : isError
-      ? '불러오기에 실패했습니다'
-      : items.length === 0
-        ? '관심 종목을 추가해보세요'
-        : null
+  const list = items.slice(0, 5)
+
+  function handleAdd({ stockCode }) {
+    add.mutate(stockCode, { onSuccess: () => setIsAddOpen(false) })
+  }
+
+  function handleRemove(e, stockCode) {
+    e.stopPropagation()
+    remove.mutate(stockCode)
+  }
+
+  const addModal = isAddOpen && (
+    <StockSelectModal
+      onSave={handleAdd}
+      onClose={() => setIsAddOpen(false)}
+    />
+  )
+
+  const addBtn = (
+    <button
+      onClick={(e) => { e.stopPropagation(); setIsAddOpen(true) }}
+      className="text-[10px] text-primary font-semibold hover:underline"
+    >
+      + 추가
+    </button>
+  )
 
   if (variant === 'watchlist-wide') {
     return (
-      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-        <div className="flex items-center justify-between mb-2 shrink-0">
-          <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">관심 종목</span>
-          <button
-            onClick={(e) => e.stopPropagation()}
-            className="text-[10px] text-primary font-semibold hover:underline"
-          >
-            + 추가
-          </button>
-        </div>
-        <div className="flex-1 flex flex-col gap-1.5 min-h-0">
-          {isLoading && <span className="text-[10px] text-foreground-disabled">불러오는 중...</span>}
-          {!isLoading && emptyMessage && <span className="text-[10px] text-foreground-disabled">{emptyMessage}</span>}
-          {!isLoading && !emptyMessage && items.map((item) => (
-            <div key={item.stockCode} className="flex items-center justify-between gap-2">
-              <span className="text-[10px] font-medium text-foreground truncate">{item.stockName}</span>
-              <div className="flex items-center gap-1.5 shrink-0">
-                <span className="text-[10px] font-semibold text-foreground">
-                  {Number(item.currentPrice).toLocaleString('ko-KR')}원
-                </span>
-                <PriceChange value={item.changeRate} className="text-[9px] font-medium" />
+      <>
+        <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+          <div className="flex items-center justify-between mb-2 shrink-0">
+            <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">관심 종목</span>
+            {addBtn}
+          </div>
+          <div className="flex-1 flex flex-col gap-1.5 min-h-0">
+            {list.length > 0 ? list.map(({ stockCode, stockName, currentPrice, changeRate }) => (
+              <div key={stockCode} className="flex items-center justify-between gap-2 group">
+                <span className="text-[10px] font-medium text-foreground truncate">{stockName}</span>
+                <div className="flex items-center gap-1.5 shrink-0">
+                  <span className="text-[10px] font-semibold text-foreground">{fmtPrice(currentPrice)}</span>
+                  <PriceChange value={changeRate} className="text-[9px] font-medium" />
+                  <button
+                    onClick={(e) => handleRemove(e, stockCode)}
+                    className="opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded text-foreground-disabled hover:text-down"
+                  >
+                    <X className="w-3 h-3" />
+                  </button>
+                </div>
               </div>
-            </div>
-          ))}
-        </div>
-      </WidgetCard>
+            )) : (
+              <div className="flex-1 flex items-center justify-center text-[9px] text-foreground-disabled">관심 종목 없음</div>
+            )}
+          </div>
+          {!isRestoring && !isAuthenticated && <LockedOverlay message="관심 종목을 보려면" />}
+        </WidgetCard>
+        {addModal}
+      </>
     )
   }
 
   /* watchlist-sm (default) */
   return (
-    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-      <div className="flex items-center justify-between mb-2 shrink-0">
-        <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">관심 종목</span>
-        <button
-          onClick={(e) => e.stopPropagation()}
-          className="text-[10px] text-primary font-semibold hover:underline"
-        >
-          + 추가
-        </button>
-      </div>
-      <div className="flex-1 flex flex-col gap-1.5 min-h-0">
-        {isLoading && <span className="text-[10px] text-foreground-disabled">불러오는 중...</span>}
-        {!isLoading && emptyMessage && <span className="text-[10px] text-foreground-disabled">{emptyMessage}</span>}
-        {!isLoading && !emptyMessage && items.map((item) => (
-          <div key={item.stockCode} className="flex items-center justify-between">
-            <span className="text-[10px] font-medium text-foreground">{item.stockName}</span>
-            <PriceChange value={item.changeRate} className="text-[9px] font-semibold" />
-          </div>
-        ))}
-      </div>
-    </WidgetCard>
+    <>
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+        <div className="flex items-center justify-between mb-2 shrink-0">
+          <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">관심 종목</span>
+          {addBtn}
+        </div>
+        <div className="flex-1 flex flex-col gap-1.5 min-h-0">
+          {list.length > 0 ? list.map(({ stockCode, stockName, changeRate }) => (
+            <div key={stockCode} className="flex items-center justify-between group">
+              <span className="text-[10px] font-medium text-foreground truncate">{stockName}</span>
+              <div className="flex items-center gap-1 shrink-0">
+                <PriceChange value={changeRate} className="text-[9px] font-semibold" />
+                <button
+                  onClick={(e) => handleRemove(e, stockCode)}
+                  className="opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded text-foreground-disabled hover:text-down"
+                >
+                  <X className="w-3 h-3" />
+                </button>
+              </div>
+            </div>
+          )) : (
+            <div className="flex-1 flex items-center justify-center text-[9px] text-foreground-disabled">관심 종목 없음</div>
+          )}
+        </div>
+        {!isRestoring && !isAuthenticated && <LockedOverlay message="관심 종목을 보려면" />}
+      </WidgetCard>
+      {addModal}
+    </>
   )
 }

--- a/src/components/widgets/WatchlistWidget.jsx
+++ b/src/components/widgets/WatchlistWidget.jsx
@@ -31,7 +31,7 @@ function useWatchlistMutations() {
 
 export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1, rowSpan = 1, onDelete }) {
   const { isAuthenticated, isRestoring } = useAuthStore()
-  const { data: items = [] } = useWatchlist({ enabled: isAuthenticated && !isRestoring })
+  const { data: items = [], isError } = useWatchlist({ enabled: isAuthenticated && !isRestoring })
   const { add, remove } = useWatchlistMutations()
   const [isAddOpen, setIsAddOpen] = useState(false)
 
@@ -71,7 +71,9 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
             {addBtn}
           </div>
           <div className="flex-1 flex flex-col gap-1.5 min-h-0">
-            {list.length > 0 ? list.map(({ stockCode, stockName, currentPrice, changeRate }) => (
+            {isError
+              ? <span className="text-[10px] text-foreground-disabled">불러오기에 실패했습니다</span>
+              : list.length > 0 ? list.map(({ stockCode, stockName, currentPrice, changeRate }) => (
               <div key={stockCode} className="flex items-center justify-between gap-2 group">
                 <span className="text-[10px] font-medium text-foreground truncate">{stockName}</span>
                 <div className="flex items-center gap-1.5 shrink-0">
@@ -105,7 +107,9 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
           {addBtn}
         </div>
         <div className="flex-1 flex flex-col gap-1.5 min-h-0">
-          {list.length > 0 ? list.map(({ stockCode, stockName, changeRate }) => (
+          {isError
+            ? <span className="text-[10px] text-foreground-disabled">불러오기에 실패했습니다</span>
+            : list.length > 0 ? list.map(({ stockCode, stockName, changeRate }) => (
             <div key={stockCode} className="flex items-center justify-between group">
               <span className="text-[10px] font-medium text-foreground truncate">{stockName}</span>
               <div className="flex items-center gap-1 shrink-0">

--- a/src/index.css
+++ b/src/index.css
@@ -216,3 +216,8 @@ select:-webkit-autofill:focus {
     );
   }
 }
+
+/* lightweight-charts TradingView attribution 숨김 */
+.tv-lightweight-charts a[href*="tradingview"] {
+  display: none !important;
+}


### PR DESCRIPTION
## 개요

홈 대시보드 위젯 목데이터를 실서버 API로 대체하고, 미구현 상태였던 관심종목 추가/삭제 기능을 구현합니다.

## 변경 사항

### 실데이터 연결
- **TradeHistoryWidget**: `GET /api/orders?status=FILLED` 연결, 캘린더 현재 날짜 기준 동적 생성, 미로그인 시 LockedOverlay 표시
- **WatchlistWidget**: `GET /api/watchlist` 연결
- **StockChartWidget**: 시가/고가/저가/거래량을 차트 캔들 데이터 및 실시간 API로 대체, `StockAvatar`에 `stockCode`/`marketType` 전달로 종목 로고 표시

### 기능 구현
- **WatchlistWidget**: `+ 추가` 버튼 → StockSelectModal 연동 (`POST /api/watchlist`)
- **WatchlistWidget**: 항목 hover 시 X 버튼 노출 → 삭제 (`DELETE /api/watchlist/{stockCode}`)
- **StockSelectModal**: 종목 선택 시 `marketType` 함께 저장
- **MiniChart**: TradingView 워터마크 CSS로 숨김

### 신규 파일
- `src/api/watchlist.js`: watchlist API 함수 및 `useWatchlist` 훅

## 테스트

- [ ] TradeHistoryWidget 로그인/미로그인 상태 확인
- [ ] TradeHistoryWidget 캘린더에 거래일 표시 확인
- [ ] WatchlistWidget 관심종목 추가/삭제 후 목록 갱신 확인
- [ ] StockChartWidget stock-3x2/2x2 시가/고가/저가/거래량 실데이터 표시 확인
- [ ] StockChartWidget 종목 변경 후 로고 이미지 표시 확인
- [ ] MiniChart 워터마크 미표시 확인

closes #70