### PR TITLE
feat(asset): 잔고 페이지 및 마켓 UI 개선

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "@stomp/stompjs": "^7.3.0",
     "@tanstack/react-query": "^5.91.2",
     "clsx": "^2.1.1",
+    "echarts": "^6.0.0",
+    "echarts-for-react": "^3.0.6",
     "lightweight-charts": "^5.1.0",
     "lucide-react": "^0.577.0",
     "react": "^19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,12 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      echarts:
+        specifier: ^6.0.0
+        version: 6.0.0
+      echarts-for-react:
+        specifier: ^3.0.6
+        version: 3.0.6(echarts@6.0.0)(react@19.2.4)
       lightweight-charts:
         specifier: ^5.1.0
         version: 5.1.0
@@ -970,6 +976,15 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
+  echarts-for-react@3.0.6:
+    resolution: {integrity: sha512-4zqLgTGWS3JvkQDXjzkR1k1CHRdpd6by0988TWMJgnvDytegWLbeP/VNZmMa+0VJx2eD7Y632bi2JquXDgiGJg==}
+    peerDependencies:
+      echarts: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
+      react: ^15.0.0 || >=16.0.0
+
+  echarts@6.0.0:
+    resolution: {integrity: sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==}
+
   electron-to-chromium@1.5.313:
     resolution: {integrity: sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==}
 
@@ -1496,6 +1511,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  size-sensor@1.0.3:
+    resolution: {integrity: sha512-+k9mJ2/rQMiRmQUcjn+qznch260leIXY8r4FyYKKyRBO/s5UoeMAHGkCJyE1R/4wrIhTJONfyloY55SkE7ve3A==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1521,6 +1539,9 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tslib@2.3.0:
+    resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1625,6 +1646,9 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zrender@6.0.0:
+    resolution: {integrity: sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==}
 
   zustand@5.0.12:
     resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
@@ -2440,6 +2464,18 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
+  echarts-for-react@3.0.6(echarts@6.0.0)(react@19.2.4):
+    dependencies:
+      echarts: 6.0.0
+      fast-deep-equal: 3.1.3
+      react: 19.2.4
+      size-sensor: 1.0.3
+
+  echarts@6.0.0:
+    dependencies:
+      tslib: 2.3.0
+      zrender: 6.0.0
+
   electron-to-chromium@1.5.313: {}
 
   enhanced-resolve@5.20.0:
@@ -2894,6 +2930,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  size-sensor@1.0.3: {}
+
   source-map-js@1.2.1: {}
 
   strip-json-comments@3.1.1: {}
@@ -2912,6 +2950,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tslib@2.3.0: {}
 
   tslib@2.8.1: {}
 
@@ -2971,6 +3011,10 @@ snapshots:
       zod: 4.3.6
 
   zod@4.3.6: {}
+
+  zrender@6.0.0:
+    dependencies:
+      tslib: 2.3.0
 
   zustand@5.0.12(@types/react@19.2.14)(react@19.2.4):
     optionalDependencies:

--- a/src/api/balance.js
+++ b/src/api/balance.js
@@ -53,3 +53,27 @@ export const useOverseasHoldings = ({ enabled = true } = {}) =>
     enabled,
     staleTime: 1000 * 30,
   })
+
+export const useBalanceSummary = ({ enabled = true } = {}) =>
+  useQuery({
+    queryKey: ['balance', 'summary'],
+    queryFn: balanceApi.getBalanceSummary,
+    enabled,
+    staleTime: 1000 * 30,
+  })
+
+export const useCashBalances = ({ enabled = true } = {}) =>
+  useQuery({
+    queryKey: ['balance', 'cash'],
+    queryFn: balanceApi.getCashBalances,
+    enabled,
+    staleTime: 1000 * 30,
+  })
+
+export const usePortfolioData = ({ enabled = true } = {}) =>
+  useQuery({
+    queryKey: ['portfolio'],
+    queryFn: balanceApi.getPortfolio,
+    enabled,
+    staleTime: 1000 * 30,
+  })

--- a/src/api/exchange.js
+++ b/src/api/exchange.js
@@ -1,0 +1,30 @@
+import { fetchWithAuth } from '@/lib/fetchWithAuth'
+
+function get(path, params) {
+  const query = params
+    ? '?' + new URLSearchParams(
+        Object.fromEntries(Object.entries(params).filter(([, v]) => v != null))
+      ).toString()
+    : ''
+  return fetchWithAuth(`/api/exchange${path}${query}`)
+}
+
+function post(path, body) {
+  return fetchWithAuth(`/api/exchange${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+export const exchangeApi = {
+  // 환전 가능 금액 / 예상 수령액 조회
+  // fromCurrency: 'KRW'|'USD', toCurrency: 'USD'|'KRW', requestAmount?: number
+  getAvailable: (fromCurrency, toCurrency, requestAmount) =>
+    get('/available', { fromCurrency, toCurrency, requestAmount }),
+
+  // 환전 실행
+  // body: { fromCurrency, toCurrency, requestAmount }
+  exchange: (fromCurrency, toCurrency, requestAmount) =>
+    post('', { fromCurrency, toCurrency, requestAmount }),
+}

--- a/src/components/asset/ExchangeModal.jsx
+++ b/src/components/asset/ExchangeModal.jsx
@@ -4,7 +4,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { exchangeApi } from '@/api/exchange'
 
 function fmt(n) {
-  return Number(n ?? 0).toLocaleString('ko-KR')
+  return Math.round(Number(n ?? 0)).toLocaleString('ko-KR')
 }
 
 function parseAmount(str) {

--- a/src/components/asset/ExchangeModal.jsx
+++ b/src/components/asset/ExchangeModal.jsx
@@ -1,0 +1,239 @@
+import { useState, useEffect, useRef } from 'react'
+import { X, ArrowLeftRight, Loader2 } from 'lucide-react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { exchangeApi } from '@/api/exchange'
+
+function fmt(n) {
+  return Number(n ?? 0).toLocaleString('ko-KR')
+}
+
+function parseAmount(str) {
+  return Number(str.replace(/,/g, '')) || 0
+}
+
+export default function ExchangeModal({ onClose, krwBalance, usdBalance }) {
+  const queryClient = useQueryClient()
+
+  const [dir, setDir] = useState('KRW_TO_USD') // 'KRW_TO_USD' | 'USD_TO_KRW'
+  const [inputRaw, setInputRaw] = useState('')   // 콤마 없는 숫자 문자열
+  const [preview, setPreview] = useState(null)
+  const [previewLoading, setPreviewLoading] = useState(false)
+  const [previewError, setPreviewError] = useState(null)
+  const [done, setDone] = useState(null)         // 완료된 ExchangeResponse
+
+  const debounceRef = useRef(null)
+
+  const fromCurrency = dir === 'KRW_TO_USD' ? 'KRW' : 'USD'
+  const toCurrency   = dir === 'KRW_TO_USD' ? 'USD' : 'KRW'
+  const maxBalance   = dir === 'KRW_TO_USD' ? krwBalance : usdBalance
+  const unit         = dir === 'KRW_TO_USD' ? '원' : '$'
+
+  // 방향 전환 시 입력·프리뷰 초기화
+  function toggleDir() {
+    setDir((d) => d === 'KRW_TO_USD' ? 'USD_TO_KRW' : 'KRW_TO_USD')
+    setInputRaw('')
+    setPreview(null)
+    setPreviewError(null)
+  }
+
+  // 금액 입력 → 디바운스 후 프리뷰
+  function handleInput(e) {
+    const raw = e.target.value.replace(/[^0-9.]/g, '')
+    setInputRaw(raw)
+    setPreview(null)
+    setPreviewError(null)
+
+    clearTimeout(debounceRef.current)
+    const amount = parseAmount(raw)
+    if (amount <= 0) return
+
+    debounceRef.current = setTimeout(async () => {
+      setPreviewLoading(true)
+      try {
+        const data = await exchangeApi.getAvailable(fromCurrency, toCurrency, amount)
+        setPreview(data)
+      } catch {
+        setPreviewError('환율 정보를 가져오지 못했습니다.')
+      } finally {
+        setPreviewLoading(false)
+      }
+    }, 400)
+  }
+
+  // 전액 입력
+  function handleMax() {
+    setInputRaw(String(maxBalance))
+  }
+
+  // 환전 실행
+  const { mutate: doExchange, isPending } = useMutation({
+    mutationFn: () =>
+      exchangeApi.exchange(fromCurrency, toCurrency, parseAmount(inputRaw)),
+    onSuccess: (data) => {
+      // 잔고 관련 쿼리 갱신
+      queryClient.invalidateQueries({ queryKey: ['balance'] })
+      queryClient.invalidateQueries({ queryKey: ['portfolio'] })
+      setDone(data)
+    },
+  })
+
+  const amount = parseAmount(inputRaw)
+  const canSubmit = amount > 0 && amount <= maxBalance && preview && !isPending
+
+  // ── 완료 화면 ─────────────────────────────────────────────────
+  if (done) {
+    const isKrwToUsd = done.fromCurrency === 'KRW'
+    return (
+      <Overlay onClose={onClose}>
+        <div className="flex flex-col items-center gap-4 py-2">
+          <div className="w-12 h-12 rounded-full bg-live/10 flex items-center justify-center">
+            <ArrowLeftRight className="w-5 h-5 text-live" strokeWidth={2.5} />
+          </div>
+          <div className="text-center">
+            <div className="text-[15px] font-bold text-foreground">환전 완료</div>
+            <div className="text-[12px] text-foreground-disabled mt-1">
+              {isKrwToUsd
+                ? `${fmt(done.requestAmount)}원 → $${fmt(done.receiveAmount)}`
+                : `$${fmt(done.requestAmount)} → ${fmt(done.receiveAmount)}원`}
+            </div>
+          </div>
+          <div className="w-full flex flex-col gap-2 bg-surface-subtle rounded-xl p-3 text-[11px]">
+            <Row label="적용 환율" value={`${fmt(done.appliedRate)}원/USD`} />
+            <Row label="수수료" value={isKrwToUsd ? `${fmt(done.feeAmount)}원` : `$${fmt(done.feeAmount)}`} />
+            <Row label="수령 금액" value={isKrwToUsd ? `$${fmt(done.receiveAmount)}` : `${fmt(done.receiveAmount)}원`} bold />
+          </div>
+          <button
+            onClick={onClose}
+            className="w-full py-2.5 rounded-xl bg-primary text-white text-[13px] font-bold hover:bg-primary-hover transition-colors"
+          >
+            확인
+          </button>
+        </div>
+      </Overlay>
+    )
+  }
+
+  // ── 입력 화면 ─────────────────────────────────────────────────
+  return (
+    <Overlay onClose={onClose}>
+      {/* 방향 선택 */}
+      <div className="flex gap-2 mb-4">
+        {[
+          { key: 'KRW_TO_USD', label: 'KRW → USD' },
+          { key: 'USD_TO_KRW', label: 'USD → KRW' },
+        ].map(({ key, label }) => (
+          <button
+            key={key}
+            onClick={() => { setDir(key); setInputRaw(''); setPreview(null) }}
+            className={`flex-1 py-2 rounded-xl text-[12px] font-semibold border transition-colors ${
+              dir === key
+                ? 'border-primary bg-primary-light text-primary'
+                : 'border-stroke bg-surface text-foreground-disabled hover:text-foreground'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* 금액 입력 */}
+      <div className="mb-1">
+        <div className="text-[10px] font-semibold text-foreground-disabled mb-1.5">환전 금액</div>
+        <div className="flex items-center gap-2 border-[1.5px] border-stroke-input rounded-[10px] px-3 py-2.5 focus-within:border-primary focus-within:shadow-[0_0_0_3px_rgba(0,70,255,.08)] transition-all">
+          <input
+            type="text"
+            inputMode="numeric"
+            value={inputRaw ? Number(inputRaw.replace(/,/g, '')).toLocaleString('ko-KR') : ''}
+            onChange={handleInput}
+            placeholder="0"
+            className="flex-1 text-[16px] font-bold text-foreground bg-transparent outline-none placeholder:text-foreground-disabled"
+          />
+          <span className="text-[12px] text-foreground-disabled shrink-0">{unit}</span>
+        </div>
+      </div>
+
+      {/* 보유 잔고 + 전액 버튼 */}
+      <div className="flex items-center justify-between mb-4">
+        <span className="text-[10px] text-foreground-disabled">
+          보유 {fromCurrency}: {dir === 'KRW_TO_USD' ? `${fmt(maxBalance)}원` : `$${fmt(maxBalance)}`}
+        </span>
+        <button
+          onClick={handleMax}
+          className="text-[10px] font-semibold text-primary hover:underline"
+        >
+          전액
+        </button>
+      </div>
+
+      {/* 프리뷰 */}
+      {previewLoading && (
+        <div className="flex items-center justify-center gap-2 py-3 mb-3 bg-surface-subtle rounded-xl">
+          <Loader2 className="w-3.5 h-3.5 text-foreground-disabled animate-spin" />
+          <span className="text-[11px] text-foreground-disabled">환율 조회 중…</span>
+        </div>
+      )}
+      {previewError && (
+        <div className="py-2 mb-3 text-center text-[11px] text-down">{previewError}</div>
+      )}
+      {preview && !previewLoading && (
+        <div className="flex flex-col gap-2 bg-surface-subtle rounded-xl p-3 mb-4 text-[11px]">
+          <Row label="적용 환율" value={`${fmt(preview.exchangeRate)}원/USD`} />
+          <Row
+            label="예상 수령액"
+            value={dir === 'KRW_TO_USD'
+              ? `$${Number(preview.estimatedReceiveAmount).toFixed(2)}`
+              : `${fmt(preview.estimatedReceiveAmount)}원`}
+            bold
+          />
+        </div>
+      )}
+
+      {/* 실행 버튼 */}
+      <button
+        disabled={!canSubmit}
+        onClick={() => doExchange()}
+        className="w-full py-2.5 rounded-xl bg-primary text-white text-[13px] font-bold shadow-primary-btn hover:bg-primary-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        {isPending ? '처리 중…' : '환전 실행'}
+      </button>
+    </Overlay>
+  )
+}
+
+// ── 공통 헬퍼 ─────────────────────────────────────────────────────
+function Row({ label, value, bold }) {
+  return (
+    <div className="flex items-center justify-between">
+      <span className="text-foreground-disabled">{label}</span>
+      <span className={`${bold ? 'font-bold text-foreground' : 'text-foreground-secondary'}`}>{value}</span>
+    </div>
+  )
+}
+
+function Overlay({ onClose, children }) {
+  return (
+    <div className="fixed inset-0 z-[200] flex items-center justify-center">
+      {/* 딤 배경 */}
+      <div className="absolute inset-0 bg-black/30" onClick={onClose} />
+
+      {/* 모달 */}
+      <div className="relative z-10 w-[380px] bg-surface rounded-2xl shadow-[0_20px_50px_rgba(0,0,0,.22)] p-6">
+        <div className="flex items-center justify-between mb-5">
+          <div className="flex items-center gap-2">
+            <div className="w-7 h-7 rounded-[9px] bg-primary flex items-center justify-center shadow-brand-glow">
+              <ArrowLeftRight className="w-3.5 h-3.5 text-white" strokeWidth={2.5} />
+            </div>
+            <span className="text-[15px] font-bold text-foreground">환전하기</span>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1 text-foreground-disabled hover:text-foreground transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/components/asset/ExchangeModal.jsx
+++ b/src/components/asset/ExchangeModal.jsx
@@ -139,7 +139,7 @@ export default function ExchangeModal({ onClose, krwBalance, usdBalance }) {
       {/* 금액 입력 */}
       <div className="mb-1">
         <div className="text-[10px] font-semibold text-foreground-disabled mb-1.5">환전 금액</div>
-        <div className="flex items-center gap-2 border-[1.5px] border-stroke-input rounded-[10px] px-3 py-2.5 focus-within:border-primary focus-within:shadow-[0_0_0_3px_rgba(0,70,255,.08)] transition-all">
+        <div className="flex items-center gap-2 border-[1.5px] border-stroke-input rounded-[10px] px-3 py-2.5 focus-within:border-primary focus-within:shadow-focus-ring transition-all">
           <input
             type="text"
             inputMode="numeric"
@@ -217,7 +217,7 @@ function Overlay({ onClose, children }) {
       <div className="absolute inset-0 bg-black/30" onClick={onClose} />
 
       {/* 모달 */}
-      <div className="relative z-10 w-[380px] bg-surface rounded-2xl shadow-[0_20px_50px_rgba(0,0,0,.22)] p-6">
+      <div className="relative z-10 w-[380px] bg-surface rounded-2xl shadow-modal p-6">
         <div className="flex items-center justify-between mb-5">
           <div className="flex items-center gap-2">
             <div className="w-7 h-7 rounded-[9px] bg-primary flex items-center justify-center shadow-brand-glow">

--- a/src/components/invest/InvestBottomPanels.jsx
+++ b/src/components/invest/InvestBottomPanels.jsx
@@ -31,6 +31,7 @@ function SectionTabs({ items, activeKey, onChange }) {
 }
 
 export default function InvestBottomPanels({
+  stockCode,
   leftTab,
   rightTab,
   dailyRows,
@@ -44,23 +45,26 @@ export default function InvestBottomPanels({
   errorMessage,
   onLeftTabChange,
   onRightTabChange,
+  marketType,
+  displayCurrency,
+  usdRate,
 }) {
   return (
     <div className="flex h-[210px] shrink-0 overflow-hidden border-t-2 border-stroke bg-surface">
       <section className="flex min-w-0 flex-1 flex-col overflow-hidden border-r border-stroke">
         <SectionTabs items={LEFT_TABS} activeKey={leftTab} onChange={onLeftTabChange} />
-        {leftTab === 'daily' && <DailyPriceTable rows={dailyRows} isLoading={dailyLoading} errorMessage={errorMessage} />}
-        {leftTab === 'realtime' && <RealtimeTradeTable rows={realtimeRows} isLoading={realtimeLoading} errorMessage={errorMessage} />}
-        {leftTab === 'opinion' && <OpinionTable data={opinion} isLoading={detailLoading} />}
-        {leftTab === 'investor' && <InvestorTable data={investor} isLoading={detailLoading} />}
-        {leftTab === 'finance' && <FinancePanel data={finance} isLoading={detailLoading} />}
+        {leftTab === 'daily' && <DailyPriceTable rows={dailyRows} isLoading={dailyLoading} errorMessage={errorMessage} marketType={marketType} displayCurrency={displayCurrency} usdRate={usdRate} />}
+        {leftTab === 'realtime' && <RealtimeTradeTable rows={realtimeRows} isLoading={realtimeLoading} errorMessage={errorMessage} marketType={marketType} displayCurrency={displayCurrency} usdRate={usdRate} />}
+        {leftTab === 'opinion' && <OpinionTable data={opinion} isLoading={detailLoading} marketType={marketType} displayCurrency={displayCurrency} usdRate={usdRate} />}
+        {leftTab === 'investor' && <InvestorTable data={investor} isLoading={detailLoading} marketType={marketType} displayCurrency={displayCurrency} usdRate={usdRate} />}
+        {leftTab === 'finance' && <FinancePanel data={finance} isLoading={detailLoading} marketType={marketType} displayCurrency={displayCurrency} usdRate={usdRate} />}
       </section>
 
       <section className="flex min-w-0 flex-1 flex-col overflow-hidden">
         <SectionTabs items={RIGHT_TABS} activeKey={rightTab} onChange={onRightTabChange} />
-        {rightTab === 'exec' && <ExecutionHistoryPanel />}
-        {rightTab === 'pending' && <PendingOrdersPanel />}
-        {rightTab === 'holding' && <HoldingPanel />}
+        {rightTab === 'exec' && <ExecutionHistoryPanel stockCode={stockCode} marketType={marketType} displayCurrency={displayCurrency} usdRate={usdRate} />}
+        {rightTab === 'pending' && <PendingOrdersPanel stockCode={stockCode} marketType={marketType} displayCurrency={displayCurrency} usdRate={usdRate} />}
+        {rightTab === 'holding' && <HoldingPanel displayCurrency={displayCurrency} usdRate={usdRate} />}
       </section>
     </div>
   )

--- a/src/components/invest/InvestOrderBookPanel.jsx
+++ b/src/components/invest/InvestOrderBookPanel.jsx
@@ -1,5 +1,5 @@
 import PriceChange from '@/components/ui/PriceChange'
-import { formatNumber } from '@/features/invest/formatters'
+import { formatNumber, formatVisiblePrice } from '@/features/invest/formatters'
 import { cn } from '@/lib/cn'
 
 export default function InvestOrderBookPanel({
@@ -8,6 +8,9 @@ export default function InvestOrderBookPanel({
   changeRate,
   orderBook,
   onSelectPrice,
+  marketType,
+  displayCurrency,
+  usdRate,
 }) {
   if (!orderBook) {
     return (
@@ -45,13 +48,13 @@ export default function InvestOrderBookPanel({
             )}
           >
             <div className="absolute inset-y-0 right-0 bg-down/10" style={{ width: `${row.depth}%` }} />
-            <span className="relative text-xs font-bold text-down">{formatNumber(row.price)}</span>
+            <span className="relative text-xs font-bold text-down">{formatVisiblePrice(row.price, { marketType, displayCurrency, usdRate })}</span>
             <span className="relative text-[10px] text-foreground-tertiary">{formatNumber(row.quantity)}</span>
           </button>
         ))}
 
         <div className="flex items-center justify-between border-y-2 border-up-border bg-up-bg px-2 py-1.5">
-          <span className="text-[15px] font-black text-up">{formatNumber(currentPrice)}</span>
+          <span className="text-[15px] font-black text-up">{formatVisiblePrice(currentPrice, { marketType, displayCurrency, usdRate })}</span>
           {changeRate != null && !Number.isNaN(changeRate) && (
             <PriceChange value={changeRate} variant="badge" />
           )}
@@ -67,7 +70,7 @@ export default function InvestOrderBookPanel({
             )}
           >
             <div className="absolute inset-y-0 right-0 bg-up/10" style={{ width: `${row.depth}%` }} />
-            <span className="relative text-xs font-bold text-up">{formatNumber(row.price)}</span>
+            <span className="relative text-xs font-bold text-up">{formatVisiblePrice(row.price, { marketType, displayCurrency, usdRate })}</span>
             <span className="relative text-[10px] text-foreground-tertiary">{formatNumber(row.quantity)}</span>
           </button>
         ))}

--- a/src/components/invest/InvestOrderPanel.jsx
+++ b/src/components/invest/InvestOrderPanel.jsx
@@ -1,6 +1,13 @@
 import { Minus, Plus } from 'lucide-react'
 import { QUICK_RATIOS } from '@/features/invest/constants'
-import { formatCurrency, formatNumber } from '@/features/invest/formatters'
+import {
+  convertDisplayValueToMarketValue,
+  formatCurrency,
+  formatDisplayPrice,
+  formatNumber,
+  getDisplayPriceUnitLabel,
+  toDisplayPriceInputValue,
+} from '@/features/invest/formatters'
 import { ORDER_TYPE_OPTIONS } from '@/mocks/invest'
 import { cn } from '@/lib/cn'
 import AccountPinKeypad from '@/components/signup/AccountPinKeypad'
@@ -12,6 +19,9 @@ const TYPE_BTN_OFF  = 'border-stroke-input bg-surface text-foreground-tertiary'
 const ORDER_KIND_LABEL = { market: '시장가', limit: '지정가', current: '현재가' }
 
 export default function InvestOrderPanel({
+  marketType,
+  displayCurrency,
+  usdRate,
   step = 'input',
   showPin = false,
   pin = '',
@@ -41,6 +51,9 @@ export default function InvestOrderPanel({
   const isBuy = side === 'buy'
   const totalAmount = quantity * unitPrice
   const isConfirm = step === 'confirm'
+  const priceUnitLabel = getDisplayPriceUnitLabel({ marketType, displayCurrency })
+  const displaySelectedPrice = toDisplayPriceInputValue(selectedPrice, { marketType, displayCurrency, usdRate })
+  const priceInputStep = priceUnitLabel === '달러' ? '0.01' : '1'
 
   const tone = isBuy
     ? {
@@ -61,8 +74,9 @@ export default function InvestOrderPanel({
       }
 
   const availabilityLabel = isBuy ? '가능' : '보유'
-  const availabilityValue = isBuy ? `${formatNumber(availableAmount)}원` : `${formatNumber(holdingQuantity ?? 0)}주`
-  const priceLabel = orderType === 'limit' ? '지정가' : '현재가'
+  const availabilityValue = isBuy
+    ? formatCurrency(availableAmount, { marketType, displayCurrency, usdRate })
+    : `${formatNumber(holdingQuantity ?? 0)}주`
 
   return (
     <section className="flex w-[250px] shrink-0 flex-col overflow-hidden bg-surface">
@@ -186,18 +200,22 @@ export default function InvestOrderPanel({
               {orderType === 'limit' ? (
                 <input
                   type="number"
-                  value={selectedPrice || ''}
+                  step={priceInputStep}
+                  value={displaySelectedPrice}
                   onChange={(e) => {
                     const v = Number(e.target.value)
-                    if (!isNaN(v) && v >= 0) onSelectPrice?.(v)
+                    const marketValue = convertDisplayValueToMarketValue(v, { marketType, displayCurrency, usdRate })
+                    if (!isNaN(v) && v >= 0 && marketValue != null) onSelectPrice?.(marketValue)
                   }}
                   className="w-full bg-transparent text-[17px] font-black text-foreground outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
                   placeholder="0"
                 />
               ) : (
-                <span className="text-[17px] font-black text-foreground">{formatNumber(unitPrice)}</span>
+                <span className="text-[17px] font-black text-foreground">
+                  {formatDisplayPrice(unitPrice, { marketType, displayCurrency, usdRate })}
+                </span>
               )}
-              <span className="ml-1 shrink-0 text-[10px] font-medium text-foreground-disabled">원</span>
+              <span className="ml-1 shrink-0 text-[10px] font-medium text-foreground-disabled">{priceUnitLabel}</span>
             </div>
           </div>
 
@@ -215,7 +233,7 @@ export default function InvestOrderPanel({
               {[
                 { label: '종목', value: stockName },
                 { label: '수량', value: `${formatNumber(quantity)}주` },
-                { label: '단가', value: formatCurrency(unitPrice) },
+                { label: '단가', value: formatCurrency(unitPrice, { marketType, displayCurrency, usdRate }) },
               ].map(({ label, value }) => (
                 <div key={label} className="flex items-center justify-between text-[10px]">
                   <span className="text-foreground-disabled">{label}</span>
@@ -228,7 +246,7 @@ export default function InvestOrderPanel({
                   {isBuy ? '예상 합계' : '예상 매도금액'}
                 </span>
                 <span className={cn('text-[17px] font-black', tone.helper)}>
-                  {formatCurrency(totalAmount)}
+                  {formatCurrency(totalAmount, { marketType, displayCurrency, usdRate })}
                 </span>
               </div>
             </div>
@@ -250,7 +268,10 @@ export default function InvestOrderPanel({
             {[
               { label: '주문 유형', value: ORDER_KIND_LABEL[orderType] },
               { label: '주문 수량', value: `${formatNumber(quantity)}주` },
-              { label: orderType === 'market' ? '현재가 (예상)' : '주문 단가', value: formatCurrency(unitPrice) },
+              {
+                label: orderType === 'market' ? '현재가 (예상)' : '주문 단가',
+                value: formatCurrency(unitPrice, { marketType, displayCurrency, usdRate }),
+              },
             ].map(({ label, value }) => (
               <div key={label} className="flex items-center justify-between text-[12px]">
                 <span className="text-foreground-disabled">{label}</span>
@@ -263,7 +284,7 @@ export default function InvestOrderPanel({
                 {isBuy ? '예상 총 매수금액' : '예상 총 매도금액'}
               </span>
               <span className={cn('text-[20px] font-black', tone.title)}>
-                {formatCurrency(totalAmount)}
+                {formatCurrency(totalAmount, { marketType, displayCurrency, usdRate })}
               </span>
             </div>
           </div>

--- a/src/components/invest/InvestOrderSection.jsx
+++ b/src/components/invest/InvestOrderSection.jsx
@@ -2,8 +2,9 @@ import { useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import InvestOrderBookPanel from '@/components/invest/InvestOrderBookPanel'
 import InvestOrderPanel from '@/components/invest/InvestOrderPanel'
-import { useBuyableAmount, useDomesticHoldings } from '@/api/balance'
+import { useBuyableAmount, useDomesticHoldings, useOverseasHoldings } from '@/api/balance'
 import { orderApi, ORDER_SIDE, ORDER_KIND } from '@/api/order'
+import { isForeignMarketType } from '@/features/invest/formatters'
 import usePinAuth from '@/hooks/usePinAuth'
 import useAuthStore from '@/store/useAuthStore'
 
@@ -15,6 +16,8 @@ export default function InvestOrderSection({
   changeRate,
   defaultPrice,
   orderBook,
+  displayCurrency,
+  usdRate,
 }) {
   const queryClient = useQueryClient()
   const { isPinCached, verifyAndCachePin } = usePinAuth()
@@ -37,6 +40,7 @@ export default function InvestOrderSection({
   const unitPrice = step === 'confirm' && confirmedUnitPrice != null
     ? confirmedUnitPrice
     : liveUnitPrice
+  const isForeignMarket = isForeignMarketType(marketType)
 
   const { data: buyableData } = useBuyableAmount({
     stockCode,
@@ -44,7 +48,13 @@ export default function InvestOrderSection({
     orderPrice: orderType === 'limit' ? selectedPrice : undefined,
     enabled: isAuthenticated && side === 'buy',
   })
-  const { data: holdingsData } = useDomesticHoldings({ enabled: isAuthenticated && side === 'sell' })
+  const { data: domesticHoldingsData } = useDomesticHoldings({
+    enabled: isAuthenticated && side === 'sell' && !isForeignMarket,
+  })
+  const { data: overseasHoldingsData } = useOverseasHoldings({
+    enabled: isAuthenticated && side === 'sell' && isForeignMarket,
+  })
+  const holdingsData = isForeignMarket ? overseasHoldingsData : domesticHoldingsData
 
   const availableAmount = buyableData?.availableAmount ?? 0
   const maxBuyableQuantity = buyableData?.maxBuyableQuantity ?? Math.floor(availableAmount / Math.max(unitPrice, 1))
@@ -177,9 +187,15 @@ export default function InvestOrderSection({
         changeRate={changeRate}
         orderBook={orderBook}
         onSelectPrice={handleSelectPrice}
+        marketType={marketType}
+        displayCurrency={displayCurrency}
+        usdRate={usdRate}
       />
 
       <InvestOrderPanel
+        marketType={marketType}
+        displayCurrency={displayCurrency}
+        usdRate={usdRate}
         step={step}
         showPin={showPin}
         pin={pin}

--- a/src/components/invest/InvestStockOverview.jsx
+++ b/src/components/invest/InvestStockOverview.jsx
@@ -1,5 +1,6 @@
-import { Star } from 'lucide-react'
+import { Heart } from 'lucide-react'
 import InvestStockChart from '@/components/market/InvestStockChart'
+import { useWatchlistSet } from '@/api/watchlist'
 import InvestStockSearch from '@/components/invest/InvestStockSearch'
 import LiveDot from '@/components/ui/LiveDot'
 import PriceChange from '@/components/ui/PriceChange'
@@ -42,6 +43,8 @@ export default function InvestStockOverview({
 }) {
   const marketType = stockMeta.marketType ?? stockMeta.market
   const isForeignMarket = isForeignMarketType(marketType)
+  const { watchedSet, toggle } = useWatchlistSet()
+  const isWatched = watchedSet.has(stockMeta.code)
   const changeTone = getDirectionClass(changeAmount)
 
   return (
@@ -109,10 +112,15 @@ export default function InvestStockOverview({
           </div>
           <button
             type="button"
-            aria-label="관심 종목"
-            className="shrink-0 rounded-full border-[1.5px] border-stroke-input bg-surface px-2 py-1 text-[10px] font-semibold text-foreground-secondary transition-colors hover:border-primary hover:bg-primary-light hover:text-primary"
+            aria-label={isWatched ? '관심종목 해제' : '관심종목 추가'}
+            onClick={() => toggle(stockMeta.code)}
+            className={`shrink-0 rounded-full border-[1.5px] px-2 py-1 text-[10px] font-semibold transition-colors ${
+              isWatched
+                ? 'border-primary bg-primary-light text-primary'
+                : 'border-stroke-input bg-surface text-foreground-secondary hover:border-primary hover:bg-primary-light hover:text-primary'
+            }`}
           >
-            <Star className="h-3 w-3" strokeWidth={2} />
+            <Heart className="h-3 w-3" fill={isWatched ? 'currentColor' : 'none'} strokeWidth={2} />
           </button>
         </div>
       </div>

--- a/src/components/invest/InvestStockOverview.jsx
+++ b/src/components/invest/InvestStockOverview.jsx
@@ -9,8 +9,11 @@ import {
   MINUTE_INTERVAL_OPTIONS,
 } from '@/features/invest/constants'
 import {
-  formatNumber,
+  DISPLAY_CURRENCY,
+  formatSignedVisiblePrice,
+  formatVisiblePrice,
   getDirectionClass,
+  isForeignMarketType,
 } from '@/features/invest/formatters'
 import { getChartPeriodLabel } from '@/features/invest/marketData'
 import { cn } from '@/lib/cn'
@@ -33,9 +36,13 @@ export default function InvestStockOverview({
   onMinuteIntervalChange,
   isLoading,
   errorMessage,
+  displayCurrency,
+  usdRate,
+  onDisplayCurrencyChange,
 }) {
+  const marketType = stockMeta.marketType ?? stockMeta.market
+  const isForeignMarket = isForeignMarketType(marketType)
   const changeTone = getDirectionClass(changeAmount)
-  const changeSign = changeAmount > 0 ? '+' : ''
 
   return (
     <section className="flex min-w-0 basis-0 flex-1 flex-col overflow-hidden border-r border-stroke bg-surface">
@@ -45,6 +52,25 @@ export default function InvestStockOverview({
             <InvestStockSearch stockMeta={stockMeta} />
           </div>
           <div className="flex shrink-0 items-center gap-1">
+            {isForeignMarket && (
+              <div className="mr-1 flex items-center rounded-lg bg-surface-muted p-0.5">
+                {[DISPLAY_CURRENCY.USD, DISPLAY_CURRENCY.KRW].map((currency) => (
+                  <button
+                    key={currency}
+                    type="button"
+                    onClick={() => onDisplayCurrencyChange?.(currency)}
+                    className={cn(
+                      'rounded-md px-2 py-0.5 text-[10px] font-semibold transition-all',
+                      displayCurrency === currency
+                        ? 'bg-primary text-white shadow-control'
+                        : 'text-foreground-disabled hover:text-foreground-secondary',
+                    )}
+                  >
+                    {currency}
+                  </button>
+                ))}
+              </div>
+            )}
             <LiveDot size="sm" />
             <span className="text-[9px] text-live">실시간</span>
           </div>
@@ -56,7 +82,12 @@ export default function InvestStockOverview({
 
       <div className="border-b border-stroke px-[14px] py-2.5 shrink-0">
         <div className="flex items-center gap-2">
-          <StockAvatar name={stockMeta.name} stockCode={stockMeta.code} marketType={stockMeta.market} size="lg" />
+          <StockAvatar
+            name={stockMeta.name}
+            stockCode={stockMeta.code}
+            marketType={stockMeta.marketType ?? stockMeta.market}
+            size="lg"
+          />
           <div className="min-w-0 flex-1">
             <div className="text-sm font-extrabold leading-tight text-foreground">{stockMeta.name}</div>
             <div className="mt-0.5 text-[9px] text-foreground-disabled">
@@ -65,11 +96,11 @@ export default function InvestStockOverview({
           </div>
           <div className="shrink-0 text-right">
             <div className="text-[22px] font-black leading-none tracking-tight text-foreground">
-              {isLoading && currentPrice == null ? '...' : formatNumber(currentPrice)}
+              {isLoading && currentPrice == null ? '...' : formatVisiblePrice(currentPrice, { marketType, displayCurrency, usdRate })}
             </div>
             <div className="mt-1 flex items-center justify-end gap-1">
               <span className={cn('text-[11px] font-bold', changeTone)}>
-                {changeSign}{formatNumber(changeAmount)}
+                {formatSignedVisiblePrice(changeAmount, { marketType, displayCurrency, usdRate })}
               </span>
               {changeRate != null && !Number.isNaN(changeRate) && (
                 <PriceChange value={changeRate} variant="text" className="text-[11px]" />
@@ -104,6 +135,9 @@ export default function InvestStockOverview({
           isLoading={chartLoading ?? isLoading}
           isLoadingMoreHistory={chartHistoryLoading}
           errorMessage={chartErrorMessage ?? errorMessage}
+          marketType={marketType}
+          displayCurrency={displayCurrency}
+          usdRate={usdRate}
         />
       </div>
     </section>

--- a/src/components/invest/InvestStockOverview.jsx
+++ b/src/components/invest/InvestStockOverview.jsx
@@ -103,7 +103,7 @@ export default function InvestStockOverview({
                 {formatSignedVisiblePrice(changeAmount, { marketType, displayCurrency, usdRate })}
               </span>
               {changeRate != null && !Number.isNaN(changeRate) && (
-                <PriceChange value={changeRate} variant="text" className="text-[11px]" />
+                <PriceChange value={changeRate} variant="text" paren className="text-[11px]" />
               )}
             </div>
           </div>

--- a/src/components/invest/panels/DailyPriceTable.jsx
+++ b/src/components/invest/panels/DailyPriceTable.jsx
@@ -1,11 +1,11 @@
 import { cn } from '@/lib/cn'
 import {
-  formatNumber,
+  formatVisiblePrice,
   formatSignedPercent,
   getDirectionClass,
 } from '@/features/invest/formatters'
 
-export default function DailyPriceTable({ rows, isLoading, errorMessage }) {
+export default function DailyPriceTable({ rows, isLoading, errorMessage, marketType, displayCurrency, usdRate }) {
   if (isLoading && rows.length === 0) {
     return (
       <div className="flex flex-1 items-center justify-center text-xs text-foreground-disabled">
@@ -49,15 +49,15 @@ export default function DailyPriceTable({ rows, isLoading, errorMessage }) {
             <tr key={row.date} className="even:bg-surface-subtle hover:bg-surface-muted">
               <td className="whitespace-nowrap px-2.5 py-1.5 font-semibold text-foreground-secondary">{row.date}</td>
               <td className={cn('whitespace-nowrap px-2.5 py-1.5 text-right font-extrabold', getDirectionClass(row.changeRate))}>
-                {formatNumber(row.close)}
+                {formatVisiblePrice(row.close, { marketType, displayCurrency, usdRate })}
               </td>
               <td className={cn('whitespace-nowrap px-2.5 py-1.5 text-right', getDirectionClass(row.changeRate))}>
                 {formatSignedPercent(row.changeRate)}
               </td>
               <td className="whitespace-nowrap px-2.5 py-1.5 text-right text-foreground-secondary">{row.volume}</td>
-              <td className="whitespace-nowrap px-2.5 py-1.5 text-right">{formatNumber(row.open)}</td>
-              <td className="whitespace-nowrap px-2.5 py-1.5 text-right text-up">{formatNumber(row.high)}</td>
-              <td className="whitespace-nowrap px-2.5 py-1.5 text-right text-down">{formatNumber(row.low)}</td>
+              <td className="whitespace-nowrap px-2.5 py-1.5 text-right">{formatVisiblePrice(row.open, { marketType, displayCurrency, usdRate })}</td>
+              <td className="whitespace-nowrap px-2.5 py-1.5 text-right text-up">{formatVisiblePrice(row.high, { marketType, displayCurrency, usdRate })}</td>
+              <td className="whitespace-nowrap px-2.5 py-1.5 text-right text-down">{formatVisiblePrice(row.low, { marketType, displayCurrency, usdRate })}</td>
             </tr>
           ))}
         </tbody>

--- a/src/components/invest/panels/ExecutionHistoryPanel.jsx
+++ b/src/components/invest/panels/ExecutionHistoryPanel.jsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import StockAvatar from '@/components/ui/StockAvatar'
 import LockedOverlay from '@/components/ui/LockedOverlay'
 import { cn } from '@/lib/cn'
-import { formatCurrency, formatNumber } from '@/features/invest/formatters'
+import { formatCurrency, formatNumber, formatVisiblePrice } from '@/features/invest/formatters'
 import { orderApi } from '@/api/order'
 import useAuthStore from '@/store/useAuthStore'
 
@@ -13,7 +13,7 @@ function formatTime(dateStr) {
   return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}`
 }
 
-export default function ExecutionHistoryPanel() {
+export default function ExecutionHistoryPanel({ stockCode, marketType, displayCurrency, usdRate }) {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
   const isRestoring = useAuthStore((s) => s.isRestoring)
   const { data, isLoading } = useQuery({
@@ -67,6 +67,7 @@ export default function ExecutionHistoryPanel() {
         const filledPrice = row.filledPrice ?? row.orderPrice ?? 0
         const filledQty = row.filledQuantity ?? row.orderQuantity ?? 0
         const total = filledPrice * filledQty
+        const rowMarketType = row.marketType ?? (row.stockCode === stockCode ? marketType : null)
 
         return (
           <div
@@ -75,17 +76,19 @@ export default function ExecutionHistoryPanel() {
           >
             <span className="text-[10px] text-foreground-disabled">{formatTime(row.filledAt ?? row.executedAt ?? row.requestedAt ?? row.createdAt)}</span>
             <div className="flex min-w-0 items-center gap-1.5">
-              <StockAvatar name={row.stockName ?? row.stockCode} stockCode={row.stockCode} marketType={row.marketType} size="sm" />
+              <StockAvatar name={row.stockName ?? row.stockCode} stockCode={row.stockCode} marketType={rowMarketType} size="sm" />
               <span className="truncate text-[10px] font-semibold text-foreground">{row.stockName ?? row.stockCode}</span>
             </div>
             <span className={cn('rounded-[4px] px-1 py-0.5 text-center text-[8px] font-bold', isBuy ? 'bg-up-bg text-up' : 'bg-down-bg text-down')}>
               {isBuy ? '매수' : '매도'}
             </span>
             <span className={cn('text-[10px] font-bold text-right', isBuy ? 'text-up' : 'text-down')}>
-              {formatNumber(filledPrice)}
+              {formatVisiblePrice(filledPrice, { marketType: rowMarketType, displayCurrency, usdRate })}
             </span>
             <span className="text-[10px] text-right">{formatNumber(filledQty)}</span>
-            <span className="text-[10px] font-semibold text-right">{formatCurrency(total)}</span>
+            <span className="text-[10px] font-semibold text-right">
+              {formatCurrency(total, { marketType: rowMarketType, displayCurrency, usdRate })}
+            </span>
           </div>
         )
       })}

--- a/src/components/invest/panels/FinancePanel.jsx
+++ b/src/components/invest/panels/FinancePanel.jsx
@@ -1,4 +1,4 @@
-import { formatNumber } from '@/features/invest/formatters'
+import { formatCurrency, formatNumber } from '@/features/invest/formatters'
 
 function formatEok(value) {
   const n = Number(String(value ?? '').replace(/,/g, '').trim())
@@ -11,7 +11,7 @@ function formatEok(value) {
   return `${formatNumber(n)}억`
 }
 
-export default function FinancePanel({ data, isLoading }) {
+export default function FinancePanel({ data, isLoading, marketType, displayCurrency, usdRate }) {
   if (isLoading) {
     return <div className="flex flex-1 items-center justify-center text-xs text-foreground-disabled">재무정보를 불러오는 중입니다.</div>
   }
@@ -24,8 +24,8 @@ export default function FinancePanel({ data, isLoading }) {
     { label: '시가총액', value: formatEok(data.marketCap) },
     { label: 'PER', value: data.per ? `${data.per}배` : '-' },
     { label: 'PBR', value: data.pbr ? `${data.pbr}배` : '-' },
-    { label: 'EPS', value: data.eps ? `${formatNumber(Number(data.eps))}원` : '-' },
-    { label: 'BPS', value: data.bps ? `${formatNumber(Number(data.bps))}원` : '-' },
+    { label: 'EPS', value: data.eps ? formatCurrency(Number(data.eps), { marketType, displayCurrency, usdRate }) : '-' },
+    { label: 'BPS', value: data.bps ? formatCurrency(Number(data.bps), { marketType, displayCurrency, usdRate }) : '-' },
     { label: 'ROE', value: data.roe ? `${data.roe}%` : '-' },
     { label: '자본금', value: formatEok(data.capital) },
     { label: '외국인 보유', value: data.foreignRatio ? `${data.foreignRatio}%` : '-' },

--- a/src/components/invest/panels/HoldingPanel.jsx
+++ b/src/components/invest/panels/HoldingPanel.jsx
@@ -1,15 +1,16 @@
 import { cn } from '@/lib/cn'
 import { formatCurrency, formatNumber } from '@/features/invest/formatters'
-import { useDomesticHoldings } from '@/api/balance'
+import { useDomesticHoldings, useOverseasHoldings } from '@/api/balance'
 import StockAvatar from '@/components/ui/StockAvatar'
 import LockedOverlay from '@/components/ui/LockedOverlay'
 import useAuthStore from '@/store/useAuthStore'
 
 
-export default function HoldingPanel() {
+export default function HoldingPanel({ displayCurrency, usdRate }) {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
   const isRestoring = useAuthStore((s) => s.isRestoring)
-  const { data, isLoading } = useDomesticHoldings({ enabled: isAuthenticated && !isRestoring })
+  const { data: domestic = [], isLoading: domesticLoading } = useDomesticHoldings({ enabled: isAuthenticated && !isRestoring })
+  const { data: overseas = [], isLoading: overseasLoading } = useOverseasHoldings({ enabled: isAuthenticated && !isRestoring })
 
   if (!isRestoring && !isAuthenticated) {
     return (
@@ -22,11 +23,11 @@ export default function HoldingPanel() {
     )
   }
 
-  if (isLoading) {
+  if (domesticLoading || overseasLoading) {
     return <div className="flex flex-1 items-center justify-center text-xs text-foreground-disabled">불러오는 중...</div>
   }
 
-  const holdings = data ?? []
+  const holdings = [...domestic, ...overseas]
 
   if (!holdings.length) {
     return <div className="flex flex-1 items-center justify-center text-xs text-foreground-disabled">보유 종목이 없습니다.</div>
@@ -58,13 +59,17 @@ export default function HoldingPanel() {
             <StockAvatar name={h.stockName ?? h.stockCode} stockCode={h.stockCode} marketType={h.marketType} size="sm" />
             <div className="min-w-0">
               <div className="truncate text-[10px] font-semibold text-foreground">{h.stockName ?? h.stockCode}</div>
-              <div className="text-[9px] text-foreground-disabled">{formatCurrency(evalPrice)}</div>
+              <div className="text-[9px] text-foreground-disabled">
+                {formatCurrency(evalPrice, { marketType: h.marketType, displayCurrency, usdRate })}
+              </div>
             </div>
             <span className="text-[10px] text-right text-foreground">{formatNumber(quantity)}주</span>
-            <span className="text-[10px] text-right text-foreground">{formatCurrency(avgPrice)}</span>
+            <span className="text-[10px] text-right text-foreground">
+              {formatCurrency(avgPrice, { marketType: h.marketType, displayCurrency, usdRate })}
+            </span>
             <div className="text-right">
               <div className={cn('text-[10px] font-bold', isProfit ? 'text-up' : 'text-down')}>
-                {isProfit ? '+' : ''}{formatCurrency(profitLoss)}
+                {isProfit ? '+' : ''}{formatCurrency(profitLoss, { marketType: h.marketType, displayCurrency, usdRate })}
               </div>
               <div className={cn('text-[9px]', isProfit ? 'text-up' : 'text-down')}>
                 {isProfit ? '+' : ''}{profitRate.toFixed(2)}%

--- a/src/components/invest/panels/InvestorTable.jsx
+++ b/src/components/invest/panels/InvestorTable.jsx
@@ -1,7 +1,12 @@
 import { cn } from '@/lib/cn'
-import { formatNumber, formatSignedNumber, formatDisplayDate, getDirectionClass } from '@/features/invest/formatters'
+import {
+  formatDisplayDate,
+  formatSignedNumber,
+  formatVisiblePrice,
+  getDirectionClass,
+} from '@/features/invest/formatters'
 
-export default function InvestorTable({ data, isLoading }) {
+export default function InvestorTable({ data, isLoading, marketType, displayCurrency, usdRate }) {
   if (isLoading) {
     return <div className="flex flex-1 items-center justify-center text-xs text-foreground-disabled">투자자 정보를 불러오는 중입니다.</div>
   }
@@ -28,7 +33,9 @@ export default function InvestorTable({ data, isLoading }) {
           {rows.map((row, i) => (
             <tr key={`${row.date}-${i}`} className="even:bg-surface-subtle hover:bg-surface-muted">
               <td className="whitespace-nowrap px-2.5 py-1.5 text-foreground-secondary">{formatDisplayDate(row.date)}</td>
-              <td className="whitespace-nowrap px-2.5 py-1.5 text-right font-bold">{formatNumber(row.close)}</td>
+              <td className="whitespace-nowrap px-2.5 py-1.5 text-right font-bold">
+                {formatVisiblePrice(row.close, { marketType, displayCurrency, usdRate })}
+              </td>
               <td className={cn('whitespace-nowrap px-2.5 py-1.5 text-right font-semibold', getDirectionClass(row.foreignNetBuy))}>
                 {formatSignedNumber(row.foreignNetBuy)}
               </td>

--- a/src/components/invest/panels/OpinionTable.jsx
+++ b/src/components/invest/panels/OpinionTable.jsx
@@ -1,5 +1,5 @@
 import { cn } from '@/lib/cn'
-import { formatNumber, formatDisplayDate } from '@/features/invest/formatters'
+import { formatDisplayDate, formatVisiblePrice } from '@/features/invest/formatters'
 
 function getOpinionClass(opinion) {
   if (!opinion) return ''
@@ -9,7 +9,7 @@ function getOpinionClass(opinion) {
   return 'text-foreground-disabled'
 }
 
-export default function OpinionTable({ data, isLoading }) {
+export default function OpinionTable({ data, isLoading, marketType, displayCurrency, usdRate }) {
   const opinions = data?.opinions ?? []
 
   if (isLoading) {
@@ -38,8 +38,12 @@ export default function OpinionTable({ data, isLoading }) {
               <td className="whitespace-nowrap px-2.5 py-1.5 text-foreground-secondary">{formatDisplayDate(row.date)}</td>
               <td className="whitespace-nowrap px-2.5 py-1.5 font-semibold">{row.brokerName}</td>
               <td className={cn('whitespace-nowrap px-2.5 py-1.5', getOpinionClass(row.opinion))}>{row.opinion}</td>
-              <td className="whitespace-nowrap px-2.5 py-1.5 text-right font-bold">{formatNumber(row.targetPrice)}</td>
-              <td className="whitespace-nowrap px-2.5 py-1.5 text-right text-foreground-disabled">{formatNumber(row.previousTargetPrice)}</td>
+              <td className="whitespace-nowrap px-2.5 py-1.5 text-right font-bold">
+                {formatVisiblePrice(row.targetPrice, { marketType, displayCurrency, usdRate })}
+              </td>
+              <td className="whitespace-nowrap px-2.5 py-1.5 text-right text-foreground-disabled">
+                {formatVisiblePrice(row.previousTargetPrice, { marketType, displayCurrency, usdRate })}
+              </td>
             </tr>
           ))}
         </tbody>

--- a/src/components/invest/panels/PendingOrdersPanel.jsx
+++ b/src/components/invest/panels/PendingOrdersPanel.jsx
@@ -10,7 +10,7 @@ import usePinAuth from '@/hooks/usePinAuth'
 import useAuthStore from '@/store/useAuthStore'
 
 
-export default function PendingOrdersPanel() {
+export default function PendingOrdersPanel({ stockCode, marketType, displayCurrency, usdRate }) {
   const queryClient = useQueryClient()
   const { isPinCached, verifyAndCachePin } = usePinAuth()
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
@@ -125,16 +125,21 @@ export default function PendingOrdersPanel() {
         {rows.map((row) => {
           const isBuy = row.orderSide === 'BUY'
           const isCancelling = cancellingId === (row.orderId ?? row.id)
+          const rowMarketType = row.marketType ?? (row.stockCode === stockCode ? marketType : null)
           return (
             <div key={row.orderId ?? row.id} className="flex items-center gap-2 border-b border-stroke-subtle px-2.5 py-1.5">
               <div className="grid flex-1 grid-cols-[24px_minmax(0,1fr)_40px_60px_80px] gap-2 items-center">
-                <StockAvatar name={row.stockName ?? row.stockCode} stockCode={row.stockCode} marketType={row.marketType} size="sm" />
+                <StockAvatar name={row.stockName ?? row.stockCode} stockCode={row.stockCode} marketType={rowMarketType} size="sm" />
                 <span className="truncate text-[10px] font-semibold text-foreground">{row.stockName ?? row.stockCode}</span>
                 <span className={cn('rounded-[4px] px-1 py-0.5 text-center text-[8px] font-bold', isBuy ? 'bg-up-bg text-up' : 'bg-down-bg text-down')}>
                   {isBuy ? '매수' : '매도'}
                 </span>
                 <span className="text-[10px] text-right">{formatNumber(row.orderQuantity ?? row.quantity)}주</span>
-                <span className="text-[10px] font-semibold text-right">{row.orderKind === 'MARKET' ? '시장가' : formatCurrency(row.orderPrice)}</span>
+                <span className="text-[10px] font-semibold text-right">
+                  {row.orderKind === 'MARKET'
+                    ? '시장가'
+                    : formatCurrency(row.orderPrice, { marketType: rowMarketType, displayCurrency, usdRate })}
+                </span>
               </div>
               <button
                 disabled={isCancelling}

--- a/src/components/invest/panels/RealtimeTradeTable.jsx
+++ b/src/components/invest/panels/RealtimeTradeTable.jsx
@@ -1,7 +1,7 @@
 import { cn } from '@/lib/cn'
-import { formatNumber, formatSignedPercent } from '@/features/invest/formatters'
+import { formatNumber, formatSignedPercent, formatVisiblePrice } from '@/features/invest/formatters'
 
-export default function RealtimeTradeTable({ rows, isLoading, errorMessage }) {
+export default function RealtimeTradeTable({ rows, isLoading, errorMessage, marketType, displayCurrency, usdRate }) {
   if (isLoading && rows.length === 0) {
     return (
       <div className="flex flex-1 items-center justify-center text-xs text-foreground-disabled">
@@ -44,7 +44,7 @@ export default function RealtimeTradeTable({ rows, isLoading, errorMessage }) {
           {rows.map((row, i) => isTick ? (
             <tr key={`${row.time}-${i}`} className="even:bg-surface-subtle hover:bg-surface-muted">
               <td className={cn('whitespace-nowrap px-2.5 py-1.5 text-right font-extrabold', row.isBuy ? 'text-up' : 'text-down')}>
-                {formatNumber(row.price)}
+                {formatVisiblePrice(row.price, { marketType, displayCurrency, usdRate })}
               </td>
               <td className={cn('whitespace-nowrap px-2.5 py-1.5 text-right font-semibold', row.isBuy ? 'text-up' : 'text-down')}>
                 {formatNumber(row.volume)}
@@ -62,7 +62,7 @@ export default function RealtimeTradeTable({ rows, isLoading, errorMessage }) {
           ) : (
             <tr key={`${row.time}-${i}`} className="even:bg-surface-subtle hover:bg-surface-muted">
               <td className={cn('whitespace-nowrap px-2.5 py-1.5 text-right font-extrabold', row.diff > 0 ? 'text-up' : row.diff < 0 ? 'text-down' : '')}>
-                {formatNumber(row.price)}
+                {formatVisiblePrice(row.price, { marketType, displayCurrency, usdRate })}
               </td>
               <td className="whitespace-nowrap px-2.5 py-1.5 text-right">
                 {row.volume}

--- a/src/components/layout/AccountSettingsPanel.jsx
+++ b/src/components/layout/AccountSettingsPanel.jsx
@@ -20,13 +20,14 @@ function Header() {
   const logout = useAuthStore((s) => s.logout)
 
   const handleLogout = async () => {
+    setChatMode()
+    logout()
+    navigate('/')
     try {
       await authApi.logout()
     } catch (err) {
       console.error('로그아웃 에러:', err)
     }
-    logout()
-    navigate('/')
   }
 
   return (

--- a/src/components/market/InvestStockChart.jsx
+++ b/src/components/market/InvestStockChart.jsx
@@ -2,6 +2,7 @@ import { memo, useEffect, useRef, useState } from 'react'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { CandlestickSeries, CrosshairMode, HistogramSeries, LineSeries, createChart } from 'lightweight-charts'
 import { ChevronDown } from 'lucide-react'
+import { formatVisiblePrice } from '@/features/invest/formatters'
 import { cn } from '@/lib/cn'
 
 const COLORS = {
@@ -23,18 +24,11 @@ function toChartTime(timestamp) {
   return Math.floor(timestamp / 1000)
 }
 
-function formatNumber(value) {
-  if (value == null || Number.isNaN(value)) return '-'
-  return new Intl.NumberFormat('ko-KR').format(Math.round(value))
-}
-
 const InvestStockChart = memo(function InvestStockChart({
   stockCode,
-  stockName,
   overview,
   series = [],
   selectedPeriod,
-  periodLabel,
   periodOptions = [],
   minuteInterval,
   minuteIntervalOptions = [],
@@ -45,6 +39,9 @@ const InvestStockChart = memo(function InvestStockChart({
   isLoading,
   isLoadingMoreHistory = false,
   errorMessage,
+  marketType,
+  displayCurrency,
+  usdRate,
 }) {
   const containerRef = useRef(null)
   const chartRef = useRef(null)
@@ -132,7 +129,7 @@ const InvestStockChart = memo(function InvestStockChart({
       localization: {
         locale: 'ko-KR',
         dateFormat: 'yyyy/MM/dd',
-        priceFormatter: (price) => new Intl.NumberFormat('ko-KR').format(Math.round(price)),
+        priceFormatter: (price) => formatVisiblePrice(price, { marketType, displayCurrency, usdRate }),
       },
     })
 
@@ -264,13 +261,11 @@ const InvestStockChart = memo(function InvestStockChart({
       volumeSeriesRef.current = null
       areaSeriesRef.current = null
     }
-  }, [isIntraday, chartType])
+  }, [chartType, displayCurrency, isIntraday, marketType, usdRate])
 
   // Effect 2: 데이터 업데이트 — series 바뀔 때만 (차트 재생성 없음)
   useEffect(() => {
     if (series.length === 0) return
-
-    const lastPoint = series[series.length - 1]
 
     if (candleSeriesRef.current) {
       candleSeriesRef.current.setData(
@@ -328,22 +323,22 @@ const InvestStockChart = memo(function InvestStockChart({
           <div className="flex items-center gap-2.5 text-[10px]">
             <span>
               <span className="mr-1 text-foreground-disabled">시가</span>
-              <span className="font-semibold text-foreground">{formatNumber(overview.open)}</span>
+              <span className="font-semibold text-foreground">{formatVisiblePrice(overview.open, { marketType, displayCurrency, usdRate })}</span>
             </span>
             <span className="select-none text-stroke-subtle">·</span>
             <span>
               <span className="mr-1 text-foreground-disabled">고가</span>
-              <span className="font-semibold text-up">{formatNumber(overview.high)}</span>
+              <span className="font-semibold text-up">{formatVisiblePrice(overview.high, { marketType, displayCurrency, usdRate })}</span>
             </span>
             <span className="select-none text-stroke-subtle">·</span>
             <span>
               <span className="mr-1 text-foreground-disabled">저가</span>
-              <span className="font-semibold text-down">{formatNumber(overview.low)}</span>
+              <span className="font-semibold text-down">{formatVisiblePrice(overview.low, { marketType, displayCurrency, usdRate })}</span>
             </span>
             <span className="select-none text-stroke-subtle">·</span>
             <span>
               <span className="mr-1 text-foreground-disabled">전일</span>
-              <span className="font-semibold text-foreground">{formatNumber(overview.previousClose)}</span>
+              <span className="font-semibold text-foreground">{formatVisiblePrice(overview.previousClose, { marketType, displayCurrency, usdRate })}</span>
             </span>
           </div>
         )}

--- a/src/components/market/InvestStockChart.jsx
+++ b/src/components/market/InvestStockChart.jsx
@@ -130,6 +130,15 @@ const InvestStockChart = memo(function InvestStockChart({
         locale: 'ko-KR',
         dateFormat: 'yyyy/MM/dd',
         priceFormatter: (price) => formatVisiblePrice(price, { marketType, displayCurrency, usdRate }),
+        timeFormatter: (t) => {
+          const d = new Date((t + 9 * 3600) * 1000) // UTC → KST
+          const yyyy = d.getUTCFullYear()
+          const mm = String(d.getUTCMonth() + 1).padStart(2, '0')
+          const dd = String(d.getUTCDate()).padStart(2, '0')
+          const hh = String(d.getUTCHours()).padStart(2, '0')
+          const mi = String(d.getUTCMinutes()).padStart(2, '0')
+          return isIntraday ? `${yyyy}/${mm}/${dd} ${hh}:${mi}` : `${yyyy}/${mm}/${dd}`
+        },
       },
     })
 

--- a/src/components/ui/PriceChange.jsx
+++ b/src/components/ui/PriceChange.jsx
@@ -5,12 +5,12 @@
  * @param {'text'|'badge'} variant - 표시 방식
  * @param {string}  className
  */
-export default function PriceChange({ value, variant = 'text', className = '' }) {
+export default function PriceChange({ value, variant = 'text', paren = false, className = '' }) {
   const isUp = value > 0
   const isZero = value === 0
   const sign = isUp ? '+' : isZero ? '' : '-'
   const absValue = Math.abs(value).toFixed(2)
-  const label = `${sign}${absValue}%`
+  const label = paren ? `(${sign}${absValue}%)` : `${sign}${absValue}%`
 
   const colorClass = isZero
     ? 'text-foreground-disabled'

--- a/src/features/asset/useAssetPage.js
+++ b/src/features/asset/useAssetPage.js
@@ -94,15 +94,22 @@ export function useAssetPage(enabled) {
 
     // Portfolio chart items — stocks first, cash last
     const rawItems = portfolio?.items ?? []
-    const stockItems = rawItems.filter((i) => i.type === 'STOCK')
-    const cashItem = rawItems.find((i) => i.type === 'CASH')
-    const orderedItems = [...stockItems, ...(cashItem ? [cashItem] : [])]
+    const orderedItems = rawItems.filter((i) => i.type === 'STOCK')
 
-    const portfolioItems = orderedItems.map((item) => ({
-      label: item.label,
-      weight: Math.round(Number(item.weight ?? 0)),
-      type: item.type,
-    }))
+    // label로 holdings에서 stockCode/marketType 매핑
+    const allHoldings = [...domesticRows, ...overseasRows]
+    const holdingByName = Object.fromEntries(allHoldings.map((h) => [h.stockName, h]))
+
+    const portfolioItems = orderedItems.map((item) => {
+      const holding = holdingByName[item.label]
+      return {
+        label: item.label,
+        weight: Math.round(Number(item.weight ?? 0)),
+        type: item.type,
+        stockCode: holding?.stockCode ?? null,
+        marketType: holding?.marketType ?? null,
+      }
+    })
 
     // Normalize weights
     const weightSum = portfolioItems.reduce((s, i) => s + i.weight, 0)

--- a/src/features/asset/useAssetPage.js
+++ b/src/features/asset/useAssetPage.js
@@ -83,13 +83,21 @@ export function useAssetPage(enabled) {
       + overseasRows.reduce((s, h) => s + h.evalKrw - h.pnl, 0)
 
     const totalAssets = krwDeposit + usdBal * usdRate + totalStockKrw
-    const profit = totalStockKrw - totalInvestedKrw
-    const profitRate = totalInvestedKrw > 0 ? (profit / totalInvestedKrw) * 100 : 0
-    const isProfit = profit >= 0
 
-    // Simulation
+    // 헤더: 백엔드 계좌 손익 (초기금 1억 대비)
+    const accountProfit = Number(summary?.accountProfitLoss ?? (totalStockKrw - totalInvestedKrw))
+    const accountProfitRate = Number(summary?.accountProfitLossRate ?? 0)
+    const isAccountProfit = accountProfit >= 0
+
+    // 포트폴리오 차트: 보유 주식 매입금 대비 손익률
+    const stockProfitRate = Number(summary?.totalStockUnrealizedProfitLossRate ?? 0)
+    const isStockProfit = stockProfitRate >= 0
+
+    // Simulation (AccountCard - 초기금 대비 수익률, 백엔드 값 우선)
     const startDate = accountInfo?.createdAt ? new Date(accountInfo.createdAt) : null
-    const simReturn = totalAssets > 0 ? ((totalAssets - SEED_MONEY) / SEED_MONEY) * 100 : 0
+    const simReturn = accountProfitRate !== 0
+      ? accountProfitRate
+      : totalAssets > 0 ? ((totalAssets - SEED_MONEY) / SEED_MONEY) * 100 : 0
     const isSimProfit = simReturn >= 0
 
     // Portfolio chart items — stocks first, cash last
@@ -121,9 +129,11 @@ export function useAssetPage(enabled) {
       isLoading,
       // Summary
       totalAssets,
-      profit,
-      profitRate,
-      isProfit,
+      accountProfit,
+      accountProfitRate,
+      isAccountProfit,
+      stockProfitRate,
+      isStockProfit,
       krwDeposit,
       krwAvailable,
       usdBal,

--- a/src/features/asset/useAssetPage.js
+++ b/src/features/asset/useAssetPage.js
@@ -1,0 +1,141 @@
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { balanceApi, useDomesticHoldings, useOverseasHoldings } from '@/api/balance'
+import { useMyAccount } from '@/api/account'
+import { orderApi } from '@/api/order'
+import useCurrencyStore from '@/store/useCurrencyStore'
+
+const SEED_MONEY = 100_000_000
+const FALLBACK_USD_RATE = 1350
+
+function buildHoldingRow(h, usdRate) {
+  const qty = h.holdingQuantity ?? 0
+  const cur = Number(h.currentPrice ?? h.avgBuyPrice ?? 0)
+  const avg = Number(h.avgBuyPrice ?? 0)
+  const isKrw = h.currencyCode === 'KRW'
+  const rate = Number(h.avgBuyExchangeRate ?? usdRate)
+  const evalKrw = isKrw ? cur * qty : cur * qty * usdRate
+  const investedKrw = isKrw ? avg * qty : avg * qty * rate
+  const pnl = evalKrw - investedKrw
+  const pnlRate = investedKrw > 0 ? (pnl / investedKrw) * 100 : 0
+  return { ...h, qty, cur, avg, evalKrw, pnl, pnlRate, isUp: pnl >= 0, isKrw }
+}
+
+export function useAssetPage(enabled) {
+  const usdRate = useCurrencyStore((s) => s.rates['USD']?.rate ?? FALLBACK_USD_RATE)
+
+  const { data: summary, isLoading: sl } = useQuery({
+    queryKey: ['balance', 'summary'],
+    queryFn: balanceApi.getBalanceSummary,
+    enabled,
+    staleTime: 30_000,
+  })
+
+  const { data: domestic = [], isLoading: dl } = useDomesticHoldings({ enabled })
+  const { data: overseas = [], isLoading: ol } = useOverseasHoldings({ enabled })
+
+  const { data: portfolio, isLoading: pl } = useQuery({
+    queryKey: ['portfolio'],
+    queryFn: balanceApi.getPortfolio,
+    enabled,
+    staleTime: 30_000,
+  })
+
+  const { data: accountInfo } = useMyAccount()
+
+  const { data: filledOrders = [] } = useQuery({
+    queryKey: ['orders', 'FILLED'],
+    queryFn: () => orderApi.getOrders('FILLED'),
+    enabled,
+    staleTime: 60_000,
+  })
+
+  return useMemo(() => {
+    const isLoading = enabled && (sl || dl || ol || pl)
+
+    // Cash
+    const cashList = summary?.cashBalances ?? []
+    const krwCash = cashList.find((b) => b.currencyCode === 'KRW')
+    const usdCash = cashList.find((b) => b.currencyCode === 'USD')
+    const krwDeposit = Number(krwCash?.totalAmount ?? 0)
+    const krwAvailable = Number(krwCash?.availableAmount ?? 0)
+    const usdBal = Number(usdCash?.totalAmount ?? 0)
+
+    // Holdings rows
+    const domesticRows = domestic
+      .map((h) => buildHoldingRow(h, usdRate))
+      .filter((h) => h.qty > 0)
+      .sort((a, b) => b.evalKrw - a.evalKrw)
+
+    const overseasRows = overseas
+      .map((h) => buildHoldingRow(h, usdRate))
+      .filter((h) => h.qty > 0)
+      .sort((a, b) => b.evalKrw - a.evalKrw)
+
+    // Totals
+    const domesticEval = domesticRows.reduce((s, h) => s + h.evalKrw, 0)
+    const domesticPnl = domesticRows.reduce((s, h) => s + h.pnl, 0)
+    const overseasEval = overseasRows.reduce((s, h) => s + h.evalKrw, 0)
+    const overseasPnl = overseasRows.reduce((s, h) => s + h.pnl, 0)
+
+    const totalStockKrw = domesticEval + overseasEval
+    const totalInvestedKrw = domesticRows.reduce((s, h) => s + h.evalKrw - h.pnl, 0)
+      + overseasRows.reduce((s, h) => s + h.evalKrw - h.pnl, 0)
+
+    const totalAssets = krwDeposit + usdBal * usdRate + totalStockKrw
+    const profit = totalStockKrw - totalInvestedKrw
+    const profitRate = totalInvestedKrw > 0 ? (profit / totalInvestedKrw) * 100 : 0
+    const isProfit = profit >= 0
+
+    // Simulation
+    const startDate = accountInfo?.createdAt ? new Date(accountInfo.createdAt) : null
+    const simReturn = totalAssets > 0 ? ((totalAssets - SEED_MONEY) / SEED_MONEY) * 100 : 0
+    const isSimProfit = simReturn >= 0
+
+    // Portfolio chart items — stocks first, cash last
+    const rawItems = portfolio?.items ?? []
+    const stockItems = rawItems.filter((i) => i.type === 'STOCK')
+    const cashItem = rawItems.find((i) => i.type === 'CASH')
+    const orderedItems = [...stockItems, ...(cashItem ? [cashItem] : [])]
+
+    const portfolioItems = orderedItems.map((item) => ({
+      label: item.label,
+      weight: Math.round(Number(item.weight ?? 0)),
+      type: item.type,
+    }))
+
+    // Normalize weights
+    const weightSum = portfolioItems.reduce((s, i) => s + i.weight, 0)
+    if (weightSum > 0 && weightSum !== 100 && portfolioItems.length > 0) {
+      portfolioItems[portfolioItems.length - 1].weight += 100 - weightSum
+    }
+
+    return {
+      isLoading,
+      // Summary
+      totalAssets,
+      profit,
+      profitRate,
+      isProfit,
+      krwDeposit,
+      krwAvailable,
+      usdBal,
+      // Asset breakdown
+      domesticEval,
+      domesticPnl,
+      overseasEval,
+      overseasPnl,
+      // Holdings tables
+      domesticRows,
+      overseasRows,
+      // Portfolio chart
+      portfolioItems,
+      // Simulation
+      startDate,
+      simReturn,
+      isSimProfit,
+      tradeCount: filledOrders.length,
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [summary, domestic, overseas, portfolio, accountInfo, filledOrders, usdRate, sl, dl, ol, pl, enabled])
+}

--- a/src/features/invest/domestic/useMarketData.js
+++ b/src/features/invest/domestic/useMarketData.js
@@ -73,18 +73,36 @@ function applyLiveDailyPrice(dailySeries, livePrice) {
 
   const today = new Date()
   const todayKey = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
-  if (last.date !== todayKey) {
-    return dailySeries
+  const todayTs = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 0, 0, 0).getTime()
+
+  const price = livePrice.currentPrice
+  const open  = livePrice.todayOpen  ?? price
+  const high  = livePrice.todayHigh  ?? price
+  const low   = livePrice.todayLow   ?? price
+  const vol   = livePrice.todayVolume ?? 0
+
+  const liveChangeRate = livePrice.changeRate ?? null
+
+  // 오늘 행이 이미 있으면 실시간 업데이트
+  if (last.date === todayKey) {
+    return [
+      ...dailySeries.slice(0, -1),
+      {
+        ...last,
+        open,
+        high: Math.max(last.high, high),
+        low:  Math.min(last.low,  low),
+        close: price,
+        volume: vol > 0 ? vol : last.volume,
+        liveChangeRate,
+      },
+    ]
   }
 
+  // 오늘 행이 없으면 (REST가 어제까지만 줬을 때) 새로 추가
   return [
-    ...dailySeries.slice(0, -1),
-    {
-      ...last,
-      high: Math.max(last.high, livePrice.currentPrice),
-      low: Math.min(last.low, livePrice.currentPrice),
-      close: livePrice.currentPrice,
-    },
+    ...dailySeries,
+    { date: todayKey, timestamp: todayTs, open, high, low, close: price, volume: vol, liveChangeRate },
   ]
 }
 
@@ -236,11 +254,23 @@ export default function useDomesticMarketData(stockCode, { enabled, activeDetail
       totalVolume: Number(liveTrade.volume ?? 0),
     }, ...prev].slice(0, 300))
 
-    setLivePrice({
+    const changeRate = Number(liveTrade.drate ?? 0)
+    // LS US3: change는 절댓값, sign(1/2=상승 3=보합 4/5=하락) 또는 drate 부호로 방향 결정
+    const sign = liveTrade.sign
+    const changeDir = sign
+      ? (['4', '5'].includes(String(sign)) ? -1 : ['1', '2'].includes(String(sign)) ? 1 : 0)
+      : Math.sign(changeRate)
+    const changeAmount = changeDir * Math.abs(Number(liveTrade.change ?? 0))
+
+    setLivePrice((prev) => ({
       currentPrice: price,
-      changeAmount: Number(liveTrade.change ?? 0),
-      changeRate: Number(liveTrade.drate ?? 0),
-    })
+      changeAmount,
+      changeRate,
+      todayOpen: prev?.todayOpen ?? price,
+      todayHigh: Math.max(prev?.todayHigh ?? price, price),
+      todayLow: Math.min(prev?.todayLow ?? price, price),
+      todayVolume: Number(liveTrade.volume ?? 0),
+    }))
   }, [liveTrade, selectedMinuteInterval])
 
   const customSeries = useMemo(() => (

--- a/src/features/invest/formatters.js
+++ b/src/features/invest/formatters.js
@@ -1,11 +1,134 @@
+export const DISPLAY_CURRENCY = {
+  KRW: 'KRW',
+  USD: 'USD',
+}
+
+export const FOREIGN_MARKET_TYPES = ['NASDAQ', 'NYSE', 'AMEX']
+export const FALLBACK_USD_RATE = 1350
+
 export function formatNumber(value) {
   if (value == null || Number.isNaN(value)) return '-'
   return new Intl.NumberFormat('ko-KR').format(Math.round(value))
 }
 
-export function formatCurrency(value) {
-  if (value == null || Number.isNaN(value)) return '-'
-  return `₩${formatNumber(value)}`
+function toFiniteNumber(value) {
+  const numeric = Number(value)
+  return Number.isFinite(numeric) ? numeric : null
+}
+
+export function isForeignMarketType(marketType) {
+  return FOREIGN_MARKET_TYPES.includes(marketType)
+}
+
+export function resolveUsdRate(usdRate) {
+  const rate = toFiniteNumber(usdRate)
+  return rate != null && rate > 0 ? rate : FALLBACK_USD_RATE
+}
+
+export function getDisplayCurrencySymbol({
+  marketType,
+  displayCurrency = DISPLAY_CURRENCY.KRW,
+} = {}) {
+  return isForeignMarketType(marketType) && displayCurrency === DISPLAY_CURRENCY.USD ? '$' : '₩'
+}
+
+export function getDisplayPriceUnitLabel({
+  marketType,
+  displayCurrency = DISPLAY_CURRENCY.KRW,
+} = {}) {
+  return isForeignMarketType(marketType) && displayCurrency === DISPLAY_CURRENCY.USD ? '달러' : '원'
+}
+
+export function convertMarketValue(
+  value,
+  {
+    marketType,
+    displayCurrency = DISPLAY_CURRENCY.KRW,
+    usdRate = FALLBACK_USD_RATE,
+  } = {},
+) {
+  const numeric = toFiniteNumber(value)
+  if (numeric == null) return null
+  if (!isForeignMarketType(marketType) || displayCurrency === DISPLAY_CURRENCY.USD) {
+    return numeric
+  }
+  return numeric * resolveUsdRate(usdRate)
+}
+
+export function convertDisplayValueToMarketValue(
+  value,
+  {
+    marketType,
+    displayCurrency = DISPLAY_CURRENCY.KRW,
+    usdRate = FALLBACK_USD_RATE,
+  } = {},
+) {
+  const numeric = toFiniteNumber(value)
+  if (numeric == null) return null
+  if (!isForeignMarketType(marketType) || displayCurrency === DISPLAY_CURRENCY.USD) {
+    return numeric
+  }
+  return numeric / resolveUsdRate(usdRate)
+}
+
+function getFractionDigits({
+  marketType,
+  displayCurrency = DISPLAY_CURRENCY.KRW,
+} = {}) {
+  return isForeignMarketType(marketType) && displayCurrency === DISPLAY_CURRENCY.USD ? 2 : 0
+}
+
+function formatConvertedValue(value, options = {}) {
+  const converted = convertMarketValue(value, options)
+  if (converted == null) return '-'
+  const fractionDigits = getFractionDigits(options)
+  return new Intl.NumberFormat('ko-KR', {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  }).format(converted)
+}
+
+export function formatDisplayPrice(value, options = {}) {
+  return formatConvertedValue(value, options)
+}
+
+export function toDisplayPriceInputValue(value, options = {}) {
+  const converted = convertMarketValue(value, options)
+  if (converted == null) return ''
+  const fractionDigits = getFractionDigits(options)
+  return fractionDigits === 0 ? Math.round(converted) : Number(converted.toFixed(fractionDigits))
+}
+
+export function formatCurrency(value, options = {}) {
+  const formatted = formatConvertedValue(value, options)
+  if (formatted === '-') return '-'
+  return `${getDisplayCurrencySymbol(options)}${formatted}`
+}
+
+export function formatSignedDisplayPrice(value, options = {}) {
+  const numeric = toFiniteNumber(value)
+  if (numeric == null) return '-'
+  const sign = numeric > 0 ? '+' : numeric < 0 ? '-' : ''
+  return `${sign}${formatDisplayPrice(Math.abs(numeric), options)}`
+}
+
+export function formatSignedCurrency(value, options = {}) {
+  const numeric = toFiniteNumber(value)
+  if (numeric == null) return '-'
+  const sign = numeric > 0 ? '+' : numeric < 0 ? '-' : ''
+  return `${sign}${formatCurrency(Math.abs(numeric), options)}`
+}
+
+export function formatVisiblePrice(value, options = {}) {
+  return isForeignMarketType(options.marketType)
+    ? formatCurrency(value, options)
+    : formatDisplayPrice(value, options)
+}
+
+export function formatSignedVisiblePrice(value, options = {}) {
+  return isForeignMarketType(options.marketType)
+    ? formatSignedCurrency(value, options)
+    : formatSignedDisplayPrice(value, options)
 }
 
 export function formatSignedNumber(value) {

--- a/src/features/invest/formatters.js
+++ b/src/features/invest/formatters.js
@@ -109,7 +109,7 @@ export function formatSignedDisplayPrice(value, options = {}) {
   const numeric = toFiniteNumber(value)
   if (numeric == null) return '-'
   const sign = numeric > 0 ? '+' : numeric < 0 ? '-' : ''
-  return `${sign}${formatDisplayPrice(Math.abs(numeric), options)}`
+  return `${sign}${formatDisplayPrice(Math.abs(numeric), options)}원`
 }
 
 export function formatSignedCurrency(value, options = {}) {

--- a/src/features/invest/marketData.js
+++ b/src/features/invest/marketData.js
@@ -118,7 +118,9 @@ export function buildDailyRows(dailySeries) {
   return dailySeries
     .map((row, index, source) => {
       const previousClose = index > 0 ? source[index - 1].close : null
-      const changeRate = previousClose ? ((row.close - previousClose) / previousClose) * 100 : 0
+      const changeRate = row.liveChangeRate != null
+        ? row.liveChangeRate
+        : (previousClose ? ((row.close - previousClose) / previousClose) * 100 : 0)
 
       return {
         date: formatDisplayDate(row.date),

--- a/src/features/invest/useInvestMarketData.js
+++ b/src/features/invest/useInvestMarketData.js
@@ -29,6 +29,7 @@ export default function useInvestMarketData(stockCode, locationState, { activeLe
     if (isDomestic) {
       return {
         ...baseStockMeta,
+        marketType: baseStockMeta.market,
         market: infoQuery.data?.marketName ?? baseStockMeta.market,
         sector: infoQuery.data?.sector ?? baseStockMeta.sector,
       }
@@ -36,6 +37,7 @@ export default function useInvestMarketData(stockCode, locationState, { activeLe
 
     return {
       ...baseStockMeta,
+      marketType: baseStockMeta.market,
       name: infoQuery.data?.korname ?? baseStockMeta.name,
       nameEn: infoQuery.data?.engname ?? baseStockMeta.nameEn,
       market: infoQuery.data?.exchangeName ?? baseStockMeta.market,

--- a/src/lib/extractLogoColor.js
+++ b/src/lib/extractLogoColor.js
@@ -1,0 +1,43 @@
+/**
+ * PNG 이미지에서 대표 색상을 추출합니다 (Canvas API 사용)
+ * 흰색·검정·투명 픽셀은 제외하고 가장 많이 등장하는 색을 반환합니다.
+ */
+export async function extractDominantColor(url, fallback = '#0046FF') {
+  return new Promise((resolve) => {
+    const img = new Image()
+    img.crossOrigin = 'anonymous'
+    img.onload = () => {
+      try {
+        const size = 32 // 빠른 처리를 위해 32x32로 리샘플
+        const canvas = document.createElement('canvas')
+        canvas.width = size
+        canvas.height = size
+        const ctx = canvas.getContext('2d')
+        ctx.drawImage(img, 0, 0, size, size)
+        const { data } = ctx.getImageData(0, 0, size, size)
+
+        const buckets = {}
+        for (let i = 0; i < data.length; i += 4) {
+          const [r, g, b, a] = [data[i], data[i + 1], data[i + 2], data[i + 3]]
+          if (a < 100) continue                        // 투명
+          if (r > 235 && g > 235 && b > 235) continue // 흰색 계열
+          if (r < 20 && g < 20 && b < 20) continue    // 검정 계열
+          // 16단위로 버킷팅
+          const key = `${Math.round(r / 16) * 16},${Math.round(g / 16) * 16},${Math.round(b / 16) * 16}`
+          buckets[key] = (buckets[key] || 0) + 1
+        }
+
+        const top = Object.entries(buckets).sort((a, b) => b[1] - a[1])[0]
+        if (!top) return resolve(fallback)
+
+        const [r, g, b] = top[0].split(',').map(Number)
+        const hex = '#' + [r, g, b].map((v) => v.toString(16).padStart(2, '0')).join('')
+        resolve(hex)
+      } catch {
+        resolve(fallback)
+      }
+    }
+    img.onerror = () => resolve(fallback)
+    img.src = url
+  })
+}

--- a/src/lib/fetchWithAuth.js
+++ b/src/lib/fetchWithAuth.js
@@ -68,6 +68,12 @@ export async function fetchWithAuth(url, options = {}) {
     })
   })
 
+  // 로그아웃 상태면 refresh 시도 안 함
+  if (!useAuthStore.getState().isAuthenticated) {
+    onRefreshFailed(new Error('not authenticated'))
+    return retryPromise
+  }
+
   // 첫 번째 요청만 refresh 수행
   if (!isRefreshing) {
     isRefreshing = true

--- a/src/pages/AssetPage.jsx
+++ b/src/pages/AssetPage.jsx
@@ -1,8 +1,474 @@
-// TODO: 잔고 페이지 구현
-export default function AssetPage() {
+import { useState } from 'react'
+import { ArrowLeftRight } from 'lucide-react'
+import LiveDot from '@/components/ui/LiveDot'
+import StockAvatar from '@/components/ui/StockAvatar'
+import FilterChip from '@/components/ui/FilterChip'
+import ExchangeModal from '@/components/asset/ExchangeModal'
+import useAuthStore from '@/store/useAuthStore'
+import { useMyAccount } from '@/api/account'
+import { useAssetPage } from '@/features/asset/useAssetPage'
+
+const CHART_COLORS = ['#0046FF', '#00A878', '#FF9500', '#EF4444', '#8B5CF6']
+
+// ── 유틸 ──────────────────────────────────────────────────────────
+function fmt(n) {
+  return Number(n ?? 0).toLocaleString('ko-KR')
+}
+function fmtDate(d) {
+  if (!d) return '-'
+  const dt = new Date(d)
+  return `${dt.getFullYear()}.${String(dt.getMonth() + 1).padStart(2, '0')}.${String(dt.getDate()).padStart(2, '0')}`
+}
+function fmtRate(r) {
+  if (r == null) return '-'
+  return (r >= 0 ? '+' : '') + Number(r).toFixed(2) + '%'
+}
+
+// ── Hero 섹션 ─────────────────────────────────────────────────────
+function HeroSection({ data, user, onExchange }) {
+  const { isLoading, totalAssets, profit, profitRate, isProfit, krwDeposit, krwAvailable, usdBal } = data
+  const blank = isLoading ? '-' : null
+
   return (
-    <div className="flex items-center justify-center h-full text-foreground-disabled text-sm">
-      잔고 — 준비 중
+    <div className="shrink-0 bg-surface border-b border-stroke px-6 py-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="text-[11px] text-foreground-disabled mb-1">
+            {user?.name ?? '–'} 님의 총 평가자산
+          </div>
+          <div className="flex items-baseline gap-2">
+            <span className="text-[26px] font-black text-foreground tracking-tight leading-none">
+              {blank ?? fmt(totalAssets)}
+            </span>
+            <span className="text-[13px] text-foreground-disabled">원</span>
+          </div>
+          <div className="flex items-center gap-1.5 mt-1.5">
+            <span className={`text-[13px] font-bold ${isProfit ? 'text-up' : 'text-down'}`}>
+              {blank ?? ((isProfit ? '+' : '') + fmt(Math.abs(profit ?? 0)) + '원')}
+            </span>
+            <span className={`text-[11px] font-semibold ${isProfit ? 'text-up' : 'text-down'}`}>
+              {blank ?? fmtRate(profitRate)}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex flex-col items-end gap-3">
+          <div className="flex items-center gap-6">
+            <div className="text-right">
+              <div className="text-[9px] font-semibold text-foreground-disabled mb-0.5">KRW 예수금</div>
+              <div className="text-[13px] font-bold text-foreground">
+                {blank ?? fmt(krwDeposit)}<span className="text-[10px] text-foreground-disabled ml-0.5">원</span>
+              </div>
+            </div>
+            <div className="text-right">
+              <div className="text-[9px] font-semibold text-foreground-disabled mb-0.5">주문가능금액</div>
+              <div className="text-[13px] font-bold text-primary">
+                {blank ?? fmt(krwAvailable)}<span className="text-[10px] text-foreground-disabled ml-0.5">원</span>
+              </div>
+            </div>
+            <div className="text-right">
+              <div className="text-[9px] font-semibold text-foreground-disabled mb-0.5">USD 잔고</div>
+              <div className="text-[13px] font-bold text-foreground">{blank ?? ('$' + fmt(usdBal))}</div>
+            </div>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <button
+              onClick={onExchange}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-primary text-white text-[11px] font-bold shadow-primary-btn hover:bg-primary-hover transition-colors"
+            >
+              <ArrowLeftRight className="w-3 h-3" strokeWidth={2.5} />환전하기
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── 계좌 카드 ─────────────────────────────────────────────────────
+function AccountCard({ data }) {
+  const { startDate, simReturn, isSimProfit, isLoading } = data
+  const { data: accountInfo } = useMyAccount()
+
+  const accountNumber = accountInfo?.accountNumber ?? '-'
+  const accountName = accountInfo?.accountName ?? '종합계좌'
+
+  return (
+    <div className="bg-surface rounded-2xl border border-stroke p-4 flex flex-col gap-3">
+      <div className="text-[11px] font-bold text-foreground">계좌</div>
+      <div className="h-px bg-stroke-subtle" />
+      <div>
+        <div className="text-[13px] font-bold text-foreground">{accountName}</div>
+        <div className="text-[11px] text-foreground-disabled mt-0.5">{accountNumber}</div>
+      </div>
+      <div className="h-px bg-stroke-subtle" />
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <span className="text-[10px] text-foreground-disabled">현재 수익률</span>
+          <span className={`text-[15px] font-black ${isSimProfit ? 'text-up' : 'text-down'}`}>
+            {isLoading ? '-' : fmtRate(simReturn)}
+          </span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-[10px] text-foreground-disabled">시작일</span>
+          <span className="text-[11px] font-semibold text-foreground">{fmtDate(startDate)}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-[10px] text-foreground-disabled">초기금</span>
+          <span className="text-[11px] font-semibold text-foreground">1억원</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── 자산 구성 카드 ────────────────────────────────────────────────
+function AssetBreakdownCard({ data }) {
+  const { domesticEval, domesticPnl, overseasEval, overseasPnl, krwDeposit, usdBal, isLoading } = data
+  const blank = isLoading ? '-' : null
+
+  const domesticInvested = domesticEval - domesticPnl
+  const overseasInvested = overseasEval - overseasPnl
+  const domesticRate = domesticInvested > 0 ? (domesticPnl / domesticInvested) * 100 : 0
+  const overseasRate = overseasInvested > 0 ? (overseasPnl / overseasInvested) * 100 : 0
+
+  const rows = [
+    {
+      label: '국내주식',
+      value: blank ?? fmt(domesticEval) + '원',
+      pnl: domesticPnl,
+      rate: domesticRate,
+    },
+    {
+      label: '해외주식',
+      value: blank ?? fmt(overseasEval) + '원',
+      pnl: overseasPnl,
+      rate: overseasRate,
+    },
+    { label: 'KRW 현금', value: blank ?? fmt(krwDeposit) + '원', pnl: null },
+    { label: 'USD 현금', value: blank ?? ('$' + fmt(usdBal)), pnl: null },
+  ]
+
+  return (
+    <div className="bg-surface rounded-2xl border border-stroke p-4 flex flex-col gap-2.5">
+      <div className="text-[11px] font-bold text-foreground mb-0.5">자산 구성</div>
+      {rows.map((row) => (
+        <div key={row.label} className="flex items-center justify-between py-1.5 border-b border-stroke-subtle last:border-0">
+          <span className="text-[11px] text-foreground-secondary">{row.label}</span>
+          <div className="text-right">
+            <div className="text-[13px] font-bold text-foreground">{row.value}</div>
+            {row.pnl != null && !isLoading && (
+              <div className={`text-[10px] font-semibold ${row.pnl >= 0 ? 'text-up' : 'text-down'}`}>
+                {(row.pnl >= 0 ? '+' : '') + fmt(row.pnl) + '원'} ({fmtRate(row.rate)})
+              </div>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ── 자산 흐름 카드 ────────────────────────────────────────────────
+function AssetFlowCard({ data }) {
+  const { tradeCount, profit, isProfit, isLoading } = data
+
+  // 거래 횟수 기반 간단한 bar sparkline (시각적 표현)
+  const bars = [28, 35, 30, 45, 40, 55, 50, 62, 58, 70, 65, 78, 72, 85, 80, 92, 88, 96, 90, 100]
+
+  return (
+    <div className="bg-surface rounded-2xl border border-stroke p-4 flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <div className="text-[11px] font-bold text-foreground">자산 흐름</div>
+        <span className="text-[9px] text-foreground-disabled">누적 {tradeCount}회 거래</span>
+      </div>
+
+      {/* 스파크라인 바 차트 */}
+      <div className="flex-1 flex items-end gap-px min-h-0 h-[60px]">
+        {bars.map((h, i) => (
+          <div
+            key={i}
+            className={`flex-1 rounded-sm ${isProfit ? 'bg-up/40' : 'bg-down/40'}`}
+            style={{ height: `${h}%` }}
+          />
+        ))}
+      </div>
+
+      <div className="h-px bg-stroke-subtle" />
+
+      <div className="flex items-center justify-between">
+        <span className="text-[10px] text-foreground-disabled">총 평가손익</span>
+        <span className={`text-[14px] font-black ${isProfit ? 'text-up' : 'text-down'}`}>
+          {isLoading ? '-' : ((isProfit ? '+' : '') + fmt(Math.abs(profit ?? 0)) + '원')}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+// ── 포트폴리오 파이차트 패널 (하단 좌) ───────────────────────────
+function PortfolioPanel({ data }) {
+  const { portfolioItems, profitRate, isProfit, isLoading } = data
+
+  const stops = portfolioItems.reduce((acc, item, i) => {
+    const start = portfolioItems.slice(0, i).reduce((s, x) => s + x.weight, 0)
+    const color = CHART_COLORS[i % CHART_COLORS.length]
+    acc.push(`${color} ${start}% ${start + item.weight}%`)
+    return acc
+  }, []).join(', ')
+
+  const hasItems = portfolioItems.length > 0 && stops
+
+  return (
+    <div className="flex-1 min-w-0 bg-surface rounded-2xl border border-stroke p-5 flex flex-col overflow-hidden">
+      <div className="flex items-center justify-between mb-4 shrink-0">
+        <div className="text-[11px] font-bold text-foreground">포트폴리오</div>
+        {!isLoading && (
+          <span className={`text-[11px] font-bold ${isProfit ? 'text-up' : 'text-down'}`}>
+            수익률 {fmtRate(profitRate)}
+          </span>
+        )}
+      </div>
+
+      {/* 도넛 차트 — 크게 */}
+      <div className="flex justify-center mb-5 shrink-0">
+        <div className="relative">
+          {hasItems ? (
+            <>
+              <div
+                className="w-[160px] h-[160px] rounded-full"
+                style={{ background: `conic-gradient(${stops})` }}
+              />
+              <div className="absolute inset-0 flex items-center justify-center">
+                <div
+                  className="w-[104px] h-[104px] rounded-full bg-surface flex flex-col items-center justify-center"
+                  style={{ boxShadow: 'inset 0 2px 8px rgba(0,0,0,.07)' }}
+                >
+                  <span className={`text-[16px] font-black ${isProfit ? 'text-up' : 'text-down'}`}>
+                    {isLoading ? '-' : fmtRate(profitRate)}
+                  </span>
+                  <span className="text-[9px] text-foreground-disabled mt-0.5">수익률</span>
+                </div>
+              </div>
+            </>
+          ) : (
+            <div className="w-[160px] h-[160px] rounded-full bg-surface-muted flex items-center justify-center">
+              <span className="text-[11px] text-foreground-disabled">데이터 없음</span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* 레전드 */}
+      <div className="flex flex-col gap-2.5 overflow-y-auto flex-1">
+        {portfolioItems.length === 0 && !isLoading && (
+          <p className="text-[11px] text-foreground-disabled text-center">보유 종목 없음</p>
+        )}
+        {portfolioItems.map((item, i) => {
+          const color = CHART_COLORS[i % CHART_COLORS.length]
+          return (
+            <div key={item.label} className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <div className="w-2.5 h-2.5 rounded-[3px] shrink-0" style={{ background: color }} />
+                <span className="text-[12px] text-foreground-secondary">{item.label}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="w-[60px] h-1 rounded-full bg-surface-muted overflow-hidden">
+                  <div className="h-full rounded-full" style={{ width: `${item.weight}%`, background: color }} />
+                </div>
+                <span className="text-[11px] font-bold text-foreground w-8 text-right">{item.weight}%</span>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+// ── 보유 종목 행 ──────────────────────────────────────────────────
+function HoldingRow({ h }) {
+  const { stockName, stockCode, marketType, qty, cur, avg, evalKrw, pnl, pnlRate, isUp, isKrw } = h
+
+  return (
+    <div
+      className="grid items-center px-4 py-2.5 border-b border-stroke-subtle cursor-pointer hover:bg-surface-subtle transition-colors"
+      style={{ gridTemplateColumns: '1fr 80px 88px 108px' }}
+    >
+      <div className="flex items-center gap-2.5">
+        <StockAvatar name={stockName} stockCode={stockCode} marketType={marketType} size="md" />
+        <div className="min-w-0">
+          <div className="text-[12px] font-bold text-foreground truncate">{stockName}</div>
+          <div className="text-[9px] text-foreground-disabled">{marketType}{!isKrw && ' 🇺🇸'}</div>
+        </div>
+      </div>
+
+      <div className="text-right">
+        <div className="text-[12px] font-bold text-foreground">{fmt(qty)}주</div>
+        <div className="text-[9px] text-foreground-disabled">
+          {isKrw ? fmt(avg) : `$${Number(avg).toFixed(1)}`}
+        </div>
+      </div>
+
+      <div className={`text-right text-[13px] font-extrabold ${isUp ? 'text-up' : 'text-down'}`}>
+        {isKrw ? fmt(cur) : `$${Number(cur).toFixed(2)}`}
+      </div>
+
+      <div className="text-right">
+        <div className={`text-[12px] font-extrabold ${isUp ? 'text-up' : 'text-down'}`}>
+          {(isUp ? '+' : '') + fmt(Math.abs(pnl))}
+        </div>
+        <div className={`text-[9px] font-bold ${isUp ? 'text-up' : 'text-down'}`}>
+          {fmtRate(pnlRate)}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── 보유 종목 패널 (하단 우) ──────────────────────────────────────
+function HoldingsPanel({ data }) {
+  const [filter, setFilter] = useState('all')
+  const { domesticRows, overseasRows, isLoading } = data
+
+  const allRows = [...domesticRows, ...overseasRows]
+    .sort((a, b) => b.evalKrw - a.evalKrw)
+
+  const rows = filter === 'domestic' ? domesticRows
+    : filter === 'overseas' ? overseasRows
+    : allRows
+
+  const totalEval = rows.reduce((s, h) => s + h.evalKrw, 0)
+  const totalPnl = rows.reduce((s, h) => s + h.pnl, 0)
+  const totalIsUp = totalPnl >= 0
+
+  const now = new Date()
+  const timeStr = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`
+
+  const filters = [
+    { key: 'all',      label: `전체 ${allRows.length}` },
+    { key: 'domestic', label: `국내주식 ${domesticRows.length}` },
+    { key: 'overseas', label: `해외주식 ${overseasRows.length}` },
+  ]
+
+  return (
+    <div className="flex-1 min-w-0 bg-surface rounded-2xl border border-stroke flex flex-col overflow-hidden">
+
+      {/* 헤더: 필터 + 시간 */}
+      <div className="shrink-0 flex items-center justify-between px-4 py-2.5 border-b border-stroke">
+        <div className="flex items-center gap-1.5">
+          {filters.map(({ key, label }) => (
+            <FilterChip
+              key={key}
+              isActive={filter === key}
+              onClick={() => setFilter(key)}
+            >
+              {label}
+            </FilterChip>
+          ))}
+        </div>
+        <div className="flex items-center gap-1">
+          <LiveDot size="sm" />
+          <span className="text-[9px] text-foreground-disabled">{timeStr} 기준</span>
+        </div>
+      </div>
+
+      {/* 컬럼 헤더 */}
+      <div
+        className="shrink-0 grid items-center px-4 py-1.5 bg-surface-subtle border-b border-stroke text-[9px] font-semibold text-foreground-disabled"
+        style={{ gridTemplateColumns: '1fr 80px 88px 108px' }}
+      >
+        <span>종목</span>
+        <span className="text-right">수량 / 평균가</span>
+        <span className="text-right">현재가</span>
+        <span className="text-right">평가손익</span>
+      </div>
+
+      {/* 종목 목록 */}
+      <div className="flex-1 overflow-y-auto">
+        {isLoading && (
+          <div className="flex items-center justify-center h-20 text-[11px] text-foreground-disabled">
+            불러오는 중…
+          </div>
+        )}
+        {!isLoading && rows.length === 0 && (
+          <div className="flex items-center justify-center h-20 text-[11px] text-foreground-disabled">
+            보유 종목 없음
+          </div>
+        )}
+        {rows.map((h) => <HoldingRow key={h.holdingId} h={h} />)}
+      </div>
+
+      {/* 합계 */}
+      {!isLoading && rows.length > 0 && (
+        <div
+          className="shrink-0 grid items-center px-4 py-2.5 bg-primary-light border-t-2 border-primary-dim"
+          style={{ gridTemplateColumns: '1fr 80px 88px 108px' }}
+        >
+          <div className="text-[12px] font-extrabold text-primary">합계</div>
+          <div />
+          <div className="text-right text-[12px] font-bold text-foreground">{fmt(totalEval)}원</div>
+          <div className={`text-right text-[12px] font-extrabold ${totalIsUp ? 'text-up' : 'text-down'}`}>
+            {(totalIsUp ? '+' : '') + fmt(Math.abs(totalPnl))}원
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── 미인증 ────────────────────────────────────────────────────────
+function AuthGuard() {
+  const openLoginModal = useAuthStore((s) => s.openLoginModal)
+  return (
+    <div className="flex flex-col items-center justify-center h-full gap-3">
+      <div className="text-[14px] text-foreground-secondary">로그인 후 자산을 확인할 수 있습니다</div>
+      <button
+        onClick={() => openLoginModal()}
+        className="px-6 py-2 rounded-xl bg-primary text-white text-[13px] font-semibold shadow-primary-btn hover:bg-primary-hover transition-colors"
+      >
+        로그인
+      </button>
+    </div>
+  )
+}
+
+// ── 메인 페이지 ───────────────────────────────────────────────────
+export default function AssetPage() {
+  const { isAuthenticated, isRestoring, user } = useAuthStore()
+  const data = useAssetPage(isAuthenticated && !isRestoring)
+  const [showExchange, setShowExchange] = useState(false)
+
+  if (!isRestoring && !isAuthenticated) return <AuthGuard />
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden bg-background">
+
+      {/* 환전 모달 */}
+      {showExchange && (
+        <ExchangeModal
+          onClose={() => setShowExchange(false)}
+          krwBalance={data.krwAvailable}
+          usdBalance={data.usdBal}
+        />
+      )}
+
+      {/* Hero */}
+      <HeroSection data={data} user={user} onExchange={() => setShowExchange(true)} />
+
+      {/* 상단 카드 3열 */}
+      <div className="shrink-0 grid grid-cols-3 gap-3 px-4 pt-3">
+        <AccountCard data={data} />
+        <AssetBreakdownCard data={data} />
+        <AssetFlowCard data={data} />
+      </div>
+
+      {/* 하단 2열: 파이차트 + 보유종목 */}
+      <div className="flex flex-1 min-h-0 gap-3 px-4 py-3">
+        <PortfolioPanel data={data} />
+        <HoldingsPanel data={data} />
+      </div>
+
     </div>
   )
 }

--- a/src/pages/AssetPage.jsx
+++ b/src/pages/AssetPage.jsx
@@ -1,5 +1,8 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { ArrowLeftRight } from 'lucide-react'
+import ReactECharts from 'echarts-for-react'
+import { getStockLogoUrl } from '@/lib/stockLogo'
+import { extractDominantColor } from '@/lib/extractLogoColor'
 import LiveDot from '@/components/ui/LiveDot'
 import StockAvatar from '@/components/ui/StockAvatar'
 import FilterChip from '@/components/ui/FilterChip'
@@ -8,11 +11,10 @@ import useAuthStore from '@/store/useAuthStore'
 import { useMyAccount } from '@/api/account'
 import { useAssetPage } from '@/features/asset/useAssetPage'
 
-const CHART_COLORS = ['#0046FF', '#00A878', '#FF9500', '#EF4444', '#8B5CF6']
 
 // ── 유틸 ──────────────────────────────────────────────────────────
 function fmt(n) {
-  return Number(n ?? 0).toLocaleString('ko-KR')
+  return Math.round(Number(n ?? 0)).toLocaleString('ko-KR')
 }
 function fmtDate(d) {
   if (!d) return '-'
@@ -206,22 +208,105 @@ function AssetFlowCard({ data }) {
   )
 }
 
+// ── 로고 대표색 추출 훅 ───────────────────────────────────────────
+const CASH_COLOR = '#9CA3AF'
+const FALLBACK_COLORS = ['#0046FF', '#00C2A8', '#7B61FF', '#FF8C00', '#0035CC']
+
+function useLogoColors(items) {
+  const [colors, setColors] = useState({})
+
+  useEffect(() => {
+    if (!items?.length) return
+    items.forEach(async (item, i) => {
+      const key = item.stockCode ?? `cash_${i}`
+      if (item.type === 'CASH') {
+        setColors((prev) => ({ ...prev, [key]: CASH_COLOR }))
+        return
+      }
+      if (!item.stockCode) {
+        setColors((prev) => ({ ...prev, [key]: FALLBACK_COLORS[i % FALLBACK_COLORS.length] }))
+        return
+      }
+      const url =
+        getStockLogoUrl(item.marketType, item.stockCode) ??
+        getStockLogoUrl('KOSPI', item.stockCode) ??
+        getStockLogoUrl('KOSDAQ', item.stockCode)
+      if (!url) {
+        setColors((prev) => ({ ...prev, [key]: FALLBACK_COLORS[i % FALLBACK_COLORS.length] }))
+        return
+      }
+      const color = await extractDominantColor(url, FALLBACK_COLORS[i % FALLBACK_COLORS.length])
+      setColors((prev) => ({ ...prev, [key]: color }))
+    })
+  // items 배열 내용 변화 감지를 위해 JSON 직렬화
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(items?.map((i) => i.stockCode))])
+
+  return (item, idx) => {
+    const key = item.stockCode ?? `cash_${idx}`
+    return colors[key] ?? FALLBACK_COLORS[idx % FALLBACK_COLORS.length]
+  }
+}
+
 // ── 포트폴리오 파이차트 패널 (하단 좌) ───────────────────────────
 function PortfolioPanel({ data }) {
   const { portfolioItems, profitRate, isProfit, isLoading } = data
 
-  const stops = portfolioItems.reduce((acc, item, i) => {
-    const start = portfolioItems.slice(0, i).reduce((s, x) => s + x.weight, 0)
-    const color = CHART_COLORS[i % CHART_COLORS.length]
-    acc.push(`${color} ${start}% ${start + item.weight}%`)
-    return acc
-  }, []).join(', ')
+  const getColor = useLogoColors(portfolioItems)
+  const hasItems = portfolioItems.length > 0
 
-  const hasItems = portfolioItems.length > 0 && stops
+  const sortedItems = [...portfolioItems].sort((a, b) => b.weight - a.weight)
+
+  const chartOption = {
+    backgroundColor: 'transparent',
+    tooltip: {
+      trigger: 'item',
+      formatter: (p) =>
+        `<div style="display:flex;flex-direction:column;gap:2px;min-width:100px">` +
+          `<div style="display:flex;align-items:center;gap:6px">` +
+            `<span style="display:inline-block;width:8px;height:8px;border-radius:2px;background:${p.color}"></span>` +
+            `<span style="font-size:12px;font-weight:700;color:#191F28">${p.name}</span>` +
+          `</div>` +
+          `<div style="display:flex;align-items:center;justify-content:space-between;gap:16px;margin-top:2px">` +
+            `<span style="font-size:10px;color:#9CA3AF">비중</span>` +
+            `<span style="font-size:13px;font-weight:800;color:#0046FF">${p.value}%</span>` +
+          `</div>` +
+        `</div>`,
+      backgroundColor: '#FFFFFF',
+      borderColor: '#EAECF0',
+      borderWidth: 1,
+      borderRadius: 10,
+      padding: [10, 12],
+      extraCssText: 'box-shadow:0 4px 16px rgba(0,0,0,0.10);',
+    },
+    series: [
+      {
+        type: 'pie',
+        radius: ['52%', '78%'],
+        center: ['50%', '50%'],
+        avoidLabelOverlap: false,
+        label: { show: false },
+        labelLine: { show: false },
+        itemStyle: {
+          borderWidth: 0,
+        },
+        emphasis: {
+          scale: true,
+          scaleSize: 6,
+          itemStyle: { shadowBlur: 12, shadowColor: 'rgba(0,0,0,0.25)' },
+        },
+        data: sortedItems.map((item, i) => ({
+          name: item.label,
+          value: item.weight,
+          itemStyle: { color: getColor(item, i) },
+        })),
+      },
+    ],
+  }
 
   return (
     <div className="flex-1 min-w-0 bg-surface rounded-2xl border border-stroke p-5 flex flex-col overflow-hidden">
-      <div className="flex items-center justify-between mb-4 shrink-0">
+      <div className="flex items-center justify-between mb-2 shrink-0">
         <div className="text-[11px] font-bold text-foreground">포트폴리오</div>
         {!isLoading && (
           <span className={`text-[11px] font-bold ${isProfit ? 'text-up' : 'text-down'}`}>
@@ -230,42 +315,36 @@ function PortfolioPanel({ data }) {
         )}
       </div>
 
-      {/* 도넛 차트 — 크게 */}
-      <div className="flex justify-center mb-5 shrink-0">
-        <div className="relative">
-          {hasItems ? (
-            <>
-              <div
-                className="w-[160px] h-[160px] rounded-full"
-                style={{ background: `conic-gradient(${stops})` }}
-              />
-              <div className="absolute inset-0 flex items-center justify-center">
-                <div
-                  className="w-[104px] h-[104px] rounded-full bg-surface flex flex-col items-center justify-center"
-                  style={{ boxShadow: 'inset 0 2px 8px rgba(0,0,0,.07)' }}
-                >
-                  <span className={`text-[16px] font-black ${isProfit ? 'text-up' : 'text-down'}`}>
-                    {isLoading ? '-' : fmtRate(profitRate)}
-                  </span>
-                  <span className="text-[9px] text-foreground-disabled mt-0.5">수익률</span>
-                </div>
-              </div>
-            </>
-          ) : (
-            <div className="w-[160px] h-[160px] rounded-full bg-surface-muted flex items-center justify-center">
-              <span className="text-[11px] text-foreground-disabled">데이터 없음</span>
+      {/* 도넛 차트 */}
+      <div className="relative shrink-0" style={{ height: 260 }}>
+        {hasItems ? (
+          <>
+            <ReactECharts
+              option={chartOption}
+              style={{ width: '100%', height: '100%' }}
+              opts={{ renderer: 'svg' }}
+            />
+            <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+              <span className={`text-[15px] font-black ${isProfit ? 'text-up' : 'text-down'}`}>
+                {isLoading ? '-' : fmtRate(profitRate)}
+              </span>
+              <span className="text-[9px] text-foreground-disabled mt-0.5">수익률</span>
             </div>
-          )}
-        </div>
+          </>
+        ) : (
+          <div className="flex items-center justify-center h-full">
+            <span className="text-[11px] text-foreground-disabled">데이터 없음</span>
+          </div>
+        )}
       </div>
 
       {/* 레전드 */}
-      <div className="flex flex-col gap-2.5 overflow-y-auto flex-1">
+      <div className="flex flex-col gap-2 overflow-y-auto flex-1 mt-2">
         {portfolioItems.length === 0 && !isLoading && (
           <p className="text-[11px] text-foreground-disabled text-center">보유 종목 없음</p>
         )}
-        {portfolioItems.map((item, i) => {
-          const color = CHART_COLORS[i % CHART_COLORS.length]
+        {sortedItems.map((item, i) => {
+          const color = getColor(item, i)
           return (
             <div key={item.label} className="flex items-center justify-between">
               <div className="flex items-center gap-2">

--- a/src/pages/AssetPage.jsx
+++ b/src/pages/AssetPage.jsx
@@ -190,8 +190,8 @@ function AssetFlowCard({ data }) {
         {bars.map((h, i) => (
           <div
             key={i}
-            className={`flex-1 rounded-sm ${isAccountProfit ? 'bg-up/40' : 'bg-down/40'}`}
-            style={{ height: `${h}%` }}
+            className={`flex-1 rounded-sm h-[var(--bar-h)] ${isAccountProfit ? 'bg-up/40' : 'bg-down/40'}`}
+            style={{ '--bar-h': `${h}%` }}
           />
         ))}
       </div>
@@ -316,12 +316,12 @@ function PortfolioPanel({ data }) {
       </div>
 
       {/* 도넛 차트 */}
-      <div className="relative shrink-0" style={{ height: 260 }}>
+      <div className="relative shrink-0 h-[260px]">
         {hasItems ? (
           <>
             <ReactECharts
               option={chartOption}
-              style={{ width: '100%', height: '100%' }}
+              className="w-full h-full"
               opts={{ renderer: 'svg' }}
             />
             <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
@@ -348,12 +348,12 @@ function PortfolioPanel({ data }) {
           return (
             <div key={item.label} className="flex items-center justify-between">
               <div className="flex items-center gap-2">
-                <div className="w-2.5 h-2.5 rounded-[3px] shrink-0" style={{ background: color }} />
+                <div className="w-2.5 h-2.5 rounded-[3px] shrink-0 bg-[var(--dot-color)]" style={{ '--dot-color': color }} />
                 <span className="text-[12px] text-foreground-secondary">{item.label}</span>
               </div>
               <div className="flex items-center gap-2">
                 <div className="w-[60px] h-1 rounded-full bg-surface-muted overflow-hidden">
-                  <div className="h-full rounded-full" style={{ width: `${item.weight}%`, background: color }} />
+                  <div className="h-full rounded-full w-[var(--bar-w)] bg-[var(--bar-color)]" style={{ '--bar-w': `${item.weight}%`, '--bar-color': color }} />
                 </div>
                 <span className="text-[11px] font-bold text-foreground w-8 text-right">{item.weight}%</span>
               </div>
@@ -370,10 +370,7 @@ function HoldingRow({ h }) {
   const { stockName, stockCode, marketType, qty, cur, avg, evalKrw, pnl, pnlRate, isUp, isKrw } = h
 
   return (
-    <div
-      className="grid items-center px-4 py-2.5 border-b border-stroke-subtle cursor-pointer hover:bg-surface-subtle transition-colors"
-      style={{ gridTemplateColumns: '1fr 80px 88px 108px' }}
-    >
+    <div className="grid grid-cols-[1fr_80px_88px_108px] items-center px-4 py-2.5 border-b border-stroke-subtle cursor-pointer hover:bg-surface-subtle transition-colors">
       <div className="flex items-center gap-2.5">
         <StockAvatar name={stockName} stockCode={stockCode} marketType={marketType} size="md" />
         <div className="min-w-0">
@@ -453,10 +450,7 @@ function HoldingsPanel({ data }) {
       </div>
 
       {/* 컬럼 헤더 */}
-      <div
-        className="shrink-0 grid items-center px-4 py-1.5 bg-surface-subtle border-b border-stroke text-[9px] font-semibold text-foreground-disabled"
-        style={{ gridTemplateColumns: '1fr 80px 88px 108px' }}
-      >
+      <div className="shrink-0 grid grid-cols-[1fr_80px_88px_108px] items-center px-4 py-1.5 bg-surface-subtle border-b border-stroke text-[9px] font-semibold text-foreground-disabled">
         <span>종목</span>
         <span className="text-right">수량 / 평균가</span>
         <span className="text-right">현재가</span>
@@ -480,10 +474,7 @@ function HoldingsPanel({ data }) {
 
       {/* 합계 */}
       {!isLoading && rows.length > 0 && (
-        <div
-          className="shrink-0 grid items-center px-4 py-2.5 bg-primary-light border-t-2 border-primary-dim"
-          style={{ gridTemplateColumns: '1fr 80px 88px 108px' }}
-        >
+        <div className="shrink-0 grid grid-cols-[1fr_80px_88px_108px] items-center px-4 py-2.5 bg-primary-light border-t-2 border-primary-dim">
           <div className="text-[12px] font-extrabold text-primary">합계</div>
           <div />
           <div className="text-right text-[12px] font-bold text-foreground">{fmt(totalEval)}원</div>

--- a/src/pages/AssetPage.jsx
+++ b/src/pages/AssetPage.jsx
@@ -28,7 +28,7 @@ function fmtRate(r) {
 
 // ── Hero 섹션 ─────────────────────────────────────────────────────
 function HeroSection({ data, user, onExchange }) {
-  const { isLoading, totalAssets, profit, profitRate, isProfit, krwDeposit, krwAvailable, usdBal } = data
+  const { isLoading, totalAssets, accountProfit, accountProfitRate, isAccountProfit, krwDeposit, krwAvailable, usdBal } = data
   const blank = isLoading ? '-' : null
 
   return (
@@ -45,11 +45,11 @@ function HeroSection({ data, user, onExchange }) {
             <span className="text-[13px] text-foreground-disabled">원</span>
           </div>
           <div className="flex items-center gap-1.5 mt-1.5">
-            <span className={`text-[13px] font-bold ${isProfit ? 'text-up' : 'text-down'}`}>
-              {blank ?? ((isProfit ? '+' : '') + fmt(Math.abs(profit ?? 0)) + '원')}
+            <span className={`text-[13px] font-bold ${isAccountProfit ? 'text-up' : 'text-down'}`}>
+              {blank ?? ((isAccountProfit ? '+' : '') + fmt(accountProfit ?? 0) + '원')}
             </span>
-            <span className={`text-[11px] font-semibold ${isProfit ? 'text-up' : 'text-down'}`}>
-              {blank ?? fmtRate(profitRate)}
+            <span className={`text-[11px] font-semibold ${isAccountProfit ? 'text-up' : 'text-down'}`}>
+              {blank ?? fmtRate(accountProfitRate)}
             </span>
           </div>
         </div>
@@ -173,7 +173,7 @@ function AssetBreakdownCard({ data }) {
 
 // ── 자산 흐름 카드 ────────────────────────────────────────────────
 function AssetFlowCard({ data }) {
-  const { tradeCount, profit, isProfit, isLoading } = data
+  const { tradeCount, accountProfit, isAccountProfit, isLoading } = data
 
   // 거래 횟수 기반 간단한 bar sparkline (시각적 표현)
   const bars = [28, 35, 30, 45, 40, 55, 50, 62, 58, 70, 65, 78, 72, 85, 80, 92, 88, 96, 90, 100]
@@ -190,7 +190,7 @@ function AssetFlowCard({ data }) {
         {bars.map((h, i) => (
           <div
             key={i}
-            className={`flex-1 rounded-sm ${isProfit ? 'bg-up/40' : 'bg-down/40'}`}
+            className={`flex-1 rounded-sm ${isAccountProfit ? 'bg-up/40' : 'bg-down/40'}`}
             style={{ height: `${h}%` }}
           />
         ))}
@@ -200,8 +200,8 @@ function AssetFlowCard({ data }) {
 
       <div className="flex items-center justify-between">
         <span className="text-[10px] text-foreground-disabled">총 평가손익</span>
-        <span className={`text-[14px] font-black ${isProfit ? 'text-up' : 'text-down'}`}>
-          {isLoading ? '-' : ((isProfit ? '+' : '') + fmt(Math.abs(profit ?? 0)) + '원')}
+        <span className={`text-[14px] font-black ${isAccountProfit ? 'text-up' : 'text-down'}`}>
+          {isLoading ? '-' : ((isAccountProfit ? '+' : '') + fmt(accountProfit ?? 0) + '원')}
         </span>
       </div>
     </div>
@@ -250,7 +250,7 @@ function useLogoColors(items) {
 
 // ── 포트폴리오 파이차트 패널 (하단 좌) ───────────────────────────
 function PortfolioPanel({ data }) {
-  const { portfolioItems, profitRate, isProfit, isLoading } = data
+  const { portfolioItems, stockProfitRate, isStockProfit, isLoading } = data
 
   const getColor = useLogoColors(portfolioItems)
   const hasItems = portfolioItems.length > 0
@@ -309,8 +309,8 @@ function PortfolioPanel({ data }) {
       <div className="flex items-center justify-between mb-2 shrink-0">
         <div className="text-[11px] font-bold text-foreground">포트폴리오</div>
         {!isLoading && (
-          <span className={`text-[11px] font-bold ${isProfit ? 'text-up' : 'text-down'}`}>
-            수익률 {fmtRate(profitRate)}
+          <span className={`text-[11px] font-bold ${isStockProfit ? 'text-up' : 'text-down'}`}>
+            수익률 {fmtRate(stockProfitRate)}
           </span>
         )}
       </div>
@@ -325,8 +325,8 @@ function PortfolioPanel({ data }) {
               opts={{ renderer: 'svg' }}
             />
             <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
-              <span className={`text-[15px] font-black ${isProfit ? 'text-up' : 'text-down'}`}>
-                {isLoading ? '-' : fmtRate(profitRate)}
+              <span className={`text-[15px] font-black ${isStockProfit ? 'text-up' : 'text-down'}`}>
+                {isLoading ? '-' : fmtRate(stockProfitRate)}
               </span>
               <span className="text-[9px] text-foreground-disabled mt-0.5">수익률</span>
             </div>

--- a/src/pages/InvestPage.jsx
+++ b/src/pages/InvestPage.jsx
@@ -3,8 +3,14 @@ import { useLocation, useParams } from 'react-router-dom'
 import InvestBottomPanels from '@/components/invest/InvestBottomPanels'
 import InvestOrderSection from '@/components/invest/InvestOrderSection'
 import InvestStockOverview from '@/components/invest/InvestStockOverview'
+import {
+  DISPLAY_CURRENCY,
+  FALLBACK_USD_RATE,
+  isForeignMarketType,
+} from '@/features/invest/formatters'
 import useInvestMarketData from '@/features/invest/useInvestMarketData'
 import { INVEST_STOCK } from '@/mocks/invest'
+import useCurrencyStore from '@/store/useCurrencyStore'
 
 export default function InvestPage() {
   const { stockCode: routeStockCode } = useParams()
@@ -41,6 +47,21 @@ export default function InvestPage() {
     onLoadMoreChartHistory,
     onMinuteIntervalChange,
   } = useInvestMarketData(stockCode, locationState, { activeLeftTab: leftTab })
+  const marketType = stockMeta.marketType ?? stockMeta.market
+  const isForeignMarket = isForeignMarketType(marketType)
+  const usdRate = useCurrencyStore((s) => s.rates.USD?.rate ?? FALLBACK_USD_RATE)
+  const defaultDisplayCurrency = isForeignMarket ? DISPLAY_CURRENCY.USD : DISPLAY_CURRENCY.KRW
+  const [displayCurrencyOverrides, setDisplayCurrencyOverrides] = useState({})
+  const displayCurrency = isForeignMarket
+    ? (displayCurrencyOverrides[stockCode] ?? defaultDisplayCurrency)
+    : DISPLAY_CURRENCY.KRW
+
+  function handleDisplayCurrencyChange(nextCurrency) {
+    setDisplayCurrencyOverrides((prev) => ({
+      ...prev,
+      [stockCode]: nextCurrency,
+    }))
+  }
 
   return (
     <div className="h-full overflow-x-auto bg-surface">
@@ -64,21 +85,27 @@ export default function InvestPage() {
             onMinuteIntervalChange={onMinuteIntervalChange}
             isLoading={marketLoading}
             errorMessage={marketErrorMessage}
+            displayCurrency={displayCurrency}
+            usdRate={usdRate}
+            onDisplayCurrencyChange={handleDisplayCurrencyChange}
           />
 
           <InvestOrderSection
             key={stockCode}
             stockCode={stockCode}
-            marketType={stockMeta.market}
+            marketType={marketType}
             stockName={stockMeta.name}
             currentPrice={currentPrice}
             changeRate={changeRate}
             defaultPrice={currentPrice ?? stockMeta.price}
             orderBook={orderBook}
+            displayCurrency={displayCurrency}
+            usdRate={usdRate}
           />
         </div>
 
         <InvestBottomPanels
+          stockCode={stockCode}
           leftTab={leftTab}
           rightTab={rightTab}
           dailyRows={dailyRows}
@@ -92,6 +119,9 @@ export default function InvestPage() {
           errorMessage={marketErrorMessage}
           onLeftTabChange={setLeftTab}
           onRightTabChange={setRightTab}
+          marketType={marketType}
+          displayCurrency={displayCurrency}
+          usdRate={usdRate}
         />
       </div>
     </div>

--- a/src/pages/MarketPage.jsx
+++ b/src/pages/MarketPage.jsx
@@ -52,16 +52,21 @@ function MarketIndexBar() {
 
 function FilterBar({ marketFilter, setMarketFilter, sortFilter, setSortFilter }) {
   return (
-    <div className="flex items-center gap-2 px-4 py-2 border-b border-stroke shrink-0 bg-surface">
-      <div className="flex gap-1 shrink-0">
-        {MARKET_FILTERS.map(({ key, label }) => (
-          <FilterChip key={key} isActive={marketFilter === key} onClick={() => setMarketFilter(key)}>
-            {label}
-          </FilterChip>
-        ))}
-      </div>
-      <div className="w-px h-4 bg-stroke-input shrink-0" />
-      <div className="flex gap-1 shrink-0">
+    <div className="flex items-center gap-3 px-4 py-1.5 border-b border-stroke shrink-0 bg-surface">
+      {MARKET_FILTERS.map(({ key, label }) => (
+        <button
+          key={key}
+          onClick={() => setMarketFilter(key)}
+          className={`text-[12px] font-semibold pb-1 border-b-2 transition-colors ${
+            marketFilter === key
+              ? 'text-foreground border-primary'
+              : 'text-foreground-disabled border-transparent hover:text-foreground'
+          }`}
+        >
+          {label}
+        </button>
+      ))}
+      <div className="ml-auto flex items-center gap-1.5">
         {SORT_FILTERS.map(({ key, label }) => (
           <FilterChip key={key} isActive={sortFilter === key} onClick={() => setSortFilter(key)}>
             {label}
@@ -72,15 +77,15 @@ function FilterBar({ marketFilter, setMarketFilter, sortFilter, setSortFilter })
   )
 }
 
-const GRID_WITH_VOL    = 'grid-cols-[32px_36px_1fr_110px_80px_88px_120px]'
-const GRID_WITHOUT_VOL = 'grid-cols-[32px_36px_1fr_110px_80px_120px]'
+const GRID_WITH_VOL    = 'grid-cols-[32px_40px_2fr_1.5fr_1fr_1fr_1.5fr]'
+const GRID_WITHOUT_VOL = 'grid-cols-[32px_40px_2fr_1.5fr_1fr_1.5fr]'
 
 function StockTableHeader({ sortFilter }) {
   const showVolume = sortFilter in VOLUME_COL_LABEL
   const grid = showVolume ? GRID_WITH_VOL : GRID_WITHOUT_VOL
 
   return (
-    <div className={`grid ${grid} items-center px-4 py-2 bg-surface-subtle border-b border-stroke text-[10px] font-semibold text-foreground-disabled`}>
+    <div className={`grid ${grid} items-center px-4 py-2.5 border-b border-stroke-subtle text-[10px] font-semibold text-foreground-disabled`}>
       <div />
       <div>순위</div>
       <div>종목명</div>

--- a/src/pages/MarketPage.jsx
+++ b/src/pages/MarketPage.jsx
@@ -25,12 +25,12 @@ function MarketIndexBar() {
   const { indices } = useMarketIndices()
 
   return (
-    <div className="flex items-center border-b border-stroke shrink-0 overflow-x-auto bg-surface">
+    <div className="flex items-center border-b border-stroke shrink-0 bg-surface">
       {indices.map((idx) => {
         return (
           <div
             key={idx.code}
-            className="flex items-center gap-2.5 px-4 py-2.5 shrink-0 border-r border-stroke-subtle"
+            className="flex-1 flex items-center gap-2.5 px-4 py-2.5 border-r border-stroke-subtle last:border-r-0"
           >
             <div>
               <div className="text-[10px] font-semibold text-foreground-disabled mb-0.5">{idx.name}</div>


### PR DESCRIPTION
## 변경 사항

### 잔고 페이지 (AssetPage)
- ECharts 도넛 차트로 포트폴리오 시각화 (보유 종목 PNG에서 대표 색상 자동 추출)
- 현금 항목 차트에서 제외, 보유 종목만 표시
- 차트 툴팁 디자인 토큰 기준으로 커스텀
- 헤더 손익/수익률: `accountProfitLoss` / `accountProfitLossRate` (초기금 1억 대비) 사용
- 포트폴리오 차트 수익률: `totalStockUnrealizedProfitLossRate` (매입금 대비) 분리
- 손익 금액 음수 부호 누락 수정 (`Math.abs` 제거)
- KRW 금액 소수점 제거 (`Math.round`)

### 투자 페이지 (InvestPage)
- 차트 크로스헤어 시간 UTC → KST 변환
- 일별시세 테이블 오늘 행 WebSocket 실시간 반영
- `changeAmount` 부호 수정 (LS US3 `change`는 절댓값, `sign` 필드로 방향 판별)
- 등락률 괄호 표기 주문 패널에만 적용 (`paren` prop)
- 국내 주식 변동 금액에 `원` 단위 표시
- 로그아웃 시 패널 채팅으로 전환 및 WebSocket 재시도 루프 방지

### 마켓 페이지 (MarketPage)
- 필터바: 국내/미국 언더라인 탭으로 변경, 정렬 칩 오른쪽 끝 배치
- 테이블 그리드 fr 비율로 변경하여 컬럼 균등 분배
- 지수바 전체 너비 균등 분배

## 테스트 체크리스트
- [ ] 잔고 페이지 도넛 차트 색상 및 툴팁 확인
- [ ] 헤더 손익/수익률 백엔드 값 일치 확인
- [ ] 마켓 페이지 필터바 및 테이블 레이아웃 확인
- [ ] 로그아웃 후 패널 상태 및 데이터 잔존 없음 확인