### PR TITLE
fix(widget): 캔들 토글 제거 및 종목 로고 추가

### DIFF
--- a/src/components/ui/MiniChart.jsx
+++ b/src/components/ui/MiniChart.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { CandlestickSeries, LineSeries, createChart } from 'lightweight-charts'
+import { LineSeries, createChart } from 'lightweight-charts'
 
 function getChartColors() {
   const style = getComputedStyle(document.documentElement)
@@ -10,15 +10,13 @@ function getChartColors() {
 }
 
 /**
- * 위젯용 미니 차트 (lightweight-charts)
- * @param {{ time: number, value: number }[]}                    data        - 라인용 (unix seconds)
- * @param {{ time: number, open, high, low, close: number }[]}  candleData  - 캔들용 (unix seconds)
- * @param {'line'|'candle'} chartType
+ * 위젯용 미니 라인 차트 (lightweight-charts)
+ * @param {{ time: number, value: number }[]} data      - 라인용 (unix seconds)
  * @param {boolean} isMinute  - true면 X축에 시간(HH:MM), false면 날짜(M/D)
  * @param {boolean} isUp
  * @param {string}  className
  */
-export default function MiniChart({ data, candleData, chartType = 'line', isMinute = false, isUp, className = '' }) {
+export default function MiniChart({ data, isMinute = false, isUp, className = '' }) {
   const ref       = useRef(null)
   const seriesRef = useRef(null)
 
@@ -59,10 +57,7 @@ export default function MiniChart({ data, candleData, chartType = 'line', isMinu
             const mm = String(d.getMinutes()).padStart(2, '0')
             return `${hh}:${mm}`
           }
-          if (tickMarkType <= 1) {
-            // Year or Month tick
-            return `${d.getMonth() + 1}월`
-          }
+          if (tickMarkType <= 1) return `${d.getMonth() + 1}월`
           return `${d.getMonth() + 1}/${d.getDate()}`
         },
       },
@@ -74,35 +69,18 @@ export default function MiniChart({ data, candleData, chartType = 'line', isMinu
       handleScale:  false,
     })
 
-    if (chartType === 'candle') {
-      const series = chart.addSeries(CandlestickSeries, {
-        upColor:         up,
-        borderUpColor:   up,
-        wickUpColor:     up,
-        downColor:       down,
-        borderDownColor: down,
-        wickDownColor:   down,
-        priceLineVisible:  false,
-        lastValueVisible:  false,
-      })
-      seriesRef.current = series
-      if (candleData?.length) {
-        series.setData(candleData)
-        chart.timeScale().fitContent()
-      }
-    } else {
-      const series = chart.addSeries(LineSeries, {
-        lineColor,
-        lineWidth:              1.5,
-        priceLineVisible:       false,
-        lastValueVisible:       false,
-        crosshairMarkerVisible: false,
-      })
-      seriesRef.current = series
-      if (data?.length) {
-        series.setData(data)
-        chart.timeScale().fitContent()
-      }
+    const series = chart.addSeries(LineSeries, {
+      lineColor,
+      lineWidth:              1.5,
+      priceLineVisible:       false,
+      lastValueVisible:       false,
+      crosshairMarkerVisible: false,
+    })
+    seriesRef.current = series
+
+    if (data?.length) {
+      series.setData(data)
+      chart.timeScale().fitContent()
     }
 
     const ro = new ResizeObserver(([entry]) => {
@@ -119,14 +97,14 @@ export default function MiniChart({ data, candleData, chartType = 'line', isMinu
       chart.remove()
       seriesRef.current = null
     }
-  }, [data, candleData, chartType, isMinute]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [data, isMinute]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // 라인 모드: isUp 변경 시 색상만 업데이트
+  // isUp 변경 시 차트 재생성 없이 색상만 업데이트
   useEffect(() => {
-    if (!seriesRef.current || chartType === 'candle') return
+    if (!seriesRef.current) return
     const { up, down } = getChartColors()
     seriesRef.current.applyOptions({ lineColor: isUp ? up : down })
-  }, [isUp, chartType])
+  }, [isUp])
 
   return <div ref={ref} className={`overflow-hidden ${className}`} />
 }

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Settings2 } from 'lucide-react'
-import { cn } from '@/lib/cn'
 import StockAvatar from '@/components/ui/StockAvatar'
 import PriceChange from '@/components/ui/PriceChange'
 import MiniChart from '@/components/ui/MiniChart'
@@ -13,11 +12,6 @@ import useWidgetStore from '@/store/useWidgetStore'
 import { useDashboardSave } from '@/hooks/useDashboardSync'
 import { normalizeDailySeries, normalizeMinuteSeries } from '@/features/invest/domestic/normalize'
 import { formatApiDate } from '@/features/invest/formatters'
-
-const CHART_TYPES = [
-  { key: 'line',   label: '라인' },
-  { key: 'candle', label: '캔들' },
-]
 
 // config.stockId(레거시) → 종목코드 매핑
 const STOCK_CODE_MAP = {
@@ -45,7 +39,6 @@ function fmtVolume(v) {
 export default function StockChartWidget({ instanceId, variant = 'stock-sm', colSpan = 1, rowSpan = 1, onDelete, config = {} }) {
   const [activePeriod, setActivePeriod] = useState('1일')
   const [isConfigOpen, setIsConfigOpen] = useState(false)
-  const [chartType, setChartType] = useState('line')
   const updateWidgetConfig = useWidgetStore((s) => s.updateWidgetConfig)
   const { mutate: saveDashboard } = useDashboardSave()
 
@@ -67,26 +60,6 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
     >
       <Settings2 className="w-3 h-3" />
     </button>
-  )
-
-  const chartTypeToggle = (
-    <div className="flex items-center rounded-md bg-surface-muted p-0.5">
-      {CHART_TYPES.map((t) => (
-        <button
-          key={t.key}
-          onClick={(e) => { e.stopPropagation(); setChartType(t.key) }}
-          aria-label={`${t.label} 차트`}
-          className={cn(
-            'rounded px-1.5 py-0.5 text-[9px] font-semibold transition-all',
-            chartType === t.key
-              ? 'bg-primary text-white'
-              : 'text-foreground-disabled hover:text-foreground-secondary',
-          )}
-        >
-          {t.label}
-        </button>
-      ))}
-    </div>
   )
 
   const { data: priceData } = useQuery({
@@ -145,7 +118,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
     staleTime: 5 * 60 * 1000,
   })
 
-  const { miniChartData, candleData, latestCandle } = useMemo(() => {
+  const { miniChartData, latestCandle } = useMemo(() => {
     let series = isMinute
       ? normalizeMinuteSeries(minuteRaw?.data ?? minuteRaw)
       : normalizeDailySeries(chartRaw?.data)
@@ -161,7 +134,6 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
     const toTime = (p) => Math.floor(p.timestamp / 1000)
     return {
       miniChartData: series.map((p) => ({ time: toTime(p), value: p.close })),
-      candleData:    series.map((p) => ({ time: toTime(p), open: p.open, high: p.high, low: p.low, close: p.close })),
       latestCandle:  series[series.length - 1] ?? null,
     }
   }, [isMinute, minuteRaw, chartRaw])
@@ -203,12 +175,15 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
         <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
           <div className="flex h-full gap-2.5 min-h-0">
             <div className="flex flex-col justify-between shrink-0">
-              <div>
-                <div className="flex items-center gap-1">
-                  <div className="text-[11px] font-bold text-foreground leading-none">{stock.name}</div>
-                  {settingsBtn}
+              <div className="flex items-center gap-1.5">
+                <StockAvatar name={stock.name} stockCode={stock.code} marketType={stock.marketType} color={stock.color} size="sm" />
+                <div>
+                  <div className="flex items-center gap-1">
+                    <div className="text-[11px] font-bold text-foreground leading-none">{stock.name}</div>
+                    {settingsBtn}
+                  </div>
+                  <div className="text-[9px] text-foreground-disabled mt-0.5">{stock.code}{stock.marketType ? ` · ${stock.marketType}` : ''}</div>
                 </div>
-                <div className="text-[9px] text-foreground-disabled mt-0.5">{stock.code}{stock.marketType ? ` · ${stock.marketType}` : ''}</div>
               </div>
               <div>
                 <div className={`text-[18px] font-bold leading-tight text-foreground`}>{stock.price}</div>
@@ -219,9 +194,8 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
                   : <div className="text-[10px] text-foreground-disabled">-</div>
                 }
               </div>
-              {chartTypeToggle}
             </div>
-            <MiniChart data={miniChartData} candleData={candleData} chartType={chartType} isMinute={isMinute} isUp={isUp} className="flex-1 min-h-0" />
+            <MiniChart data={miniChartData} isMinute={isMinute} isUp={isUp} className="flex-1 min-h-0" />
           </div>
         </WidgetCard>
         {selectModal}
@@ -249,7 +223,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
               <PriceChange value={stock.change} className="text-[10px]" />
             </div>
           </div>
-          <div className="flex items-center justify-between shrink-0 mb-1.5">
+          <div className="flex items-center shrink-0 mb-1.5">
             <div className="flex gap-1.5">
               {PERIODS.map((p) => (
                 <button
@@ -261,9 +235,8 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
                 </button>
               ))}
             </div>
-            {chartTypeToggle}
           </div>
-          <MiniChart data={miniChartData} candleData={candleData} chartType={chartType} isMinute={isMinute} isUp={isUp} className="flex-1 min-h-0 rounded-xl" />
+          <MiniChart data={miniChartData} isMinute={isMinute} isUp={isUp} className="flex-1 min-h-0 rounded-xl" />
           <div className="flex justify-between shrink-0 mt-1.5">
             {[
               { label: '시가',  val: stock.open },
@@ -303,10 +276,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
               <PriceChange value={stock.change} className="text-[10px]" />
             </div>
           </div>
-          <div className="flex justify-end shrink-0 mt-0.5 mb-1">
-            {chartTypeToggle}
-          </div>
-          <MiniChart data={miniChartData} candleData={candleData} chartType={chartType} isMinute={isMinute} isUp={isUp} className="flex-1 min-h-0 rounded-xl mb-1.5" />
+          <MiniChart data={miniChartData} isMinute={isMinute} isUp={isUp} className="flex-1 min-h-0 rounded-xl mb-1.5" />
           <div className="flex justify-between shrink-0">
             {[
               { label: '시가', val: stock.open },
@@ -330,7 +300,10 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
     <>
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
         <div className="flex items-center justify-between shrink-0">
-          <span className="text-[12px] font-bold text-foreground leading-none">{stock.name}</span>
+          <div className="flex items-center gap-1.5">
+            <StockAvatar name={stock.name} stockCode={stock.code} marketType={stock.marketType} color={stock.color} size="sm" />
+            <span className="text-[12px] font-bold text-foreground leading-none">{stock.name}</span>
+          </div>
           <div className="flex items-center gap-1">
             <span className="text-[9px] text-foreground-disabled">{stock.code}</span>
             {settingsBtn}


### PR DESCRIPTION
## 개요

closes #84

## 변경 사항

| 항목 | 내용 |
|------|------|
| 캔들 토글 제거 | 라인/캔들 토글 UI 및 `CandlestickSeries` 제거, 라인 차트 고정 |
| MiniChart 단순화 | `candleData`, `chartType` prop 제거 |
| stock-sm 로고 추가 | 1×1 위젯 상단에 `StockAvatar` 추가 |
| stock-wide 로고 추가 | 2×1 위젯 좌측 상단에 `StockAvatar` 추가 |

## 테스트 항목

- [ ] stock-sm(1×1), stock-wide(2×1) 종목 로고 표시 확인
- [ ] stock-2x2, stock-3x2 기존 로고 정상 표시 유지
- [ ] 라인 차트만 렌더링, 캔들 토글 UI 없음 확인
- [ ] 종목 변경 후 로고 정상 갱신