### PR TITLE
feat(notifications): 알림센터 구현

### DIFF
--- a/src/api/notification.js
+++ b/src/api/notification.js
@@ -1,0 +1,26 @@
+import { fetchWithAuth } from '@/lib/fetchWithAuth'
+
+function get(path) {
+  return fetchWithAuth(path)
+}
+
+function put(path, body) {
+  return fetchWithAuth(path, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function patch(path) {
+  return fetchWithAuth(path, { method: 'PATCH' })
+}
+
+export const notificationApi = {
+  getNotifications:       () => get('/api/notifications'),
+  getUnreadCount:         () => get('/api/notifications/unread-count'),
+  markAsRead:     (id)    => patch(`/api/notifications/${id}/read`),
+  markAllAsRead:          () => patch('/api/notifications/read-all'),
+  getSettings:            () => get('/api/notifications/settings'),
+  updateSettings: (body)  => put('/api/notifications/settings', body),
+}

--- a/src/components/layout/AppHeader.jsx
+++ b/src/components/layout/AppHeader.jsx
@@ -7,6 +7,7 @@ import useRightPanelStore from '@/store/useRightPanelStore'
 import useEditModeStore from '@/store/useEditModeStore'
 import useWidgetStore from '@/store/useWidgetStore'
 import { useDashboardSave } from '@/hooks/useDashboardSync'
+import NotificationCenter from '@/components/ui/NotificationCenter'
 
 function Logo() {
   return (
@@ -130,6 +131,7 @@ export default function AppHeader() {
       <NavTabs />
       <div className="flex-1" />
       {isHome && (isEditMode ? <EditModeActions /> : <WidgetEditButton />)}
+      <NotificationCenter />
       <UserArea />
     </header>
   )

--- a/src/components/ui/NotificationCenter.jsx
+++ b/src/components/ui/NotificationCenter.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { Bell, Settings2, CheckCheck, Loader } from 'lucide-react'
+import { Bell, Settings2, CheckCheck, Loader2 } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import useAuthStore from '@/store/useAuthStore'
 import useNotificationStore from '@/store/useNotificationStore'
@@ -37,7 +37,7 @@ function NotificationItem({ notification, onClose }) {
     >
       <div className="flex items-start gap-2.5">
         <span
-          className={`mt-[7px] w-1.5 h-1.5 rounded-full shrink-0 ${!notification.read ? 'bg-primary' : 'bg-transparent'}`}
+          className={`mt-2 w-1.5 h-1.5 rounded-full shrink-0 ${!notification.read ? 'bg-primary' : 'bg-transparent'}`}
         />
         <div className="min-w-0">
           <p className="text-[13px] font-semibold text-foreground leading-snug truncate">
@@ -133,7 +133,7 @@ export default function NotificationCenter() {
 
       {/* 드롭다운 — z-[60]: 헤더(z-50) 위, 모달 아래 */}
       {isOpen && (
-        <div className="absolute right-0 top-full mt-2 w-80 bg-surface rounded-xl border border-stroke shadow-lg z-[60] overflow-hidden">
+        <div className="absolute right-0 top-full mt-2 w-80 bg-surface rounded-xl border border-stroke shadow-dropdown z-[60] overflow-hidden">
           {/* 헤더 */}
           <div className="flex items-center justify-between px-4 py-3 border-b border-stroke">
             <span className="text-[14px] font-bold text-foreground">알림센터</span>
@@ -161,7 +161,7 @@ export default function NotificationCenter() {
           <div className="max-h-80 overflow-y-auto">
             {isLoading ? (
               <div className="py-10 flex justify-center">
-                <Loader className="w-4 h-4 text-foreground-disabled animate-spin" strokeWidth={2} />
+                <Loader2 className="w-4 h-4 text-foreground-disabled animate-spin" strokeWidth={2} />
               </div>
             ) : notifications.length === 0 ? (
               <div className="py-10 text-center text-[13px] text-foreground-disabled">

--- a/src/components/ui/NotificationCenter.jsx
+++ b/src/components/ui/NotificationCenter.jsx
@@ -1,0 +1,184 @@
+import { useEffect, useRef } from 'react'
+import { Bell, Settings2, CheckCheck, Loader } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
+import useAuthStore from '@/store/useAuthStore'
+import useNotificationStore from '@/store/useNotificationStore'
+import useStompSubscription from '@/hooks/useStompSubscription'
+
+function timeAgo(dateStr) {
+  if (!dateStr) return ''
+  const diffMs = Date.now() - new Date(dateStr).getTime()
+  const diffMin = Math.floor(diffMs / 60000)
+  if (diffMin < 1) return '방금 전'
+  if (diffMin < 60) return `${diffMin}분 전`
+  const diffH = Math.floor(diffMin / 60)
+  if (diffH < 24) return `${diffH}시간 전`
+  return `${Math.floor(diffH / 24)}일 전`
+}
+
+function NotificationItem({ notification, onClose }) {
+  const navigate = useNavigate()
+  const markAsRead = useNotificationStore((s) => s.markAsRead)
+
+  function handleClick() {
+    if (!notification.read) {
+      markAsRead(notification.notificationId)
+    }
+    if (notification.notificationType === 'PRICE_ALERT' && notification.referenceId) {
+      navigate(`/invest/${notification.referenceId}`)
+      onClose()
+    }
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      className={`w-full text-left px-4 py-3 hover:bg-surface-muted transition-colors border-b border-stroke-subtle last:border-0 ${!notification.read ? 'bg-primary-light/50' : ''}`}
+    >
+      <div className="flex items-start gap-2.5">
+        <span
+          className={`mt-[7px] w-1.5 h-1.5 rounded-full shrink-0 ${!notification.read ? 'bg-primary' : 'bg-transparent'}`}
+        />
+        <div className="min-w-0">
+          <p className="text-[13px] font-semibold text-foreground leading-snug truncate">
+            {notification.title}
+          </p>
+          <p className="text-[12px] text-foreground-secondary mt-0.5 leading-snug">
+            {notification.message}
+          </p>
+          <p className="text-[11px] text-foreground-disabled mt-1">
+            {timeAgo(notification.createdAt)}
+          </p>
+        </div>
+      </div>
+    </button>
+  )
+}
+
+export default function NotificationCenter() {
+  const navigate = useNavigate()
+  const { isAuthenticated, user } = useAuthStore()
+  const {
+    notifications,
+    unreadCount,
+    isOpen,
+    isLoading,
+    setOpen,
+    fetchNotifications,
+    fetchUnreadCount,
+    addNotification,
+    markAllAsRead,
+    reset,
+  } = useNotificationStore()
+
+  const dropdownRef = useRef(null)
+
+  // 실시간 알림 수신 (기존 useStompSubscription 훅 활용)
+  const topic = isAuthenticated && user?.userId ? `/topic/notifications/${user.userId}` : null
+  const latestNotification = useStompSubscription(topic)
+
+  useEffect(() => {
+    if (latestNotification) {
+      addNotification(latestNotification)
+    }
+  }, [latestNotification, addNotification])
+
+  // 로그인 시 미읽은 수 초기 조회, 로그아웃 시 상태 초기화
+  useEffect(() => {
+    if (isAuthenticated && user?.userId) {
+      fetchUnreadCount()
+    } else {
+      reset()
+    }
+  }, [isAuthenticated, user?.userId, fetchUnreadCount, reset])
+
+  // 드롭다운 열릴 때 목록 로드
+  useEffect(() => {
+    if (isOpen && isAuthenticated) {
+      fetchNotifications()
+    }
+  }, [isOpen, isAuthenticated, fetchNotifications])
+
+  // 외부 클릭 시 닫기
+  useEffect(() => {
+    if (!isOpen) return
+    function handleClickOutside(e) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [isOpen, setOpen])
+
+  if (!isAuthenticated) return null
+
+  const badge = unreadCount > 99 ? '99+' : unreadCount > 0 ? String(unreadCount) : null
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      {/* 종 아이콘 버튼 */}
+      <button
+        onClick={() => setOpen(!isOpen)}
+        className="relative flex items-center justify-center w-8 h-8 rounded-lg hover:bg-surface-muted transition-colors"
+        aria-label="알림센터"
+      >
+        <Bell className="w-4 h-4 text-foreground-secondary" strokeWidth={2} />
+        {badge && (
+          <span className="absolute -top-1 -right-1 min-w-[16px] h-4 px-0.5 rounded-full bg-danger text-white text-[10px] font-bold flex items-center justify-center leading-none">
+            {badge}
+          </span>
+        )}
+      </button>
+
+      {/* 드롭다운 — z-[60]: 헤더(z-50) 위, 모달 아래 */}
+      {isOpen && (
+        <div className="absolute right-0 top-full mt-2 w-80 bg-surface rounded-xl border border-stroke shadow-lg z-[60] overflow-hidden">
+          {/* 헤더 */}
+          <div className="flex items-center justify-between px-4 py-3 border-b border-stroke">
+            <span className="text-[14px] font-bold text-foreground">알림센터</span>
+            <div className="flex items-center gap-0.5">
+              {unreadCount > 0 && (
+                <button
+                  onClick={markAllAsRead}
+                  className="flex items-center gap-1 px-2 py-1 rounded-lg text-[11px] text-foreground-tertiary hover:bg-surface-muted transition-colors"
+                >
+                  <CheckCheck className="w-3.5 h-3.5" strokeWidth={2} />
+                  모두 읽음
+                </button>
+              )}
+              <button
+                onClick={() => { setOpen(false); navigate('/notifications/settings') }}
+                className="p-1.5 rounded-lg text-foreground-tertiary hover:bg-surface-muted transition-colors"
+                aria-label="알림 설정"
+              >
+                <Settings2 className="w-3.5 h-3.5" strokeWidth={2} />
+              </button>
+            </div>
+          </div>
+
+          {/* 알림 목록 */}
+          <div className="max-h-80 overflow-y-auto">
+            {isLoading ? (
+              <div className="py-10 flex justify-center">
+                <Loader className="w-4 h-4 text-foreground-disabled animate-spin" strokeWidth={2} />
+              </div>
+            ) : notifications.length === 0 ? (
+              <div className="py-10 text-center text-[13px] text-foreground-disabled">
+                새로운 알림이 없습니다
+              </div>
+            ) : (
+              notifications.map((n) => (
+                <NotificationItem
+                  key={n.notificationId}
+                  notification={n}
+                  onClose={() => setOpen(false)}
+                />
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/pages/NotificationSettingsPage.jsx
+++ b/src/pages/NotificationSettingsPage.jsx
@@ -1,0 +1,247 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { ArrowLeft, Check } from 'lucide-react'
+import { notificationApi } from '@/api/notification'
+import useAuthStore from '@/store/useAuthStore'
+
+const THRESHOLD_OPTIONS = [1, 3, 5, 10, 15, 20]
+
+const TOGGLE_ITEMS = [
+  { key: 'priceAlertEnabled', label: '가격 변동 알림', desc: '설정한 기준 이상 가격 변동 시 알림' },
+  { key: 'executionAlertEnabled', label: '체결 알림', desc: '매수/매도 주문 체결 시 알림' },
+]
+
+function Toggle({ checked, onChange }) {
+  return (
+    <button
+      role="switch"
+      aria-checked={checked}
+      onClick={onChange}
+      className={`relative w-10 h-[22px] rounded-full transition-colors duration-200 ${checked ? 'bg-primary' : 'bg-stroke-input'}`}
+    >
+      <span
+        className={`absolute top-[2px] left-[2px] w-[18px] h-[18px] rounded-full bg-white shadow-sm transition-transform duration-200 ${checked ? 'translate-x-[18px]' : 'translate-x-0'}`}
+      />
+    </button>
+  )
+}
+
+export default function NotificationSettingsPage() {
+  const navigate = useNavigate()
+  const { isAuthenticated } = useAuthStore()
+
+  const [settings, setSettings] = useState({
+    priceAlertEnabled: true,
+    executionAlertEnabled: true,
+    defaultThresholdPercent: 5,
+  })
+  const [isCustom, setIsCustom] = useState(false)
+  const [customValue, setCustomValue] = useState('')
+  const [allOffWarning, setAllOffWarning] = useState(false)
+  const [loadError, setLoadError] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+  const [saveError, setSaveError] = useState('')
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      navigate('/', { replace: true })
+      return
+    }
+    notificationApi.getSettings()
+      .then((data) => {
+        const threshold = parseFloat(data.defaultThresholdPercent)
+        setSettings({
+          priceAlertEnabled: data.priceAlertEnabled,
+          executionAlertEnabled: data.executionAlertEnabled,
+          defaultThresholdPercent: threshold,
+        })
+        if (!THRESHOLD_OPTIONS.includes(threshold)) {
+          setIsCustom(true)
+          setCustomValue(String(data.defaultThresholdPercent))
+        }
+      })
+      .catch((err) => {
+        console.warn('[Notification] 설정 조회 실패:', err?.message)
+        setLoadError(true)
+      })
+  }, [isAuthenticated, navigate])
+
+  function handleToggle(key) {
+    const next = { ...settings, [key]: !settings[key] }
+    const anyOn = next.priceAlertEnabled || next.executionAlertEnabled
+    setAllOffWarning(!anyOn)
+    setSettings(next)
+  }
+
+  function selectThreshold(val) {
+    setIsCustom(false)
+    setSaveError('')
+    setSettings((s) => ({ ...s, defaultThresholdPercent: val }))
+  }
+
+  function handleCustomChange(val) {
+    setCustomValue(val)
+    setSettings((s) => ({ ...s, defaultThresholdPercent: parseFloat(val) || 0 }))
+  }
+
+  async function handleSave() {
+    const percent = settings.defaultThresholdPercent
+    if (!percent || percent < 0.01 || percent > 99.99) {
+      setSaveError('유효한 범위를 입력해주세요 (0.01 ~ 99.99)')
+      return
+    }
+    setSaveError('')
+    setSaving(true)
+    try {
+      await notificationApi.updateSettings({
+        priceAlertEnabled: settings.priceAlertEnabled,
+        executionAlertEnabled: settings.executionAlertEnabled,
+        defaultThresholdPercent: percent,
+      })
+      setSaved(true)
+      setTimeout(() => setSaved(false), 2000)
+    } catch (err) {
+      console.warn('[Notification] 설정 저장 실패:', err?.message)
+      setSaveError('설정 저장에 실패했습니다.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loadError) {
+    return (
+      <div className="max-w-lg mx-auto px-4 py-8">
+        <div className="flex items-center gap-3 mb-8">
+          <button onClick={() => navigate(-1)} className="p-1.5 rounded-lg hover:bg-surface-muted transition-colors">
+            <ArrowLeft className="w-5 h-5 text-foreground-secondary" strokeWidth={2} />
+          </button>
+          <h1 className="text-[18px] font-bold text-foreground">알림 설정</h1>
+        </div>
+        <div className="bg-surface rounded-xl border border-stroke px-4 py-10 text-center">
+          <p className="text-[13px] text-foreground-secondary">설정을 불러오지 못했습니다.</p>
+          <button
+            onClick={() => { setLoadError(false); navigate(0) }}
+            className="mt-3 text-[13px] text-primary hover:underline"
+          >
+            다시 시도
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-lg mx-auto px-4 py-8">
+      {/* 상단 */}
+      <div className="flex items-center gap-3 mb-8">
+        <button
+          onClick={() => navigate(-1)}
+          className="p-1.5 rounded-lg hover:bg-surface-muted transition-colors"
+        >
+          <ArrowLeft className="w-5 h-5 text-foreground-secondary" strokeWidth={2} />
+        </button>
+        <h1 className="text-[18px] font-bold text-foreground">알림 설정</h1>
+      </div>
+
+      {/* 알림 유형별 토글 */}
+      <section className="bg-surface rounded-xl border border-stroke overflow-hidden mb-4">
+        <div className="px-4 py-3 border-b border-stroke-subtle">
+          <p className="text-[13px] font-semibold text-foreground">알림 유형</p>
+        </div>
+        {TOGGLE_ITEMS.map(({ key, label, desc }) => (
+          <div
+            key={key}
+            className="flex items-center justify-between px-4 py-3.5 border-b border-stroke-subtle last:border-0"
+          >
+            <div>
+              <p className="text-[13px] font-medium text-foreground">{label}</p>
+              <p className="text-[12px] text-foreground-tertiary mt-0.5">{desc}</p>
+            </div>
+            <Toggle checked={settings[key]} onChange={() => handleToggle(key)} />
+          </div>
+        ))}
+      </section>
+
+      {allOffWarning && (
+        <p className="text-[12px] text-warning mb-4 px-1">
+          모든 알림이 비활성화됩니다. 최소 하나 이상 켜두는 것을 권장합니다.
+        </p>
+      )}
+
+      {/* 가격 변동 알림 기준 */}
+      <section className="bg-surface rounded-xl border border-stroke overflow-hidden mb-6">
+        <div className="px-4 py-3 border-b border-stroke-subtle">
+          <p className="text-[13px] font-semibold text-foreground">관심 종목 가격 변동 알림 기준</p>
+          <p className="text-[12px] text-foreground-tertiary mt-0.5">
+            전일 대비 변동률이 해당 값 이상일 때 알림을 받습니다
+          </p>
+        </div>
+        <div className="px-4 py-4">
+          <div className="flex flex-wrap gap-2 mb-3">
+            {THRESHOLD_OPTIONS.map((opt) => {
+              const selected = !isCustom && settings.defaultThresholdPercent === opt
+              return (
+                <button
+                  key={opt}
+                  onClick={() => selectThreshold(opt)}
+                  className={`px-3 py-1.5 rounded-lg text-[12px] font-medium border transition-colors ${
+                    selected
+                      ? 'bg-primary text-white border-primary'
+                      : 'border-stroke-input text-foreground-secondary hover:border-primary hover:text-primary hover:bg-primary-light'
+                  }`}
+                >
+                  ±{opt}%
+                </button>
+              )
+            })}
+            <button
+              onClick={() => { setIsCustom(true); setCustomValue(String(settings.defaultThresholdPercent)) }}
+              className={`px-3 py-1.5 rounded-lg text-[12px] font-medium border transition-colors ${
+                isCustom
+                  ? 'bg-primary text-white border-primary'
+                  : 'border-stroke-input text-foreground-secondary hover:border-primary hover:text-primary hover:bg-primary-light'
+              }`}
+            >
+              직접 입력
+            </button>
+          </div>
+
+          {isCustom && (
+            <div className="flex items-center gap-2">
+              <input
+                type="number"
+                value={customValue}
+                onChange={(e) => handleCustomChange(e.target.value)}
+                placeholder="예: 7.5"
+                min="0.01"
+                max="99.99"
+                step="0.01"
+                className="w-36 px-3 py-2 rounded-lg border border-stroke-input text-[13px] text-foreground placeholder:text-foreground-disabled focus:outline-none focus:border-primary"
+              />
+              <span className="text-[13px] text-foreground-secondary">%</span>
+            </div>
+          )}
+
+          {saveError && (
+            <p className="text-[12px] text-danger mt-2">{saveError}</p>
+          )}
+        </div>
+      </section>
+
+      {/* 저장 버튼 */}
+      <button
+        onClick={handleSave}
+        disabled={saving}
+        className="w-full py-3 rounded-xl bg-primary text-white text-[14px] font-semibold hover:bg-primary-hover transition-colors disabled:opacity-50 shadow-primary-btn"
+      >
+        {saved ? (
+          <span className="flex items-center justify-center gap-1.5">
+            <Check className="w-4 h-4" strokeWidth={2.5} />
+            저장 완료
+          </span>
+        ) : saving ? '저장 중…' : '설정 저장'}
+      </button>
+    </div>
+  )
+}

--- a/src/pages/NotificationSettingsPage.jsx
+++ b/src/pages/NotificationSettingsPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ArrowLeft, Check } from 'lucide-react'
 import { notificationApi } from '@/api/notification'
@@ -41,7 +41,12 @@ export default function NotificationSettingsPage() {
   const [loadError, setLoadError] = useState(false)
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
+  const savedTimerRef = useRef(null)
   const [saveError, setSaveError] = useState('')
+
+  useEffect(() => {
+    return () => clearTimeout(savedTimerRef.current)
+  }, [])
 
   useEffect(() => {
     if (!isAuthenticated) {
@@ -100,7 +105,8 @@ export default function NotificationSettingsPage() {
         defaultThresholdPercent: percent,
       })
       setSaved(true)
-      setTimeout(() => setSaved(false), 2000)
+      clearTimeout(savedTimerRef.current)
+      savedTimerRef.current = setTimeout(() => setSaved(false), 2000)
     } catch (err) {
       console.warn('[Notification] 설정 저장 실패:', err?.message)
       setSaveError('설정 저장에 실패했습니다.')

--- a/src/pages/NotificationSettingsPage.jsx
+++ b/src/pages/NotificationSettingsPage.jsx
@@ -113,7 +113,7 @@ export default function NotificationSettingsPage() {
     return (
       <div className="max-w-lg mx-auto px-4 py-8">
         <div className="flex items-center gap-3 mb-8">
-          <button onClick={() => navigate(-1)} className="p-1.5 rounded-lg hover:bg-surface-muted transition-colors">
+          <button onClick={() => navigate(-1)} aria-label="뒤로" className="p-1.5 rounded-lg hover:bg-surface-muted transition-colors">
             <ArrowLeft className="w-5 h-5 text-foreground-secondary" strokeWidth={2} />
           </button>
           <h1 className="text-[18px] font-bold text-foreground">알림 설정</h1>
@@ -137,6 +137,7 @@ export default function NotificationSettingsPage() {
       <div className="flex items-center gap-3 mb-8">
         <button
           onClick={() => navigate(-1)}
+          aria-label="뒤로"
           className="p-1.5 rounded-lg hover:bg-surface-muted transition-colors"
         >
           <ArrowLeft className="w-5 h-5 text-foreground-secondary" strokeWidth={2} />

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -4,6 +4,7 @@ import HomePage from '@/pages/HomePage'
 import MarketPage from '@/pages/MarketPage'
 import InvestPage from '@/pages/InvestPage'
 import AssetPage from '@/pages/AssetPage'
+import NotificationSettingsPage from '@/pages/NotificationSettingsPage'
 import SignupPage from '@/pages/auth/SignupPage'
 import EmailVerifyPage from '@/pages/auth/EmailVerifyPage'
 import PasswordResetPage from '@/pages/auth/PasswordResetPage'
@@ -21,6 +22,7 @@ export const router = createBrowserRouter([
       { path: 'asset',      element: <AssetPage /> },
       { path: 'password/reset', element: <PasswordResetPage /> },
       { path: 'account/pin/reset', element: <PinResetPage /> },
+      { path: 'notifications/settings', element: <NotificationSettingsPage /> },
     ],
   },
   { path: '/signup',            element: <SignupPage /> },

--- a/src/store/useNotificationStore.js
+++ b/src/store/useNotificationStore.js
@@ -1,0 +1,75 @@
+import { create } from 'zustand'
+import { notificationApi } from '@/api/notification'
+
+const useNotificationStore = create((set, get) => ({
+  notifications: [],
+  unreadCount: 0,
+  isOpen: false,
+  isLoading: false,
+
+  setOpen: (open) => set({ isOpen: open }),
+
+  reset: () => set({ notifications: [], unreadCount: 0, isOpen: false, isLoading: false }),
+
+  fetchNotifications: async () => {
+    set({ isLoading: true })
+    try {
+      const data = await notificationApi.getNotifications()
+      set((state) => {
+        // STOMP으로 받은 알림 중 API 응답에 없는 것(아직 DB 미반영)은 보존
+        const apiIds = new Set(data.map((n) => n.notificationId))
+        const stompOnly = state.notifications.filter((n) => !apiIds.has(n.notificationId))
+        return { notifications: [...stompOnly, ...data], isLoading: false }
+      })
+    } catch (err) {
+      console.warn('[Notification] 알림 목록 조회 실패:', err?.message)
+      set({ isLoading: false })
+    }
+  },
+
+  fetchUnreadCount: async () => {
+    try {
+      const data = await notificationApi.getUnreadCount()
+      set({ unreadCount: data.unreadCount ?? 0 })
+    } catch (err) {
+      console.warn('[Notification] 미읽은 수 조회 실패:', err?.message)
+    }
+  },
+
+  addNotification: (notification) => {
+    set((state) => ({
+      notifications: [notification, ...state.notifications],
+      unreadCount: state.unreadCount + 1,
+    }))
+  },
+
+  markAsRead: async (notificationId) => {
+    const target = get().notifications.find((n) => n.notificationId === notificationId)
+    const wasUnread = target && !target.read
+    try {
+      await notificationApi.markAsRead(notificationId)
+      set((state) => ({
+        notifications: state.notifications.map((n) =>
+          n.notificationId === notificationId ? { ...n, read: true } : n,
+        ),
+        unreadCount: wasUnread ? Math.max(0, state.unreadCount - 1) : state.unreadCount,
+      }))
+    } catch (err) {
+      console.warn('[Notification] 읽음 처리 실패:', err?.message)
+    }
+  },
+
+  markAllAsRead: async () => {
+    try {
+      await notificationApi.markAllAsRead()
+      set((state) => ({
+        notifications: state.notifications.map((n) => ({ ...n, read: true })),
+        unreadCount: 0,
+      }))
+    } catch (err) {
+      console.warn('[Notification] 전체 읽음 처리 실패:', err?.message)
+    }
+  },
+}))
+
+export default useNotificationStore

--- a/src/store/useNotificationStore.js
+++ b/src/store/useNotificationStore.js
@@ -43,20 +43,18 @@ const useNotificationStore = create((set, get) => ({
     }))
   },
 
-  markAsRead: async (notificationId) => {
+  markAsRead: (notificationId) => {
     const target = get().notifications.find((n) => n.notificationId === notificationId)
     const wasUnread = target && !target.read
-    try {
-      await notificationApi.markAsRead(notificationId)
-      set((state) => ({
-        notifications: state.notifications.map((n) =>
-          n.notificationId === notificationId ? { ...n, read: true } : n,
-        ),
-        unreadCount: wasUnread ? Math.max(0, state.unreadCount - 1) : state.unreadCount,
-      }))
-    } catch (err) {
+    set((state) => ({
+      notifications: state.notifications.map((n) =>
+        n.notificationId === notificationId ? { ...n, read: true } : n,
+      ),
+      unreadCount: wasUnread ? Math.max(0, state.unreadCount - 1) : state.unreadCount,
+    }))
+    notificationApi.markAsRead(notificationId).catch((err) => {
       console.warn('[Notification] 읽음 처리 실패:', err?.message)
-    }
+    })
   },
 
   markAllAsRead: async () => {


### PR DESCRIPTION
## 구현 내용

### 신규 파일
| 파일 | 설명 |
|------|------|
| `src/api/notification.js` | 알림 관련 API 함수 모음 (목록/미읽은 수/읽음 처리/설정) |
| `src/store/useNotificationStore.js` | 알림 전역 상태 관리 (Zustand) |
| `src/components/ui/NotificationCenter.jsx` | 헤더 알림 아이콘 + 드롭다운 UI |
| `src/pages/NotificationSettingsPage.jsx` | 알림 설정 페이지 |

### 기능
- 헤더 종 아이콘, 읽지 않은 알림 개수 뱃지 (99+ 처리)
- 드롭다운: 알림 목록, 단건/전체 읽음, 알림 설정 진입, 로딩 스피너
- STOMP `/topic/notifications/{userId}` 실시간 알림 수신 (`useStompSubscription` 훅 사용)
- 가격 변동 알림 클릭 시 해당 종목 투자 화면으로 이동
- 알림 설정 페이지: 가격 변동·체결 알림 유형별 토글, 관심 종목 가격 변동 알림 기준(%) 설정
- 새로고침 후에도 미읽은 수 복원 (`fetchUnreadCount` on auth restore)
- 로그아웃 시 알림 상태 초기화

### 기존 코드 변경
| 파일 | 변경 내용 |
|------|-----------|
| `src/components/layout/AppHeader.jsx` | `<NotificationCenter />` 추가 |
| `src/router.jsx` | `/notifications/settings` 라우트 추가 |

---

## 체크리스트
- [x] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항
- STOMP 수신 알림이 아직 DB에 반영되기 전에 API fetch가 오는 경우, stompOnly 병합 전략으로 처리했는데 엣지 케이스가 있을지 봐주세요