### PR TITLE
fix(chart): MiniChart 가격 레이블 잘림 방지 — 동적 여백 계산 및 overflow-hidden 제거

### DIFF
--- a/src/components/ui/MiniChart.jsx
+++ b/src/components/ui/MiniChart.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { LineSeries, createChart } from 'lightweight-charts'
+import { CandlestickSeries, createChart } from 'lightweight-charts'
 
 function getChartColors() {
   const style = getComputedStyle(document.documentElement)
@@ -10,22 +10,22 @@ function getChartColors() {
 }
 
 /**
- * 위젯용 미니 라인 차트 (lightweight-charts)
- * @param {{ time: number, value: number }[]} data      - 라인용 (unix seconds)
- * @param {boolean} isMinute  - true면 X축에 시간(HH:MM), false면 날짜(M/D)
- * @param {boolean} isUp
+ * 위젯용 캔들 차트 (lightweight-charts)
+ * @param {{ time: number, open, high, low, close: number }[]} candleData - 캔들 데이터 (unix seconds)
+ * @param {{ time: number, open, high, low, close: number }}   liveCandle - STOMP 실시간 업데이트 포인트
+ * @param {boolean} isMinute  - true면 X축 HH:MM / 좌측 고정, false면 M/D
  * @param {string}  className
  */
-export default function MiniChart({ data, isMinute = false, isUp, className = '' }) {
+export default function MiniChart({ candleData, liveCandle, isMinute = false, className = '' }) {
   const ref       = useRef(null)
   const seriesRef = useRef(null)
 
+  // 차트 생성 — candleData / isMinute 변경 시 재생성
   useEffect(() => {
     const el = ref.current
     if (!el) return
 
     const { up, down, textMuted } = getChartColors()
-    const lineColor = isUp ? up : down
 
     const chart = createChart(el, {
       width:  el.clientWidth,
@@ -41,7 +41,15 @@ export default function MiniChart({ data, isMinute = false, isUp, className = ''
         horzLines: { visible: false },
       },
       leftPriceScale:  { visible: false },
-      rightPriceScale: { visible: false },
+      rightPriceScale: {
+        visible:       true,
+        borderVisible: false,
+        minimumWidth:  48,
+        scaleMargins:  { top: 0.08, bottom: 0.08 },
+      },
+      localization: {
+        priceFormatter: (price) => Math.round(price).toLocaleString('ko-KR'),
+      },
       timeScale: {
         visible:        true,
         timeVisible:    isMinute,
@@ -49,7 +57,7 @@ export default function MiniChart({ data, isMinute = false, isUp, className = ''
         borderVisible:  false,
         ticksVisible:   false,
         fixLeftEdge:    true,
-        fixRightEdge:   true,
+        fixRightEdge:   !isMinute, // 분봉: 우측 열린 상태로 캔들이 오른쪽으로 추가됨
         tickMarkFormatter: (time, tickMarkType) => {
           const d = new Date(time * 1000)
           if (isMinute) {
@@ -69,18 +77,26 @@ export default function MiniChart({ data, isMinute = false, isUp, className = ''
       handleScale:  false,
     })
 
-    const series = chart.addSeries(LineSeries, {
-      lineColor,
-      lineWidth:              1.5,
-      priceLineVisible:       false,
-      lastValueVisible:       false,
-      crosshairMarkerVisible: false,
+    const series = chart.addSeries(CandlestickSeries, {
+      upColor:         up,
+      borderUpColor:   up,
+      wickUpColor:     up,
+      downColor:       down,
+      borderDownColor: down,
+      wickDownColor:   down,
+      priceLineVisible: false,
+      lastValueVisible: false,
     })
     seriesRef.current = series
 
-    if (data?.length) {
-      series.setData(data)
-      chart.timeScale().fitContent()
+    if (candleData?.length) {
+      series.setData(candleData)
+      if (isMinute) {
+        // 09:01(첫 캔들)을 좌측에 고정, 오른쪽으로 채워지도록
+        chart.timeScale().setVisibleLogicalRange({ from: -0.5, to: candleData.length - 0.5 })
+      } else {
+        chart.timeScale().fitContent()
+      }
     }
 
     const ro = new ResizeObserver(([entry]) => {
@@ -97,14 +113,13 @@ export default function MiniChart({ data, isMinute = false, isUp, className = ''
       chart.remove()
       seriesRef.current = null
     }
-  }, [data, isMinute]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [candleData, isMinute])
 
-  // isUp 변경 시 차트 재생성 없이 색상만 업데이트
+  // STOMP 실시간 캔들 업데이트 — 차트 재생성 없이 마지막 봉만 갱신
   useEffect(() => {
-    if (!seriesRef.current) return
-    const { up, down } = getChartColors()
-    seriesRef.current.applyOptions({ lineColor: isUp ? up : down })
-  }, [isUp])
+    if (!seriesRef.current || !liveCandle) return
+    seriesRef.current.update(liveCandle)
+  }, [liveCandle])
 
   return <div ref={ref} className={`overflow-hidden ${className}`} />
 }

--- a/src/components/ui/MiniChart.jsx
+++ b/src/components/ui/MiniChart.jsx
@@ -9,21 +9,14 @@ function getChartColors() {
   return { up, down, textMuted }
 }
 
-// 미국 EDT 여부 판별 (3~11월 근사, US DST: 3월 둘째 일요일 ~ 11월 첫째 일요일)
-function isUSEDT(unixSeconds) {
-  const month = new Date(unixSeconds * 1000).getUTCMonth() + 1
-  return month >= 3 && month <= 11
-}
-
 /**
  * 위젯용 캔들 차트 (lightweight-charts)
  * @param {{ time: number, open, high, low, close: number }[]} candleData - 캔들 데이터 (unix seconds)
  * @param {{ time: number, open, high, low, close: number }}   liveCandle - STOMP 실시간 업데이트 포인트
- * @param {boolean} isMinute   - true면 X축 HH:MM / 좌측 고정, false면 M/D
- * @param {boolean} isOverseas - 해외주식 여부 (분봉 X축 ET→KST 변환 적용)
+ * @param {boolean} isMinute  - true면 X축 HH:MM / 좌측 고정, false면 M/D
  * @param {string}  className
  */
-export default function MiniChart({ candleData, liveCandle, isMinute = false, isOverseas = false, className = '' }) {
+export default function MiniChart({ candleData, liveCandle, isMinute = false, className = '' }) {
   const ref       = useRef(null)
   const seriesRef = useRef(null)
 
@@ -66,18 +59,12 @@ export default function MiniChart({ candleData, liveCandle, isMinute = false, is
         fixLeftEdge:    true,
         fixRightEdge:   !isMinute, // 분봉: 우측 열린 상태로 캔들이 오른쪽으로 추가됨
         tickMarkFormatter: (time, tickMarkType) => {
-          if (isMinute && isOverseas) {
-            // 해외 분봉: LS loctime은 미국 ET (현지시간)이 KST로 오해석된 상태
-            // JS가 "09:30:00"을 KST로 파싱 → 00:30 UTC
-            // 실제 KST: ET+14h(EST) 또는 ET+13h(EDT) → +22h/+23h로 보정
-            const addH = isUSEDT(time) ? 22 : 23
-            const d = new Date((time + addH * 3600) * 1000)
-            return `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`
-          }
-          // 국내 분봉 / 일봉: UTC+9h → KST
+          // UTC + 9h → KST (시세탭 InvestStockChart와 동일한 방식)
           const d = new Date((time + 9 * 3600) * 1000)
           if (isMinute) {
-            return `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`
+            const hh = String(d.getUTCHours()).padStart(2, '0')
+            const mm = String(d.getUTCMinutes()).padStart(2, '0')
+            return `${hh}:${mm}`
           }
           if (tickMarkType <= 1) return `${d.getUTCMonth() + 1}월`
           return `${d.getUTCMonth() + 1}/${d.getUTCDate()}`
@@ -128,7 +115,7 @@ export default function MiniChart({ candleData, liveCandle, isMinute = false, is
       chart.remove()
       seriesRef.current = null
     }
-  }, [candleData, isMinute, isOverseas])
+  }, [candleData, isMinute])
 
   // STOMP 실시간 캔들 업데이트 — 차트 재생성 없이 마지막 봉만 갱신
   useEffect(() => {

--- a/src/components/ui/MiniChart.jsx
+++ b/src/components/ui/MiniChart.jsx
@@ -59,14 +59,15 @@ export default function MiniChart({ candleData, liveCandle, isMinute = false, cl
         fixLeftEdge:    true,
         fixRightEdge:   !isMinute, // 분봉: 우측 열린 상태로 캔들이 오른쪽으로 추가됨
         tickMarkFormatter: (time, tickMarkType) => {
-          const d = new Date(time * 1000)
+          // UTC + 9h → KST (시세탭 InvestStockChart와 동일한 방식)
+          const d = new Date((time + 9 * 3600) * 1000)
           if (isMinute) {
-            const hh = String(d.getHours()).padStart(2, '0')
-            const mm = String(d.getMinutes()).padStart(2, '0')
+            const hh = String(d.getUTCHours()).padStart(2, '0')
+            const mm = String(d.getUTCMinutes()).padStart(2, '0')
             return `${hh}:${mm}`
           }
-          if (tickMarkType <= 1) return `${d.getMonth() + 1}월`
-          return `${d.getMonth() + 1}/${d.getDate()}`
+          if (tickMarkType <= 1) return `${d.getUTCMonth() + 1}월`
+          return `${d.getUTCMonth() + 1}/${d.getUTCDate()}`
         },
       },
       crosshair: {

--- a/src/components/ui/MiniChart.jsx
+++ b/src/components/ui/MiniChart.jsx
@@ -91,15 +91,13 @@ export default function MiniChart({ candleData, liveCandle, isMinute = false, cl
 
     if (candleData?.length) {
       series.setData(candleData)
-      if (isMinute) {
-        // 장 시작~마감(09:00~15:30)을 고정 범위로 지정 → 캔들 폭이 일정하게 유지
-        const today = new Date()
-        const from = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 9, 0, 0).getTime() / 1000
-        const to   = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 15, 30, 0).getTime() / 1000
-        chart.timeScale().setVisibleRange({ from, to })
-      } else {
-        chart.timeScale().fitContent()
-      }
+    }
+    if (isMinute) {
+      // 09:00~15:25 사이 5분봉 최대 78개 슬롯을 고정 → 캔들 폭이 일정하게 유지
+      // setVisibleRange는 데이터 밖 시간을 빈 공간으로 처리하지 못해 setVisibleLogicalRange 사용
+      chart.timeScale().setVisibleLogicalRange({ from: -0.5, to: 77.5 })
+    } else if (candleData?.length) {
+      chart.timeScale().fitContent()
     }
 
     const ro = new ResizeObserver(([entry]) => {

--- a/src/components/ui/MiniChart.jsx
+++ b/src/components/ui/MiniChart.jsx
@@ -91,12 +91,15 @@ export default function MiniChart({ candleData, liveCandle, isMinute = false, cl
 
     if (candleData?.length) {
       series.setData(candleData)
-      if (isMinute) {
-        // 09:01(첫 캔들)을 좌측에 고정, 오른쪽으로 채워지도록
-        chart.timeScale().setVisibleLogicalRange({ from: -0.5, to: candleData.length - 0.5 })
-      } else {
-        chart.timeScale().fitContent()
-      }
+    }
+    if (isMinute) {
+      // 장 시작~마감(09:00~15:30)을 고정 범위로 지정 → 캔들 폭이 일정하게 유지
+      const today = new Date()
+      const from = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 9, 0, 0).getTime() / 1000
+      const to   = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 15, 30, 0).getTime() / 1000
+      chart.timeScale().setVisibleRange({ from, to })
+    } else if (candleData?.length) {
+      chart.timeScale().fitContent()
     }
 
     const ro = new ResizeObserver(([entry]) => {

--- a/src/components/ui/MiniChart.jsx
+++ b/src/components/ui/MiniChart.jsx
@@ -91,15 +91,15 @@ export default function MiniChart({ candleData, liveCandle, isMinute = false, cl
 
     if (candleData?.length) {
       series.setData(candleData)
-    }
-    if (isMinute) {
-      // 장 시작~마감(09:00~15:30)을 고정 범위로 지정 → 캔들 폭이 일정하게 유지
-      const today = new Date()
-      const from = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 9, 0, 0).getTime() / 1000
-      const to   = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 15, 30, 0).getTime() / 1000
-      chart.timeScale().setVisibleRange({ from, to })
-    } else if (candleData?.length) {
-      chart.timeScale().fitContent()
+      if (isMinute) {
+        // 장 시작~마감(09:00~15:30)을 고정 범위로 지정 → 캔들 폭이 일정하게 유지
+        const today = new Date()
+        const from = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 9, 0, 0).getTime() / 1000
+        const to   = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 15, 30, 0).getTime() / 1000
+        chart.timeScale().setVisibleRange({ from, to })
+      } else {
+        chart.timeScale().fitContent()
+      }
     }
 
     const ro = new ResizeObserver(([entry]) => {

--- a/src/components/ui/MiniChart.jsx
+++ b/src/components/ui/MiniChart.jsx
@@ -1,6 +1,24 @@
 import { useEffect, useRef } from 'react'
 import { CandlestickSeries, createChart } from 'lightweight-charts'
 
+function getPriceScaleMargins(height) {
+  const h = Math.max(1, height || 0)
+
+  // 작은 위젯에서도 우측 가격 라벨이 상/하단에 걸리지 않도록 px 기반으로 여백 환산
+  let top = Math.max(0.22, Math.min(0.46, 22 / h))
+  let bottom = Math.max(0.12, Math.min(0.28, 14 / h))
+
+  // 플롯 영역이 지나치게 줄어들지 않게 합계 상한 적용
+  const maxTotal = 0.74
+  if (top + bottom > maxTotal) {
+    const ratio = maxTotal / (top + bottom)
+    top *= ratio
+    bottom *= ratio
+  }
+
+  return { top, bottom }
+}
+
 function getChartColors() {
   const style = getComputedStyle(document.documentElement)
   const up        = style.getPropertyValue('--color-up').trim()                  || '#E8393E'
@@ -27,6 +45,8 @@ export default function MiniChart({ candleData, liveCandle, isMinute = false, cl
 
     const { up, down, textMuted } = getChartColors()
 
+    const priceScaleMargins = getPriceScaleMargins(el.clientHeight)
+
     const chart = createChart(el, {
       width:  el.clientWidth,
       height: el.clientHeight,
@@ -45,7 +65,8 @@ export default function MiniChart({ candleData, liveCandle, isMinute = false, cl
         visible:       true,
         borderVisible: false,
         minimumWidth:  48,
-        scaleMargins:  { top: 0.15, bottom: 0.08 },
+        entireTextOnly: true,
+        scaleMargins:  priceScaleMargins,
       },
       localization: {
         priceFormatter: (price) => Math.round(price).toLocaleString('ko-KR'),
@@ -103,9 +124,13 @@ export default function MiniChart({ candleData, liveCandle, isMinute = false, cl
 
     const ro = new ResizeObserver(([entry]) => {
       if (!entry) return
+      const margins = getPriceScaleMargins(entry.contentRect.height)
       chart.applyOptions({
         width:  entry.contentRect.width,
         height: entry.contentRect.height,
+        rightPriceScale: {
+          scaleMargins: margins,
+        },
       })
     })
     ro.observe(el)
@@ -123,5 +148,5 @@ export default function MiniChart({ candleData, liveCandle, isMinute = false, cl
     seriesRef.current.update(liveCandle)
   }, [liveCandle])
 
-  return <div ref={ref} className={`overflow-hidden ${className}`} />
+  return <div ref={ref} className={className} />
 }

--- a/src/components/ui/MiniChart.jsx
+++ b/src/components/ui/MiniChart.jsx
@@ -45,7 +45,7 @@ export default function MiniChart({ candleData, liveCandle, isMinute = false, cl
         visible:       true,
         borderVisible: false,
         minimumWidth:  48,
-        scaleMargins:  { top: 0.08, bottom: 0.08 },
+        scaleMargins:  { top: 0.15, bottom: 0.08 },
       },
       localization: {
         priceFormatter: (price) => Math.round(price).toLocaleString('ko-KR'),

--- a/src/components/ui/MiniChart.jsx
+++ b/src/components/ui/MiniChart.jsx
@@ -9,14 +9,21 @@ function getChartColors() {
   return { up, down, textMuted }
 }
 
+// 미국 EDT 여부 판별 (3~11월 근사, US DST: 3월 둘째 일요일 ~ 11월 첫째 일요일)
+function isUSEDT(unixSeconds) {
+  const month = new Date(unixSeconds * 1000).getUTCMonth() + 1
+  return month >= 3 && month <= 11
+}
+
 /**
  * 위젯용 캔들 차트 (lightweight-charts)
  * @param {{ time: number, open, high, low, close: number }[]} candleData - 캔들 데이터 (unix seconds)
  * @param {{ time: number, open, high, low, close: number }}   liveCandle - STOMP 실시간 업데이트 포인트
- * @param {boolean} isMinute  - true면 X축 HH:MM / 좌측 고정, false면 M/D
+ * @param {boolean} isMinute   - true면 X축 HH:MM / 좌측 고정, false면 M/D
+ * @param {boolean} isOverseas - 해외주식 여부 (분봉 X축 ET→KST 변환 적용)
  * @param {string}  className
  */
-export default function MiniChart({ candleData, liveCandle, isMinute = false, className = '' }) {
+export default function MiniChart({ candleData, liveCandle, isMinute = false, isOverseas = false, className = '' }) {
   const ref       = useRef(null)
   const seriesRef = useRef(null)
 
@@ -59,12 +66,18 @@ export default function MiniChart({ candleData, liveCandle, isMinute = false, cl
         fixLeftEdge:    true,
         fixRightEdge:   !isMinute, // 분봉: 우측 열린 상태로 캔들이 오른쪽으로 추가됨
         tickMarkFormatter: (time, tickMarkType) => {
-          // UTC + 9h → KST (시세탭 InvestStockChart와 동일한 방식)
+          if (isMinute && isOverseas) {
+            // 해외 분봉: LS loctime은 미국 ET (현지시간)이 KST로 오해석된 상태
+            // JS가 "09:30:00"을 KST로 파싱 → 00:30 UTC
+            // 실제 KST: ET+14h(EST) 또는 ET+13h(EDT) → +22h/+23h로 보정
+            const addH = isUSEDT(time) ? 22 : 23
+            const d = new Date((time + addH * 3600) * 1000)
+            return `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`
+          }
+          // 국내 분봉 / 일봉: UTC+9h → KST
           const d = new Date((time + 9 * 3600) * 1000)
           if (isMinute) {
-            const hh = String(d.getUTCHours()).padStart(2, '0')
-            const mm = String(d.getUTCMinutes()).padStart(2, '0')
-            return `${hh}:${mm}`
+            return `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`
           }
           if (tickMarkType <= 1) return `${d.getUTCMonth() + 1}월`
           return `${d.getUTCMonth() + 1}/${d.getUTCDate()}`
@@ -115,7 +128,7 @@ export default function MiniChart({ candleData, liveCandle, isMinute = false, cl
       chart.remove()
       seriesRef.current = null
     }
-  }, [candleData, isMinute])
+  }, [candleData, isMinute, isOverseas])
 
   // STOMP 실시간 캔들 업데이트 — 차트 재생성 없이 마지막 봉만 갱신
   useEffect(() => {

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -320,7 +320,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
                 }
               </div>
             </div>
-            <MiniChart candleData={candleData} liveCandle={isMinute ? liveCandle : null} isMinute={isMinute} isOverseas={isOverseas} className="flex-1 min-h-0" />
+            <MiniChart candleData={candleData} liveCandle={isMinute ? liveCandle : null} isMinute={isMinute} className="flex-1 min-h-0" />
           </div>
         </WidgetCard>
         {selectModal}
@@ -351,7 +351,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
           <div className="flex items-center shrink-0 mb-1.5">
             {periodTabs}
           </div>
-          <MiniChart candleData={candleData} liveCandle={isMinute ? liveCandle : null} isMinute={isMinute} isOverseas={isOverseas} className="flex-1 min-h-0 rounded-xl" />
+          <MiniChart candleData={candleData} liveCandle={isMinute ? liveCandle : null} isMinute={isMinute} className="flex-1 min-h-0 rounded-xl" />
           <div className="flex justify-between shrink-0 mt-1.5">
             {[
               { label: '시가',  val: stock.open },
@@ -394,7 +394,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
           <div className="flex shrink-0 mb-1">
             {periodTabs}
           </div>
-          <MiniChart candleData={candleData} liveCandle={isMinute ? liveCandle : null} isMinute={isMinute} isOverseas={isOverseas} className="flex-1 min-h-0 rounded-xl mb-1.5" />
+          <MiniChart candleData={candleData} liveCandle={isMinute ? liveCandle : null} isMinute={isMinute} className="flex-1 min-h-0 rounded-xl mb-1.5" />
           <div className="flex justify-between shrink-0">
             {[
               { label: '시가', val: stock.open },

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -7,7 +7,7 @@ import MiniChart from '@/components/ui/MiniChart'
 import WidgetCard from './WidgetCard'
 import StockSelectModal from './StockSelectModal'
 import { HOME_STOCKS } from '@/mocks/home'
-import { marketApi, foreignMarketApi, getExchcd } from '@/api/market'
+import { marketApi, foreignMarketApi } from '@/api/market'
 import useWidgetStore from '@/store/useWidgetStore'
 import { useDashboardSave } from '@/hooks/useDashboardSync'
 import useStompSubscription from '@/hooks/useStompSubscription'
@@ -23,7 +23,12 @@ const STOCK_CODE_MAP = {
 
 const PERIODS = ['1일', '1주', '1달', '3달']
 
-const OVERSEAS_MARKET_TYPES = ['NAS', 'NYS', 'AMS']
+// 백엔드 InstrumentSearchResponse.marketType 값 (NASDAQ, NYSE, AMEX)
+const OVERSEAS_MARKET_TYPES = ['NASDAQ', 'NYSE', 'AMEX']
+// 백엔드 InstrumentSearchResponse.exchangeCode → LS증권 exchcd 매핑
+const EXCHCD_BY_EXCHANGE_CODE = { NAS: '82', NYS: '81', AMS: '81' }
+// marketType 직접 → exchcd 매핑 (exchangeCode 미저장 위젯 대비 폴백)
+const EXCHCD_BY_MARKET_TYPE   = { NASDAQ: '82', NYSE: '81', AMEX: '81' }
 
 const PERIOD_CONFIG = {
   '1일': { type: 'minute', ncnt: 5 },
@@ -65,7 +70,10 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
   const stockMeta  = HOME_STOCKS.find((s) => s.id === stockId) ?? HOME_STOCKS[0]
   const marketType = config.marketType ?? stockMeta.market ?? null
   const isOverseas = OVERSEAS_MARKET_TYPES.includes(marketType)
-  const exchcd     = isOverseas ? getExchcd(marketType) : null
+  // exchangeCode(NAS/NYS/AMS)가 저장돼 있으면 우선, 없으면 marketType(NASDAQ/NYSE/AMEX)으로 파생
+  const exchcd = isOverseas
+    ? (EXCHCD_BY_EXCHANGE_CODE[config.exchangeCode] ?? EXCHCD_BY_MARKET_TYPE[marketType] ?? '82')
+    : null
 
   // 종목 변경 시 실시간 상태 초기화
   useEffect(() => {
@@ -73,8 +81,8 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
     setLiveCandle(null)
   }, [stockCode])
 
-  function handleStockSave({ stockCode: newCode, stockName: newName, marketType: newMarket }) {
-    updateWidgetConfig(instanceId, { stockCode: newCode, stockName: newName, marketType: newMarket, stockId: undefined })
+  function handleStockSave({ stockCode: newCode, stockName: newName, marketType: newMarket, exchangeCode: newExchangeCode }) {
+    updateWidgetConfig(instanceId, { stockCode: newCode, stockName: newName, marketType: newMarket, exchangeCode: newExchangeCode, stockId: undefined })
     saveDashboard()
     setIsConfigOpen(false)
   }

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -320,7 +320,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
                 }
               </div>
             </div>
-            <MiniChart candleData={candleData} liveCandle={isMinute ? liveCandle : null} isMinute={isMinute} className="flex-1 min-h-0" />
+            <MiniChart candleData={candleData} liveCandle={isMinute ? liveCandle : null} isMinute={isMinute} isOverseas={isOverseas} className="flex-1 min-h-0" />
           </div>
         </WidgetCard>
         {selectModal}
@@ -351,7 +351,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
           <div className="flex items-center shrink-0 mb-1.5">
             {periodTabs}
           </div>
-          <MiniChart candleData={candleData} liveCandle={isMinute ? liveCandle : null} isMinute={isMinute} className="flex-1 min-h-0 rounded-xl" />
+          <MiniChart candleData={candleData} liveCandle={isMinute ? liveCandle : null} isMinute={isMinute} isOverseas={isOverseas} className="flex-1 min-h-0 rounded-xl" />
           <div className="flex justify-between shrink-0 mt-1.5">
             {[
               { label: '시가',  val: stock.open },
@@ -394,7 +394,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
           <div className="flex shrink-0 mb-1">
             {periodTabs}
           </div>
-          <MiniChart candleData={candleData} liveCandle={isMinute ? liveCandle : null} isMinute={isMinute} className="flex-1 min-h-0 rounded-xl mb-1.5" />
+          <MiniChart candleData={candleData} liveCandle={isMinute ? liveCandle : null} isMinute={isMinute} isOverseas={isOverseas} className="flex-1 min-h-0 rounded-xl mb-1.5" />
           <div className="flex justify-between shrink-0">
             {[
               { label: '시가', val: stock.open },

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -7,11 +7,12 @@ import MiniChart from '@/components/ui/MiniChart'
 import WidgetCard from './WidgetCard'
 import StockSelectModal from './StockSelectModal'
 import { HOME_STOCKS } from '@/mocks/home'
-import { marketApi } from '@/api/market'
+import { marketApi, foreignMarketApi, getExchcd } from '@/api/market'
 import useWidgetStore from '@/store/useWidgetStore'
 import { useDashboardSave } from '@/hooks/useDashboardSync'
 import useStompSubscription from '@/hooks/useStompSubscription'
 import { normalizeDailySeries, normalizeMinuteSeries } from '@/features/invest/domestic/normalize'
+import { normalizeForeignDailySeries, normalizeForeignMinuteSeries } from '@/features/invest/foreign/normalize'
 import { formatApiDate } from '@/features/invest/formatters'
 
 // config.stockId(레거시) → 종목코드 매핑
@@ -22,11 +23,13 @@ const STOCK_CODE_MAP = {
 
 const PERIODS = ['1일', '1주', '1달', '3달']
 
+const OVERSEAS_MARKET_TYPES = ['NAS', 'NYS', 'AMS']
+
 const PERIOD_CONFIG = {
-  '1일': { type: 'minute', ncnt: 5              },
-  '1주': { type: 'daily',  period: 'DAILY',   days: 7   },
-  '1달': { type: 'daily',  period: 'DAILY',   days: 30  },
-  '3달': { type: 'weekly', period: 'WEEKLY',  days: 90  },
+  '1일': { type: 'minute', ncnt: 5 },
+  '1주': { type: 'daily',  period: 'DAILY',  foreignPeriod: 'DAY', days: 7  },
+  '1달': { type: 'daily',  period: 'DAILY',  foreignPeriod: 'DAY', days: 30 },
+  '3달': { type: 'weekly', period: 'WEEKLY', foreignPeriod: 'DAY', days: 90 },
 }
 
 // 5분봉 버킷 타임스탬프 계산
@@ -56,10 +59,13 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
   const updateWidgetConfig = useWidgetStore((s) => s.updateWidgetConfig)
   const { mutate: saveDashboard } = useDashboardSave()
 
-  const stockId   = config.stockId ?? 'samsung'
-  const stockCode = config.stockCode ?? STOCK_CODE_MAP[stockId]
-  const stockName = config.stockName ?? null
-  const stockMeta = HOME_STOCKS.find((s) => s.id === stockId) ?? HOME_STOCKS[0]
+  const stockId    = config.stockId ?? 'samsung'
+  const stockCode  = config.stockCode ?? STOCK_CODE_MAP[stockId]
+  const stockName  = config.stockName ?? null
+  const stockMeta  = HOME_STOCKS.find((s) => s.id === stockId) ?? HOME_STOCKS[0]
+  const marketType = config.marketType ?? stockMeta.market ?? null
+  const isOverseas = OVERSEAS_MARKET_TYPES.includes(marketType)
+  const exchcd     = isOverseas ? getExchcd(marketType) : null
 
   // 종목 변경 시 실시간 상태 초기화
   useEffect(() => {
@@ -102,12 +108,19 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
   )
 
   // ── REST 초기 데이터 ────────────────────────────────────────────
-  const { data: priceData } = useQuery({
-    queryKey: ['stock', 'price', stockCode],
-    queryFn:  () => marketApi.getCurrentPrice(stockCode),
+  const { data: priceRaw } = useQuery({
+    queryKey: isOverseas ? ['foreign', 'price', stockCode, exchcd] : ['stock', 'price', stockCode],
+    queryFn:  isOverseas
+      ? () => foreignMarketApi.getCurrentPrice(stockCode, exchcd)
+      : () => marketApi.getCurrentPrice(stockCode),
     enabled:  !!stockCode,
     staleTime: 30_000,
   })
+
+  // 해외 가격 응답 필드 통일 ({ price, rate, diff } → { currentPrice, changeRate, changeAmount })
+  const priceData = isOverseas && priceRaw
+    ? { currentPrice: priceRaw.price, changeRate: priceRaw.rate, changeAmount: priceRaw.diff }
+    : priceRaw
 
   const queryClient = useQueryClient()
 
@@ -116,21 +129,37 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
     const end = formatApiDate(new Date())
     Object.values(PERIOD_CONFIG).forEach((cfg) => {
       if (cfg.type === 'minute') {
-        queryClient.prefetchQuery({
-          queryKey: ['stock', 'minute-chart', stockCode, cfg.ncnt],
-          queryFn:  () => marketApi.getMinuteChart(stockCode, { ncnt: cfg.ncnt }),
-          staleTime: 60_000,
-        })
+        if (isOverseas) {
+          queryClient.prefetchQuery({
+            queryKey: ['foreign', 'minuteChart', stockCode, exchcd, 5],
+            queryFn:  () => foreignMarketApi.getMinuteChart(stockCode, exchcd, { nmin: 5 }),
+            staleTime: 60_000,
+          })
+        } else {
+          queryClient.prefetchQuery({
+            queryKey: ['stock', 'minute-chart', stockCode, cfg.ncnt],
+            queryFn:  () => marketApi.getMinuteChart(stockCode, { ncnt: cfg.ncnt }),
+            staleTime: 60_000,
+          })
+        }
       } else {
         const start = formatApiDate(new Date(Date.now() - cfg.days * 24 * 60 * 60 * 1000))
-        queryClient.prefetchQuery({
-          queryKey: ['stock', 'chart', cfg.period, stockCode, start, end],
-          queryFn:  () => marketApi.getChart(stockCode, { period: cfg.period, startDate: start, endDate: end }),
-          staleTime: 5 * 60 * 1000,
-        })
+        if (isOverseas) {
+          queryClient.prefetchQuery({
+            queryKey: ['foreign', 'chart', cfg.foreignPeriod, stockCode, exchcd, start, end],
+            queryFn:  () => foreignMarketApi.getChart(stockCode, exchcd, { period: cfg.foreignPeriod, startDate: start, endDate: end }),
+            staleTime: 5 * 60 * 1000,
+          })
+        } else {
+          queryClient.prefetchQuery({
+            queryKey: ['stock', 'chart', cfg.period, stockCode, start, end],
+            queryFn:  () => marketApi.getChart(stockCode, { period: cfg.period, startDate: start, endDate: end }),
+            staleTime: 5 * 60 * 1000,
+          })
+        }
       }
     })
-  }, [stockCode, queryClient])
+  }, [stockCode, exchcd, isOverseas, queryClient])
 
   const periodCfg = PERIOD_CONFIG[activePeriod]
   const isMinute  = periodCfg.type === 'minute'
@@ -142,21 +171,29 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
   )
 
   const { data: minuteRaw } = useQuery({
-    queryKey: ['stock', 'minute-chart', stockCode, periodCfg.ncnt],
-    queryFn:  () => marketApi.getMinuteChart(stockCode, { ncnt: periodCfg.ncnt }),
+    queryKey: isOverseas
+      ? ['foreign', 'minuteChart', stockCode, exchcd, 5]
+      : ['stock', 'minute-chart', stockCode, periodCfg.ncnt],
+    queryFn: isOverseas
+      ? () => foreignMarketApi.getMinuteChart(stockCode, exchcd, { nmin: 5 })
+      : () => marketApi.getMinuteChart(stockCode, { ncnt: periodCfg.ncnt }),
     enabled:  !!stockCode && isMinute,
     staleTime: 60_000,
   })
 
   const { data: chartRaw } = useQuery({
-    queryKey: ['stock', 'chart', periodCfg.period, stockCode, startDate, endDate],
-    queryFn:  () => marketApi.getChart(stockCode, { period: periodCfg.period, startDate, endDate }),
+    queryKey: isOverseas
+      ? ['foreign', 'chart', periodCfg.foreignPeriod, stockCode, exchcd, startDate, endDate]
+      : ['stock', 'chart', periodCfg.period, stockCode, startDate, endDate],
+    queryFn: isOverseas
+      ? () => foreignMarketApi.getChart(stockCode, exchcd, { period: periodCfg.foreignPeriod, startDate, endDate })
+      : () => marketApi.getChart(stockCode, { period: periodCfg.period, startDate, endDate }),
     enabled:  !!stockCode && !isMinute,
     staleTime: 5 * 60 * 1000,
   })
 
-  // ── STOMP 실시간 체결 구독 ──────────────────────────────────────
-  const liveTrade = useStompSubscription(stockCode ? `/topic/stock/trade/${stockCode}` : null)
+  // ── STOMP 실시간 체결 구독 (국내 전용) ─────────────────────────
+  const liveTrade = useStompSubscription(!isOverseas && stockCode ? `/topic/stock/trade/${stockCode}` : null)
 
   useEffect(() => {
     if (!liveTrade) return
@@ -185,9 +222,16 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
 
   // ── 차트 데이터 ────────────────────────────────────────────────
   const { candleData, latestCandle } = useMemo(() => {
-    let series = isMinute
-      ? normalizeMinuteSeries(minuteRaw?.data ?? minuteRaw)
-      : normalizeDailySeries(chartRaw?.data)
+    let series
+    if (isMinute) {
+      series = isOverseas
+        ? normalizeForeignMinuteSeries(minuteRaw?.dataPoints)
+        : normalizeMinuteSeries(minuteRaw?.data ?? minuteRaw)
+    } else {
+      series = isOverseas
+        ? normalizeForeignDailySeries(chartRaw?.dataPoints)
+        : normalizeDailySeries(chartRaw?.data)
+    }
 
     // 분봉: 오늘 세션만 표시
     if (isMinute) {
@@ -202,7 +246,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
       candleData:   series.map((p) => ({ time: toTime(p), open: p.open, high: p.high, low: p.low, close: p.close })),
       latestCandle: series[series.length - 1] ?? null,
     }
-  }, [isMinute, minuteRaw, chartRaw])
+  }, [isMinute, isOverseas, minuteRaw, chartRaw])
 
   // ── 가격 표시용 (STOMP > REST 우선) ───────────────────────────
   const priceSource = livePrice ?? priceData
@@ -224,7 +268,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
     volume:     priceSource?.volume != null
                   ? fmtVolume(priceSource.volume)
                   : latestCandle ? fmtVolume(latestCandle.volume) : '-',
-    marketType: config.marketType ?? stockMeta.market ?? null,
+    marketType,
   }
   const isUp = stock.change > 0
 

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -47,7 +47,9 @@ function fmtVolume(v) {
 }
 
 export default function StockChartWidget({ instanceId, variant = 'stock-sm', colSpan = 1, rowSpan = 1, onDelete, config = {} }) {
-  const [activePeriod, setActivePeriod] = useState('1일')
+  const [activePeriod, setActivePeriod] = useState(
+    () => localStorage.getItem(`widget.period.${instanceId}`) ?? '1일'
+  )
   const [isConfigOpen, setIsConfigOpen] = useState(false)
   const [livePrice, setLivePrice]   = useState(null)
   const [liveCandle, setLiveCandle] = useState(null)
@@ -80,12 +82,17 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
     </button>
   )
 
+  function handlePeriodChange(p) {
+    setActivePeriod(p)
+    localStorage.setItem(`widget.period.${instanceId}`, p)
+  }
+
   const periodTabs = (
     <div className="flex gap-1">
       {PERIODS.map((p) => (
         <button
           key={p}
-          onClick={(e) => { e.stopPropagation(); setActivePeriod(p) }}
+          onClick={(e) => { e.stopPropagation(); handlePeriodChange(p) }}
           className={`text-[9px] px-1.5 py-0.5 rounded font-medium transition-colors duration-[150ms] ${activePeriod === p ? 'bg-primary-light text-primary' : 'text-foreground-disabled hover:text-foreground'}`}
         >
           {p}
@@ -237,18 +244,20 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
       <>
         <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
           <div className="flex h-full gap-2.5 min-h-0">
-            <div className="flex flex-col gap-1.5 shrink-0 justify-between">
-              <div className="flex items-center gap-1.5">
-                <StockAvatar name={stock.name} stockCode={stock.code} marketType={stock.marketType} color={stock.color} size="sm" />
-                <div>
-                  <div className="flex items-center gap-1">
-                    <div className="text-[11px] font-bold text-foreground leading-none">{stock.name}</div>
-                    {settingsBtn}
+            <div className="flex flex-col shrink-0 justify-between">
+              <div>
+                <div className="flex items-center gap-1.5 mb-1">
+                  <StockAvatar name={stock.name} stockCode={stock.code} marketType={stock.marketType} color={stock.color} size="sm" />
+                  <div>
+                    <div className="flex items-center gap-1">
+                      <div className="text-[11px] font-bold text-foreground leading-none">{stock.name}</div>
+                      {settingsBtn}
+                    </div>
+                    <div className="text-[9px] text-foreground-disabled mt-0.5">{stock.code}{stock.marketType ? ` · ${stock.marketType}` : ''}</div>
                   </div>
-                  <div className="text-[9px] text-foreground-disabled mt-0.5">{stock.code}{stock.marketType ? ` · ${stock.marketType}` : ''}</div>
                 </div>
+                {periodTabs}
               </div>
-              {periodTabs}
               <div>
                 <div className="text-[18px] font-bold leading-tight text-foreground">{stock.price}</div>
                 {hasPrice

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -10,6 +10,7 @@ import { HOME_STOCKS } from '@/mocks/home'
 import { marketApi } from '@/api/market'
 import useWidgetStore from '@/store/useWidgetStore'
 import { useDashboardSave } from '@/hooks/useDashboardSync'
+import useStompSubscription from '@/hooks/useStompSubscription'
 import { normalizeDailySeries, normalizeMinuteSeries } from '@/features/invest/domestic/normalize'
 import { formatApiDate } from '@/features/invest/formatters'
 
@@ -28,6 +29,16 @@ const PERIOD_CONFIG = {
   '3달': { type: 'weekly', period: 'WEEKLY',  days: 90  },
 }
 
+// 5분봉 버킷 타임스탬프 계산
+function toMinuteBucketTime(chetime) {
+  const hh = parseInt(chetime.slice(0, 2), 10)
+  const mm = parseInt(chetime.slice(2, 4), 10)
+  const bucketMm = Math.floor(mm / 5) * 5
+  const now = new Date()
+  const ts = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hh, bucketMm, 0).getTime()
+  return Math.floor(ts / 1000) // unix seconds (lightweight-charts 기준)
+}
+
 function fmtVolume(v) {
   if (v == null) return '-'
   if (v >= 100_000_000) return `${(v / 100_000_000).toFixed(1)}억`
@@ -35,17 +46,24 @@ function fmtVolume(v) {
   return v.toLocaleString('ko-KR')
 }
 
-
 export default function StockChartWidget({ instanceId, variant = 'stock-sm', colSpan = 1, rowSpan = 1, onDelete, config = {} }) {
   const [activePeriod, setActivePeriod] = useState('1일')
   const [isConfigOpen, setIsConfigOpen] = useState(false)
+  const [livePrice, setLivePrice]   = useState(null)
+  const [liveCandle, setLiveCandle] = useState(null)
   const updateWidgetConfig = useWidgetStore((s) => s.updateWidgetConfig)
   const { mutate: saveDashboard } = useDashboardSave()
 
-  const stockId      = config.stockId ?? 'samsung'
-  const stockCode    = config.stockCode ?? STOCK_CODE_MAP[stockId]
-  const stockName    = config.stockName ?? null
-  const stockMeta    = HOME_STOCKS.find((s) => s.id === stockId) ?? HOME_STOCKS[0]
+  const stockId   = config.stockId ?? 'samsung'
+  const stockCode = config.stockCode ?? STOCK_CODE_MAP[stockId]
+  const stockName = config.stockName ?? null
+  const stockMeta = HOME_STOCKS.find((s) => s.id === stockId) ?? HOME_STOCKS[0]
+
+  // 종목 변경 시 실시간 상태 초기화
+  useEffect(() => {
+    setLivePrice(null)
+    setLiveCandle(null)
+  }, [stockCode])
 
   function handleStockSave({ stockCode: newCode, stockName: newName, marketType: newMarket }) {
     updateWidgetConfig(instanceId, { stockCode: newCode, stockName: newName, marketType: newMarket, stockId: undefined })
@@ -62,17 +80,30 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
     </button>
   )
 
+  const periodTabs = (
+    <div className="flex gap-1">
+      {PERIODS.map((p) => (
+        <button
+          key={p}
+          onClick={(e) => { e.stopPropagation(); setActivePeriod(p) }}
+          className={`text-[9px] px-1.5 py-0.5 rounded font-medium transition-colors duration-[150ms] ${activePeriod === p ? 'bg-primary-light text-primary' : 'text-foreground-disabled hover:text-foreground'}`}
+        >
+          {p}
+        </button>
+      ))}
+    </div>
+  )
+
+  // ── REST 초기 데이터 ────────────────────────────────────────────
   const { data: priceData } = useQuery({
     queryKey: ['stock', 'price', stockCode],
     queryFn:  () => marketApi.getCurrentPrice(stockCode),
     enabled:  !!stockCode,
-    staleTime: 5_000,
-    refetchInterval: 10_000,
+    staleTime: 30_000,
   })
 
   const queryClient = useQueryClient()
 
-  // 위젯 마운트 시 모든 기간 데이터를 백그라운드 prefetch
   useEffect(() => {
     if (!stockCode) return
     const end = formatApiDate(new Date())
@@ -108,7 +139,6 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
     queryFn:  () => marketApi.getMinuteChart(stockCode, { ncnt: periodCfg.ncnt }),
     enabled:  !!stockCode && isMinute,
     staleTime: 60_000,
-    refetchInterval: 60_000,
   })
 
   const { data: chartRaw } = useQuery({
@@ -118,12 +148,41 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
     staleTime: 5 * 60 * 1000,
   })
 
-  const { miniChartData, latestCandle } = useMemo(() => {
+  // ── STOMP 실시간 체결 구독 ──────────────────────────────────────
+  const liveTrade = useStompSubscription(stockCode ? `/topic/stock/trade/${stockCode}` : null)
+
+  useEffect(() => {
+    if (!liveTrade) return
+    const price  = Number(liveTrade.price)
+    const volume = Number(liveTrade.cvolume)
+    if (!price || !volume) return
+
+    const chetime = liveTrade.chetime ?? ''
+    if (chetime.length < 4) return
+    const time = toMinuteBucketTime(chetime)
+
+    // 캔들 누적 (분봉 기간일 때만 차트 업데이트)
+    if (isMinute) {
+      setLiveCandle((prev) => {
+        if (!prev || prev.time !== time) {
+          return { time, open: price, high: price, low: price, close: price }
+        }
+        return { ...prev, high: Math.max(prev.high, price), low: Math.min(prev.low, price), close: price }
+      })
+    }
+
+    const changeRate   = Number(liveTrade.drate ?? 0)
+    const changeAmount = Number(liveTrade.change ?? 0) * (changeRate >= 0 ? 1 : -1)
+    setLivePrice({ currentPrice: price, changeRate, changeAmount })
+  }, [liveTrade, isMinute])
+
+  // ── 차트 데이터 ────────────────────────────────────────────────
+  const { candleData, latestCandle } = useMemo(() => {
     let series = isMinute
       ? normalizeMinuteSeries(minuteRaw?.data ?? minuteRaw)
       : normalizeDailySeries(chartRaw?.data)
 
-    // 1일(분봉)은 오늘 세션만 표시 — API가 여러 날 반환할 수 있음
+    // 분봉: 오늘 세션만 표시
     if (isMinute) {
       const today = new Date()
       const todayKey = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
@@ -133,28 +192,30 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
 
     const toTime = (p) => Math.floor(p.timestamp / 1000)
     return {
-      miniChartData: series.map((p) => ({ time: toTime(p), value: p.close })),
-      latestCandle:  series[series.length - 1] ?? null,
+      candleData:   series.map((p) => ({ time: toTime(p), open: p.open, high: p.high, low: p.low, close: p.close })),
+      latestCandle: series[series.length - 1] ?? null,
     }
   }, [isMinute, minuteRaw, chartRaw])
 
-  const hasPrice = priceData != null
+  // ── 가격 표시용 (STOMP > REST 우선) ───────────────────────────
+  const priceSource = livePrice ?? priceData
+  const hasPrice = priceSource != null
   const stock = {
     ...stockMeta,
     name:      stockName ?? stockMeta.name,
     code:      stockCode ?? stockMeta.code,
-    price:     priceData?.currentPrice != null
-                 ? Number(priceData.currentPrice).toLocaleString('ko-KR')
+    price:     priceSource?.currentPrice != null
+                 ? Number(priceSource.currentPrice).toLocaleString('ko-KR')
                  : '-',
-    change:    priceData?.changeRate ?? 0,
-    changeAmt: priceData?.changeAmount != null
-                 ? Math.abs(Number(priceData.changeAmount)).toLocaleString('ko-KR')
+    change:    priceSource?.changeRate ?? 0,
+    changeAmt: priceSource?.changeAmount != null
+                 ? Math.abs(Number(priceSource.changeAmount)).toLocaleString('ko-KR')
                  : '-',
     open:       latestCandle ? Number(latestCandle.open).toLocaleString('ko-KR') : '-',
     high:       latestCandle ? Number(latestCandle.high).toLocaleString('ko-KR') : '-',
     low:        latestCandle ? Number(latestCandle.low).toLocaleString('ko-KR')  : '-',
-    volume:     priceData?.volume != null
-                  ? fmtVolume(priceData.volume)
+    volume:     priceSource?.volume != null
+                  ? fmtVolume(priceSource.volume)
                   : latestCandle ? fmtVolume(latestCandle.volume) : '-',
     marketType: config.marketType ?? stockMeta.market ?? null,
   }
@@ -169,12 +230,14 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
     />
   )
 
+  // ── variants ──────────────────────────────────────────────────
+
   if (variant === 'stock-wide') {
     return (
       <>
         <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
           <div className="flex h-full gap-2.5 min-h-0">
-            <div className="flex flex-col justify-between shrink-0">
+            <div className="flex flex-col gap-1.5 shrink-0 justify-between">
               <div className="flex items-center gap-1.5">
                 <StockAvatar name={stock.name} stockCode={stock.code} marketType={stock.marketType} color={stock.color} size="sm" />
                 <div>
@@ -185,8 +248,9 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
                   <div className="text-[9px] text-foreground-disabled mt-0.5">{stock.code}{stock.marketType ? ` · ${stock.marketType}` : ''}</div>
                 </div>
               </div>
+              {periodTabs}
               <div>
-                <div className={`text-[18px] font-bold leading-tight text-foreground`}>{stock.price}</div>
+                <div className="text-[18px] font-bold leading-tight text-foreground">{stock.price}</div>
                 {hasPrice
                   ? <div className={`text-[10px] ${isUp ? 'text-up' : 'text-down'}`}>
                       {isUp ? '▲' : '▼'} {stock.changeAmt}원 ({isUp ? '+' : ''}{stock.change}%)
@@ -195,7 +259,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
                 }
               </div>
             </div>
-            <MiniChart data={miniChartData} isMinute={isMinute} isUp={isUp} className="flex-1 min-h-0" />
+            <MiniChart candleData={candleData} liveCandle={isMinute ? liveCandle : null} isMinute={isMinute} className="flex-1 min-h-0" />
           </div>
         </WidgetCard>
         {selectModal}
@@ -219,24 +283,14 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
               </div>
             </div>
             <div className="text-right">
-              <div className={`text-[20px] font-bold leading-tight text-foreground`}>{stock.price}</div>
+              <div className="text-[20px] font-bold leading-tight text-foreground">{stock.price}</div>
               <PriceChange value={stock.change} className="text-[10px]" />
             </div>
           </div>
           <div className="flex items-center shrink-0 mb-1.5">
-            <div className="flex gap-1.5">
-              {PERIODS.map((p) => (
-                <button
-                  key={p}
-                  onClick={(e) => { e.stopPropagation(); setActivePeriod(p) }}
-                  className={`text-[9px] px-1.5 py-0.5 rounded font-medium transition-colors duration-[150ms] ${activePeriod === p ? 'bg-primary-light text-primary' : 'text-foreground-disabled hover:text-foreground'}`}
-                >
-                  {p}
-                </button>
-              ))}
-            </div>
+            {periodTabs}
           </div>
-          <MiniChart data={miniChartData} isMinute={isMinute} isUp={isUp} className="flex-1 min-h-0 rounded-xl" />
+          <MiniChart candleData={candleData} liveCandle={isMinute ? liveCandle : null} isMinute={isMinute} className="flex-1 min-h-0 rounded-xl" />
           <div className="flex justify-between shrink-0 mt-1.5">
             {[
               { label: '시가',  val: stock.open },
@@ -272,11 +326,14 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
               </div>
             </div>
             <div className="text-right">
-              <div className={`text-[18px] font-bold leading-tight text-foreground`}>{stock.price}</div>
+              <div className="text-[18px] font-bold leading-tight text-foreground">{stock.price}</div>
               <PriceChange value={stock.change} className="text-[10px]" />
             </div>
           </div>
-          <MiniChart data={miniChartData} isMinute={isMinute} isUp={isUp} className="flex-1 min-h-0 rounded-xl mb-1.5" />
+          <div className="flex shrink-0 mb-1">
+            {periodTabs}
+          </div>
+          <MiniChart candleData={candleData} liveCandle={isMinute ? liveCandle : null} isMinute={isMinute} className="flex-1 min-h-0 rounded-xl mb-1.5" />
           <div className="flex justify-between shrink-0">
             {[
               { label: '시가', val: stock.open },

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -298,7 +298,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
           <div className="flex h-full gap-2.5 min-h-0">
             <div className="flex flex-col shrink-0 justify-between">
               <div>
-                <div className="flex items-center gap-1.5 mb-1">
+                <div className="flex items-center gap-1.5 mb-1.5">
                   <StockAvatar name={stock.name} stockCode={stock.code} marketType={stock.marketType} color={stock.color} size="sm" />
                   <div>
                     <div className="flex items-center gap-1">

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -187,6 +187,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
       : () => marketApi.getMinuteChart(stockCode, { ncnt: periodCfg.ncnt }),
     enabled:  !!stockCode && isMinute,
     staleTime: 60_000,
+    refetchInterval: isOverseas && isMinute ? 60_000 : false,
   })
 
   const { data: chartRaw } = useQuery({

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -298,7 +298,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
           <div className="flex h-full gap-2.5 min-h-0">
             <div className="flex flex-col shrink-0 justify-between">
               <div>
-                <div className="flex items-center gap-1.5 mb-1.5">
+                <div className="flex items-center gap-1.5 mb-2">
                   <StockAvatar name={stock.name} stockCode={stock.code} marketType={stock.marketType} color={stock.color} size="sm" />
                   <div>
                     <div className="flex items-center gap-1">

--- a/src/components/widgets/StockSelectModal.jsx
+++ b/src/components/widgets/StockSelectModal.jsx
@@ -69,7 +69,7 @@ export default function StockSelectModal({ currentCode, currentName, onSave, onC
           {results.map((stock) => (
             <button
               key={stock.stockCode}
-              onClick={() => onSave({ stockCode: stock.stockCode, stockName: stock.stockName, marketType: stock.marketType })}
+              onClick={() => onSave({ stockCode: stock.stockCode, stockName: stock.stockName, marketType: stock.marketType, exchangeCode: stock.exchangeCode })}
               className="flex items-center justify-between px-3 py-2.5 rounded-xl hover:bg-surface-subtle transition-colors text-left"
             >
               <span className="text-[12px] font-semibold text-foreground">{stock.stockName}</span>

--- a/src/components/widgets/WidgetCard.jsx
+++ b/src/components/widgets/WidgetCard.jsx
@@ -23,7 +23,7 @@ export default function WidgetCard({ children, className = '', onDelete }) {
         <div
           className={cn(
             'h-full bg-surface border rounded-2xl p-[14px_16px]',
-            'flex flex-col overflow-hidden',
+            'flex flex-col',
             isEditMode
               ? 'border-stroke-input shadow-widget-edit'
               : 'border-stroke transition-[border-color,box-shadow] duration-[200ms] hover:border-widget-border-hover hover:shadow-widget-hover',

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -5,6 +5,7 @@ import LiveDot from '@/components/ui/LiveDot'
 import useEditModeStore from '@/store/useEditModeStore'
 import useGridStore from '@/store/useGridStore'
 import useWidgetStore from '@/store/useWidgetStore'
+import useAuthStore from '@/store/useAuthStore'
 import { cn } from '@/lib/cn'
 import SortableWidgetCard from '@/components/widgets/SortableWidgetCard'
 import PageEditModal from '@/components/layout/PageEditModal'
@@ -29,8 +30,15 @@ function PhantomSlot({ colSpan, rowSpan, gridCol, gridRow }) {
 export default function HomePage() {
   const { isEditMode } = useEditModeStore()
   const { setCellSize, setPreviewCellSize } = useGridStore()
-  const { widgets, removeWidget, phantomWidget, isDraggingNewWidget, pages, currentPageId, switchPage } = useWidgetStore()
+  const { widgets, isLoaded, removeWidget, phantomWidget, isDraggingNewWidget, pages, currentPageId, switchPage } = useWidgetStore()
+  const { isAuthenticated, isRestoring } = useAuthStore()
   const [isPageEditOpen, setIsPageEditOpen] = useState(false)
+
+  // 로드 완료 전에는 위젯 미표시 (새로고침 flash 방지)
+  // - 인증 확인 중(isRestoring): 대기
+  // - 비로그인: 빈 대시보드 표시
+  // - 로그인 + 서버 데이터 미도착: 대기
+  const safeWidgets = (!isRestoring && (isLoaded || !isAuthenticated)) ? widgets : []
   const gridRef = useRef(null)
   const isEditModeRef = useRef(isEditMode)
 
@@ -71,8 +79,8 @@ export default function HomePage() {
   // push-aside 미리보기: B를 push-aside 목적지로 임시 이동해 렌더링
   // → phantom(A의 목적지)과 B가 같은 셀에 겹치는 현상 방지
   const displayWidgets = (() => {
-    if (!phantomWidget) return widgets
-    let base = widgets
+    if (!phantomWidget) return safeWidgets
+    let base = safeWidgets
     if (phantomWidget.pushAsideId) {
       base = widgets.map((w) =>
         w.instanceId === phantomWidget.pushAsideId

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -82,7 +82,7 @@ export default function HomePage() {
     if (!phantomWidget) return safeWidgets
     let base = safeWidgets
     if (phantomWidget.pushAsideId) {
-      base = widgets.map((w) =>
+      base = base.map((w) =>
         w.instanceId === phantomWidget.pushAsideId
           ? { ...w, gridCol: phantomWidget.pushAsideCol, gridRow: phantomWidget.pushAsideRow }
           : w,


### PR DESCRIPTION
## 관련 이슈

closes #86

## 작업 내용

- `getPriceScaleMargins` 함수 추가 — 위젯 높이를 px 기준으로 환산해 `top`/`bottom` 여백을 동적 계산, 작은 위젯에서도 레이블이 경계에 걸리지 않도록 처리
- ResizeObserver에서 리사이즈 시 `scaleMargins` 재계산 후 `applyOptions` 반영
- `entireTextOnly: true` 추가 — 공간 부족 시 레이블을 숨겨 부분 표시 방지
- `MiniChart` 컨테이너 및 `WidgetCard`에서 `overflow-hidden` 제거

## 확인 방법

1. 홈 대시보드에서 주가/차트 위젯을 2×1 사이즈로 배치
2. 우측 가격 레이블이 상·하단에서 잘리지 않고 온전히 표시되는지 확인
3. 위젯 리사이즈(2×1 → 2×2 → 3×2) 전환 시 여백이 동적으로 조정되는지 확인