### PR TITLE
fix(widgets): 위젯 hover lift 효과 제거, 위젯 편집 버튼 홈 탭에서만 표시

### DIFF
--- a/src/components/layout/AppHeader.jsx
+++ b/src/components/layout/AppHeader.jsx
@@ -1,5 +1,5 @@
 import { Activity, LayoutGrid } from 'lucide-react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 import NavTabs from './NavTabs'
 import useAuthStore from '@/store/useAuthStore'
 import { useMyAccount } from '@/api/account'
@@ -121,13 +121,15 @@ function WidgetEditButton() {
 
 export default function AppHeader() {
   const { isEditMode } = useEditModeStore()
+  const { pathname } = useLocation()
+  const isHome = pathname === '/'
 
   return (
     <header className="h-header flex items-center px-4 gap-3 bg-surface border-b border-stroke shrink-0 z-50">
       <Logo />
       <NavTabs />
       <div className="flex-1" />
-      {isEditMode ? <EditModeActions /> : <WidgetEditButton />}
+      {isHome && (isEditMode ? <EditModeActions /> : <WidgetEditButton />)}
       <UserArea />
     </header>
   )

--- a/src/components/widgets/WidgetCard.jsx
+++ b/src/components/widgets/WidgetCard.jsx
@@ -16,7 +16,7 @@ export default function WidgetCard({ children, className = '', onDelete }) {
           'h-full',
           isEditMode
             ? 'animate-wiggle'
-            : 'cursor-pointer transition-[transform] duration-[200ms] hover:-translate-y-px',
+            : 'cursor-pointer',
         )}
         style={isEditMode ? { animationDelay: `${wiggleDelay}ms` } : undefined}
       >


### PR DESCRIPTION
Closes #73

## 변경 사항

### WidgetCard — hover lift 효과 제거
`hover:-translate-y-px` 제거. 테두리 색상(`hover:border-widget-border-hover`) 강조만 유지.

### AppHeader — 위젯 편집 버튼 홈 탭 한정
`useLocation`으로 현재 경로를 확인해 `pathname === '/'`일 때만 '위젯 편집' / EditModeActions 렌더링.