### PR TITLE
fix: 자산과 투자 화면 흐름을 개선

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 3.2.2(react@19.2.4)
       '@hookform/resolvers':
         specifier: ^5.2.2
-        version: 5.2.2(react-hook-form@7.71.2(react@19.2.4))
+        version: 5.2.2(react-hook-form@7.72.0(react@19.2.4))
       '@radix-ui/react-accordion':
         specifier: ^1.2.2
         version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -37,7 +37,7 @@ importers:
         version: 7.3.0
       '@tanstack/react-query':
         specifier: ^5.91.2
-        version: 5.91.2(react@19.2.4)
+        version: 5.95.2(react@19.2.4)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -61,13 +61,19 @@ importers:
         version: 19.2.4(react@19.2.4)
       react-hook-form:
         specifier: ^7.71.2
-        version: 7.71.2(react@19.2.4)
+        version: 7.72.0(react@19.2.4)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.14)(react@19.2.4)
       react-router-dom:
         specifier: ^7.13.1
-        version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react-simple-keyboard:
         specifier: ^3.8.176
-        version: 3.8.176(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 3.8.179(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -83,7 +89,7 @@ importers:
         version: 9.39.4
       '@tailwindcss/vite':
         specifier: ^4.2.1
-        version: 4.2.1(vite@8.0.0(jiti@2.6.1))
+        version: 4.2.2(vite@8.0.3(jiti@2.6.1))
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -92,7 +98,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.0
-        version: 6.0.1(vite@8.0.0(jiti@2.6.1))
+        version: 6.0.1(vite@8.0.3(jiti@2.6.1))
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.6.1)
@@ -107,10 +113,10 @@ importers:
         version: 17.4.0
       tailwindcss:
         specifier: ^4.2.1
-        version: 4.2.1
+        version: 4.2.2
       vite:
-        specifier: ^8.0.0
-        version: 8.0.0(jiti@2.6.1)
+        specifier: ^8.0.2
+        version: 8.0.3(jiti@2.6.1)
 
 packages:
 
@@ -160,12 +166,12 @@ packages:
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.28.6':
-    resolution: {integrity: sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==}
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.29.0':
-    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -203,11 +209,11 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
 
-  '@emnapi/core@1.9.0':
-    resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
+  '@emnapi/core@1.9.1':
+    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
 
-  '@emnapi/runtime@1.9.0':
-    resolution: {integrity: sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==}
+  '@emnapi/runtime@1.9.1':
+    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
 
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
@@ -305,12 +311,8 @@ packages:
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
-  '@oxc-project/runtime@0.115.0':
-    resolution: {integrity: sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-
-  '@oxc-project/types@0.115.0':
-    resolution: {integrity: sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==}
+  '@oxc-project/types@0.122.0':
+    resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
@@ -639,106 +641,106 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.9':
-    resolution: {integrity: sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
-    resolution: {integrity: sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.9':
-    resolution: {integrity: sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
+    resolution: {integrity: sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
-    resolution: {integrity: sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
+    resolution: {integrity: sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
-    resolution: {integrity: sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
+    resolution: {integrity: sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
-    resolution: {integrity: sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
-    resolution: {integrity: sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
+    resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
-    resolution: {integrity: sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
-    resolution: {integrity: sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
-    resolution: {integrity: sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
-    resolution: {integrity: sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
+    resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
-    resolution: {integrity: sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
-    resolution: {integrity: sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==}
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
+    resolution: {integrity: sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
-    resolution: {integrity: sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
+    resolution: {integrity: sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
-    resolution: {integrity: sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
+    resolution: {integrity: sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
+  '@rolldown/pluginutils@1.0.0-rc.12':
+    resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
+
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
-
-  '@rolldown/pluginutils@1.0.0-rc.9':
-    resolution: {integrity: sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==}
 
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
@@ -746,69 +748,69 @@ packages:
   '@stomp/stompjs@7.3.0':
     resolution: {integrity: sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ==}
 
-  '@tailwindcss/node@4.2.1':
-    resolution: {integrity: sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==}
+  '@tailwindcss/node@4.2.2':
+    resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
 
-  '@tailwindcss/oxide-android-arm64@4.2.1':
-    resolution: {integrity: sha512-eZ7G1Zm5EC8OOKaesIKuw77jw++QJ2lL9N+dDpdQiAB/c/B2wDh0QPFHbkBVrXnwNugvrbJFk1gK2SsVjwWReg==}
+  '@tailwindcss/oxide-android-arm64@4.2.2':
+    resolution: {integrity: sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [android]
 
-  '@tailwindcss/oxide-darwin-arm64@4.2.1':
-    resolution: {integrity: sha512-q/LHkOstoJ7pI1J0q6djesLzRvQSIfEto148ppAd+BVQK0JYjQIFSK3JgYZJa+Yzi0DDa52ZsQx2rqytBnf8Hw==}
+  '@tailwindcss/oxide-darwin-arm64@4.2.2':
+    resolution: {integrity: sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
 
-  '@tailwindcss/oxide-darwin-x64@4.2.1':
-    resolution: {integrity: sha512-/f/ozlaXGY6QLbpvd/kFTro2l18f7dHKpB+ieXz+Cijl4Mt9AI2rTrpq7V+t04nK+j9XBQHnSMdeQRhbGyt6fw==}
+  '@tailwindcss/oxide-darwin-x64@4.2.2':
+    resolution: {integrity: sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
 
-  '@tailwindcss/oxide-freebsd-x64@4.2.1':
-    resolution: {integrity: sha512-5e/AkgYJT/cpbkys/OU2Ei2jdETCLlifwm7ogMC7/hksI2fC3iiq6OcXwjibcIjPung0kRtR3TxEITkqgn0TcA==}
+  '@tailwindcss/oxide-freebsd-x64@4.2.2':
+    resolution: {integrity: sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [freebsd]
 
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1':
-    resolution: {integrity: sha512-Uny1EcVTTmerCKt/1ZuKTkb0x8ZaiuYucg2/kImO5A5Y/kBz41/+j0gxUZl+hTF3xkWpDmHX+TaWhOtba2Fyuw==}
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
+    resolution: {integrity: sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==}
     engines: {node: '>= 20'}
     cpu: [arm]
     os: [linux]
 
-  '@tailwindcss/oxide-linux-arm64-gnu@4.2.1':
-    resolution: {integrity: sha512-CTrwomI+c7n6aSSQlsPL0roRiNMDQ/YzMD9EjcR+H4f0I1SQ8QqIuPnsVp7QgMkC1Qi8rtkekLkOFjo7OlEFRQ==}
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
+    resolution: {integrity: sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
-    resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
+    resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
-    resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
+    resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@tailwindcss/oxide-linux-x64-musl@4.2.1':
-    resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
+  '@tailwindcss/oxide-linux-x64-musl@4.2.2':
+    resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@tailwindcss/oxide-wasm32-wasi@4.2.1':
-    resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
+  '@tailwindcss/oxide-wasm32-wasi@4.2.2':
+    resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
     bundledDependencies:
@@ -819,43 +821,58 @@ packages:
       - '@emnapi/wasi-threads'
       - tslib
 
-  '@tailwindcss/oxide-win32-arm64-msvc@4.2.1':
-    resolution: {integrity: sha512-YlUEHRHBGnCMh4Nj4GnqQyBtsshUPdiNroZj8VPkvTZSoHsilRCwXcVKnG9kyi0ZFAS/3u+qKHBdDc81SADTRA==}
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
+    resolution: {integrity: sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [win32]
 
-  '@tailwindcss/oxide-win32-x64-msvc@4.2.1':
-    resolution: {integrity: sha512-rbO34G5sMWWyrN/idLeVxAZgAKWrn5LiR3/I90Q9MkA67s6T1oB0xtTe+0heoBvHSpbU9Mk7i6uwJnpo4u21XQ==}
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
+    resolution: {integrity: sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
 
-  '@tailwindcss/oxide@4.2.1':
-    resolution: {integrity: sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw==}
+  '@tailwindcss/oxide@4.2.2':
+    resolution: {integrity: sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==}
     engines: {node: '>= 20'}
 
-  '@tailwindcss/vite@4.2.1':
-    resolution: {integrity: sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==}
+  '@tailwindcss/vite@4.2.2':
+    resolution: {integrity: sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==}
     peerDependencies:
-      vite: ^5.2.0 || ^6 || ^7
+      vite: ^5.2.0 || ^6 || ^7 || ^8
 
-  '@tanstack/query-core@5.91.2':
-    resolution: {integrity: sha512-Uz2pTgPC1mhqrrSGg18RKCWT/pkduAYtxbcyIyKBhw7dTWjXZIzqmpzO2lBkyWr4hlImQgpu1m1pei3UnkFRWw==}
+  '@tanstack/query-core@5.95.2':
+    resolution: {integrity: sha512-o4T8vZHZET4Bib3jZ/tCW9/7080urD4c+0/AUaYVpIqOsr7y0reBc1oX3ttNaSW5mYyvZHctiQ/UOP2PfdmFEQ==}
 
-  '@tanstack/react-query@5.91.2':
-    resolution: {integrity: sha512-GClLPzbM57iFXv+FlvOUL56XVe00PxuTaVEyj1zAObhRiKF008J5vedmaq7O6ehs+VmPHe8+PUQhMuEyv8d9wQ==}
+  '@tanstack/react-query@5.95.2':
+    resolution: {integrity: sha512-/wGkvLj/st5Ud1Q76KF1uFxScV7WeqN1slQx5280ycwAyYkIPGaRZAEgHxe3bjirSd5Zpwkj6zNcR4cqYni/ZA==}
     peerDependencies:
       react: ^18 || ^19
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -864,6 +881,15 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
@@ -902,11 +928,14 @@ packages:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  baseline-browser-mapping@2.10.8:
-    resolution: {integrity: sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==}
+  baseline-browser-mapping@2.10.10:
+    resolution: {integrity: sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -922,12 +951,27 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  caniuse-lite@1.0.30001779:
-    resolution: {integrity: sha512-U5og2PN7V4DMgF50YPNtnZJGWVLFjjsN3zb6uMT5VGYIewieDj1upwfuVNXf4Kor+89c3iCRJnSzMD5LmTvsfA==}
+  caniuse-lite@1.0.30001781:
+    resolution: {integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==}
+
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -939,6 +983,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -966,8 +1013,15 @@ packages:
       supports-color:
         optional: true
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -975,6 +1029,9 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   echarts-for-react@3.0.6:
     resolution: {integrity: sha512-4zqLgTGWS3JvkQDXjzkR1k1CHRdpd6by0988TWMJgnvDytegWLbeP/VNZmMa+0VJx2eD7Y632bi2JquXDgiGJg==}
@@ -985,11 +1042,11 @@ packages:
   echarts@6.0.0:
     resolution: {integrity: sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==}
 
-  electron-to-chromium@1.5.313:
-    resolution: {integrity: sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==}
+  electron-to-chromium@1.5.325:
+    resolution: {integrity: sha512-PwfIw7WQSt3xX7yOf5OE/unLzsK9CaN2f/FvV3WjPR1Knoc1T9vePRVV4W1EM301JzzysK51K7FNKcusCr0zYA==}
 
-  enhanced-resolve@5.20.0:
-    resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
+  enhanced-resolve@5.20.1:
+    resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
   escalade@3.2.0:
@@ -999,6 +1056,10 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   eslint-plugin-react-hooks@7.0.1:
     resolution: {integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==}
@@ -1049,9 +1110,15 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fancy-canvas@2.1.0:
     resolution: {integrity: sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==}
@@ -1086,8 +1153,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.4.1:
-    resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1121,11 +1188,20 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1139,6 +1215,18 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1146,6 +1234,13 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1187,34 +1282,16 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  lightningcss-android-arm64@1.31.1:
-    resolution: {integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [android]
-
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [android]
 
-  lightningcss-darwin-arm64@1.31.1:
-    resolution: {integrity: sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [darwin]
-
   lightningcss-darwin-arm64@1.32.0:
     resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
-    os: [darwin]
-
-  lightningcss-darwin-x64@1.31.1:
-    resolution: {integrity: sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
     os: [darwin]
 
   lightningcss-darwin-x64@1.32.0:
@@ -1223,36 +1300,17 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  lightningcss-freebsd-x64@1.31.1:
-    resolution: {integrity: sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [freebsd]
-
   lightningcss-freebsd-x64@1.32.0:
     resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
 
-  lightningcss-linux-arm-gnueabihf@1.31.1:
-    resolution: {integrity: sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm]
-    os: [linux]
-
   lightningcss-linux-arm-gnueabihf@1.32.0:
     resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
-
-  lightningcss-linux-arm64-gnu@1.31.1:
-    resolution: {integrity: sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
@@ -1261,26 +1319,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  lightningcss-linux-arm64-musl@1.31.1:
-    resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
-
-  lightningcss-linux-x64-gnu@1.31.1:
-    resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
@@ -1289,13 +1333,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  lightningcss-linux-x64-musl@1.31.1:
-    resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
@@ -1303,22 +1340,10 @@ packages:
     os: [linux]
     libc: [musl]
 
-  lightningcss-win32-arm64-msvc@1.31.1:
-    resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [win32]
-
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
-    os: [win32]
-
-  lightningcss-win32-x64-msvc@1.31.1:
-    resolution: {integrity: sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
     os: [win32]
 
   lightningcss-win32-x64-msvc@1.32.0:
@@ -1326,10 +1351,6 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
-
-  lightningcss@1.31.1:
-    resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
-    engines: {node: '>= 12.0.0'}
 
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
@@ -1345,6 +1366,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -1355,6 +1379,138 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
@@ -1389,6 +1545,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1400,8 +1559,8 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   postcss@8.5.8:
@@ -1412,6 +1571,9 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1421,11 +1583,17 @@ packages:
     peerDependencies:
       react: ^19.2.4
 
-  react-hook-form@7.71.2:
-    resolution: {integrity: sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==}
+  react-hook-form@7.72.0:
+    resolution: {integrity: sha512-V4v6jubaf6JAurEaVnT9aUPKFbNtDgohj5CIgVGyPHvT9wRx5OZHVjz31GsxnPNI278XMu+ruFz+wGOscHaLKw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -1447,15 +1615,15 @@ packages:
       '@types/react':
         optional: true
 
-  react-router-dom@7.13.1:
-    resolution: {integrity: sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==}
+  react-router-dom@7.13.2:
+    resolution: {integrity: sha512-aR7SUORwTqAW0JDeiWF07e9SBE9qGpByR9I8kJT5h/FrBKxPMS6TiC7rmVO+gC0q52Bx7JnjWe8Z1sR9faN4YA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  react-router@7.13.1:
-    resolution: {integrity: sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==}
+  react-router@7.13.2:
+    resolution: {integrity: sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -1464,8 +1632,8 @@ packages:
       react-dom:
         optional: true
 
-  react-simple-keyboard@3.8.176:
-    resolution: {integrity: sha512-Ozf4ybTG0wXaCXM0A8sie9kWlXM3Wxut7OP9InXE2x0cshYQZRnFBE346MVaIWD49bU6BTzeFjgkTEvqKzuv0A==}
+  react-simple-keyboard@3.8.179:
+    resolution: {integrity: sha512-J9WZl6zwHju+LN1o9oQW2sFwAMAikR0GzrDbXBc6rImItNb1jYkI3f6WsWcFIMfDz4cdI7yhhK8dtrFbF43/eg==}
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -1484,12 +1652,24 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
-  rolldown@1.0.0-rc.9:
-    resolution: {integrity: sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==}
+  rolldown@1.0.0-rc.12:
+    resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -1518,9 +1698,21 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -1529,16 +1721,22 @@ packages:
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
-  tailwindcss@4.2.1:
-    resolution: {integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==}
+  tailwindcss@4.2.2:
+    resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
 
-  tapable@2.3.0:
-    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+  tapable@2.3.2:
+    resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
   tslib@2.3.0:
     resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
@@ -1549,6 +1747,24 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -1579,13 +1795,19 @@ packages:
       '@types/react':
         optional: true
 
-  vite@8.0.0:
-    resolution: {integrity: sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==}
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite@8.0.3:
+    resolution: {integrity: sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.0.0-alpha.31
+      '@vitejs/devtools': ^0.1.0
       esbuild: ^0.27.0
       jiti: '>=1.21.0'
       less: ^4.0.0
@@ -1668,6 +1890,9 @@ packages:
       use-sync-external-store:
         optional: true
 
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
 snapshots:
 
   '@babel/code-frame@7.29.0':
@@ -1684,8 +1909,8 @@ snapshots:
       '@babel/generator': 7.29.1
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helpers': 7.28.6
-      '@babel/parser': 7.29.0
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
@@ -1700,7 +1925,7 @@ snapshots:
 
   '@babel/generator@7.29.1':
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
@@ -1738,19 +1963,19 @@ snapshots:
 
   '@babel/helper-validator-option@7.27.1': {}
 
-  '@babel/helpers@7.28.6':
+  '@babel/helpers@7.29.2':
     dependencies:
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
 
-  '@babel/parser@7.29.0':
+  '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
 
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
 
   '@babel/traverse@7.29.0':
@@ -1758,7 +1983,7 @@ snapshots:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
       debug: 4.4.3
@@ -1795,13 +2020,13 @@ snapshots:
       react: 19.2.4
       tslib: 2.8.1
 
-  '@emnapi/core@1.9.0':
+  '@emnapi/core@1.9.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.0
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.0':
+  '@emnapi/runtime@1.9.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -1874,10 +2099,10 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@hookform/resolvers@5.2.2(react-hook-form@7.71.2(react@19.2.4))':
+  '@hookform/resolvers@5.2.2(react-hook-form@7.72.0(react@19.2.4))':
     dependencies:
       '@standard-schema/utils': 0.3.0
-      react-hook-form: 7.71.2(react@19.2.4)
+      react-hook-form: 7.72.0(react@19.2.4)
 
   '@humanfs/core@0.19.1': {}
 
@@ -1911,14 +2136,12 @@ snapshots:
 
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
-      '@emnapi/core': 1.9.0
-      '@emnapi/runtime': 1.9.0
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@oxc-project/runtime@0.115.0': {}
-
-  '@oxc-project/types@0.115.0': {}
+  '@oxc-project/types@0.122.0': {}
 
   '@radix-ui/primitive@1.1.3': {}
 
@@ -2231,134 +2454,134 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.9':
+  '@rolldown/binding-android-arm64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.9':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
     dependencies:
       '@napi-rs/wasm-runtime': 1.1.1
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
     optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.12': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
-
-  '@rolldown/pluginutils@1.0.0-rc.9': {}
 
   '@standard-schema/utils@0.3.0': {}
 
   '@stomp/stompjs@7.3.0': {}
 
-  '@tailwindcss/node@4.2.1':
+  '@tailwindcss/node@4.2.2':
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      enhanced-resolve: 5.20.0
+      enhanced-resolve: 5.20.1
       jiti: 2.6.1
-      lightningcss: 1.31.1
+      lightningcss: 1.32.0
       magic-string: 0.30.21
       source-map-js: 1.2.1
-      tailwindcss: 4.2.1
+      tailwindcss: 4.2.2
 
-  '@tailwindcss/oxide-android-arm64@4.2.1':
+  '@tailwindcss/oxide-android-arm64@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-darwin-arm64@4.2.1':
+  '@tailwindcss/oxide-darwin-arm64@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-darwin-x64@4.2.1':
+  '@tailwindcss/oxide-darwin-x64@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-freebsd-x64@4.2.1':
+  '@tailwindcss/oxide-freebsd-x64@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1':
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm64-gnu@4.2.1':
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-linux-x64-musl@4.2.1':
+  '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-wasm32-wasi@4.2.1':
+  '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-win32-arm64-msvc@4.2.1':
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-win32-x64-msvc@4.2.1':
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide@4.2.1':
+  '@tailwindcss/oxide@4.2.2':
     optionalDependencies:
-      '@tailwindcss/oxide-android-arm64': 4.2.1
-      '@tailwindcss/oxide-darwin-arm64': 4.2.1
-      '@tailwindcss/oxide-darwin-x64': 4.2.1
-      '@tailwindcss/oxide-freebsd-x64': 4.2.1
-      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.1
-      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.1
-      '@tailwindcss/oxide-linux-arm64-musl': 4.2.1
-      '@tailwindcss/oxide-linux-x64-gnu': 4.2.1
-      '@tailwindcss/oxide-linux-x64-musl': 4.2.1
-      '@tailwindcss/oxide-wasm32-wasi': 4.2.1
-      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.1
-      '@tailwindcss/oxide-win32-x64-msvc': 4.2.1
+      '@tailwindcss/oxide-android-arm64': 4.2.2
+      '@tailwindcss/oxide-darwin-arm64': 4.2.2
+      '@tailwindcss/oxide-darwin-x64': 4.2.2
+      '@tailwindcss/oxide-freebsd-x64': 4.2.2
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.2
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.2
+      '@tailwindcss/oxide-linux-arm64-musl': 4.2.2
+      '@tailwindcss/oxide-linux-x64-gnu': 4.2.2
+      '@tailwindcss/oxide-linux-x64-musl': 4.2.2
+      '@tailwindcss/oxide-wasm32-wasi': 4.2.2
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
+      '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
 
-  '@tailwindcss/vite@4.2.1(vite@8.0.0(jiti@2.6.1))':
+  '@tailwindcss/vite@4.2.2(vite@8.0.3(jiti@2.6.1))':
     dependencies:
-      '@tailwindcss/node': 4.2.1
-      '@tailwindcss/oxide': 4.2.1
-      tailwindcss: 4.2.1
-      vite: 8.0.0(jiti@2.6.1)
+      '@tailwindcss/node': 4.2.2
+      '@tailwindcss/oxide': 4.2.2
+      tailwindcss: 4.2.2
+      vite: 8.0.3(jiti@2.6.1)
 
-  '@tanstack/query-core@5.91.2': {}
+  '@tanstack/query-core@5.95.2': {}
 
-  '@tanstack/react-query@5.91.2(react@19.2.4)':
+  '@tanstack/react-query@5.95.2(react@19.2.4)':
     dependencies:
-      '@tanstack/query-core': 5.91.2
+      '@tanstack/query-core': 5.95.2
       react: 19.2.4
 
   '@tybys/wasm-util@0.10.1':
@@ -2366,9 +2589,27 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
+
   '@types/estree@1.0.8': {}
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/json-schema@7.0.15': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -2378,10 +2619,16 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.0(jiti@2.6.1))':
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
+
+  '@ungap/structured-clone@1.3.0': {}
+
+  '@vitejs/plugin-react@6.0.1(vite@8.0.3(jiti@2.6.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.0(jiti@2.6.1)
+      vite: 8.0.3(jiti@2.6.1)
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -2406,9 +2653,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
-  baseline-browser-mapping@2.10.8: {}
+  baseline-browser-mapping@2.10.10: {}
 
   brace-expansion@1.1.12:
     dependencies:
@@ -2417,20 +2666,30 @@ snapshots:
 
   browserslist@4.28.1:
     dependencies:
-      baseline-browser-mapping: 2.10.8
-      caniuse-lite: 1.0.30001779
-      electron-to-chromium: 1.5.313
+      baseline-browser-mapping: 2.10.10
+      caniuse-lite: 1.0.30001781
+      electron-to-chromium: 1.5.325
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
   callsites@3.1.0: {}
 
-  caniuse-lite@1.0.30001779: {}
+  caniuse-lite@1.0.30001781: {}
+
+  ccount@2.0.1: {}
 
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   clsx@2.1.1: {}
 
@@ -2439,6 +2698,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   concat-map@0.0.1: {}
 
@@ -2458,11 +2719,21 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   deep-is@0.1.4: {}
+
+  dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   echarts-for-react@3.0.6(echarts@6.0.0)(react@19.2.4):
     dependencies:
@@ -2476,21 +2747,23 @@ snapshots:
       tslib: 2.3.0
       zrender: 6.0.0
 
-  electron-to-chromium@1.5.313: {}
+  electron-to-chromium@1.5.325: {}
 
-  enhanced-resolve@5.20.0:
+  enhanced-resolve@5.20.1:
     dependencies:
       graceful-fs: 4.2.11
-      tapable: 2.3.0
+      tapable: 2.3.2
 
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   eslint-plugin-react-hooks@7.0.1(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       eslint: 9.39.4(jiti@2.6.1)
       hermes-parser: 0.25.1
       zod: 4.3.6
@@ -2568,7 +2841,11 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
   esutils@2.0.3: {}
+
+  extend@3.0.2: {}
 
   fancy-canvas@2.1.0: {}
 
@@ -2578,9 +2855,9 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -2593,10 +2870,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.4.1
+      flatted: 3.4.2
       keyv: 4.5.4
 
-  flatted@3.4.1: {}
+  flatted@3.4.2: {}
 
   fsevents@2.3.3:
     optional: true
@@ -2617,11 +2894,37 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hermes-estree@0.25.1: {}
 
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  html-url-attributes@3.0.1: {}
 
   ignore@5.3.2: {}
 
@@ -2632,11 +2935,26 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  inline-style-parser@0.2.7: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
+  is-decimal@2.0.1: {}
+
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-hexadecimal@2.0.1: {}
+
+  is-plain-obj@4.1.0: {}
 
   isexe@2.0.0: {}
 
@@ -2667,87 +2985,38 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  lightningcss-android-arm64@1.31.1:
-    optional: true
-
   lightningcss-android-arm64@1.32.0:
-    optional: true
-
-  lightningcss-darwin-arm64@1.31.1:
     optional: true
 
   lightningcss-darwin-arm64@1.32.0:
     optional: true
 
-  lightningcss-darwin-x64@1.31.1:
-    optional: true
-
   lightningcss-darwin-x64@1.32.0:
-    optional: true
-
-  lightningcss-freebsd-x64@1.31.1:
     optional: true
 
   lightningcss-freebsd-x64@1.32.0:
     optional: true
 
-  lightningcss-linux-arm-gnueabihf@1.31.1:
-    optional: true
-
   lightningcss-linux-arm-gnueabihf@1.32.0:
-    optional: true
-
-  lightningcss-linux-arm64-gnu@1.31.1:
     optional: true
 
   lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
-  lightningcss-linux-arm64-musl@1.31.1:
-    optional: true
-
   lightningcss-linux-arm64-musl@1.32.0:
-    optional: true
-
-  lightningcss-linux-x64-gnu@1.31.1:
     optional: true
 
   lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
-  lightningcss-linux-x64-musl@1.31.1:
-    optional: true
-
   lightningcss-linux-x64-musl@1.32.0:
-    optional: true
-
-  lightningcss-win32-arm64-msvc@1.31.1:
     optional: true
 
   lightningcss-win32-arm64-msvc@1.32.0:
     optional: true
 
-  lightningcss-win32-x64-msvc@1.31.1:
-    optional: true
-
   lightningcss-win32-x64-msvc@1.32.0:
     optional: true
-
-  lightningcss@1.31.1:
-    dependencies:
-      detect-libc: 2.1.2
-    optionalDependencies:
-      lightningcss-android-arm64: 1.31.1
-      lightningcss-darwin-arm64: 1.31.1
-      lightningcss-darwin-x64: 1.31.1
-      lightningcss-freebsd-x64: 1.31.1
-      lightningcss-linux-arm-gnueabihf: 1.31.1
-      lightningcss-linux-arm64-gnu: 1.31.1
-      lightningcss-linux-arm64-musl: 1.31.1
-      lightningcss-linux-x64-gnu: 1.31.1
-      lightningcss-linux-x64-musl: 1.31.1
-      lightningcss-win32-arm64-msvc: 1.31.1
-      lightningcss-win32-x64-msvc: 1.31.1
 
   lightningcss@1.32.0:
     dependencies:
@@ -2775,6 +3044,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  longest-streak@3.1.0: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -2786,6 +3057,352 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  markdown-table@3.0.4: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   minimatch@3.1.5:
     dependencies:
@@ -2820,13 +3437,23 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
 
   picocolors@1.1.1: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   postcss@8.5.8:
     dependencies:
@@ -2836,6 +3463,8 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  property-information@7.1.0: {}
+
   punycode@2.3.1: {}
 
   react-dom@19.2.4(react@19.2.4):
@@ -2843,9 +3472,27 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
-  react-hook-form@7.71.2(react@19.2.4):
+  react-hook-form@7.72.0(react@19.2.4):
     dependencies:
       react: 19.2.4
+
+  react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.14
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.4
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
     dependencies:
@@ -2866,13 +3513,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  react-router-dom@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-router-dom@7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      react-router: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-router: 7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-router@7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       cookie: 1.1.1
       react: 19.2.4
@@ -2880,7 +3527,7 @@ snapshots:
     optionalDependencies:
       react-dom: 19.2.4(react@19.2.4)
 
-  react-simple-keyboard@3.8.176(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-simple-keyboard@3.8.179(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -2895,28 +3542,62 @@ snapshots:
 
   react@19.2.4: {}
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
   resolve-from@4.0.0: {}
 
-  rolldown@1.0.0-rc.9:
+  rolldown@1.0.0-rc.12:
     dependencies:
-      '@oxc-project/types': 0.115.0
-      '@rolldown/pluginutils': 1.0.0-rc.9
+      '@oxc-project/types': 0.122.0
+      '@rolldown/pluginutils': 1.0.0-rc.12
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.9
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.9
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.9
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.9
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.9
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.9
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.9
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.9
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.9
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.9
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.9
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.9
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.9
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.9
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.9
+      '@rolldown/binding-android-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.12
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
 
   scheduler@0.27.0: {}
 
@@ -2934,7 +3615,22 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-json-comments@3.1.1: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   supports-color@7.2.0:
     dependencies:
@@ -2942,14 +3638,18 @@ snapshots:
 
   tailwind-merge@3.5.0: {}
 
-  tailwindcss@4.2.1: {}
+  tailwindcss@4.2.2: {}
 
-  tapable@2.3.0: {}
+  tapable@2.3.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
 
   tslib@2.3.0: {}
 
@@ -2958,6 +3658,39 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
@@ -2984,13 +3717,22 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  vite@8.0.0(jiti@2.6.1):
+  vfile-message@4.0.3:
     dependencies:
-      '@oxc-project/runtime': 0.115.0
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
+  vite@8.0.3(jiti@2.6.1):
+    dependencies:
       lightningcss: 1.32.0
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       postcss: 8.5.8
-      rolldown: 1.0.0-rc.9
+      rolldown: 1.0.0-rc.12
       tinyglobby: 0.2.15
     optionalDependencies:
       fsevents: 2.3.3
@@ -3020,3 +3762,5 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       react: 19.2.4
+
+  zwitch@2.0.4: {}

--- a/src/api/balance.js
+++ b/src/api/balance.js
@@ -25,6 +25,9 @@ export const balanceApi = {
   // 총 평가자산 요약
   getBalanceSummary: () => get('/api/balance/summary'),
 
+  // 자산 흐름 시계열
+  getAssetFlow: (range = '1M') => get('/api/balance/flow', { range }),
+
   // 포트폴리오 비중
   getPortfolio: () => get('/api/portfolio'),
 }

--- a/src/components/asset/ExchangeModal.jsx
+++ b/src/components/asset/ExchangeModal.jsx
@@ -1,14 +1,52 @@
-import { useState, useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { X, ArrowLeftRight, Loader2 } from 'lucide-react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { exchangeApi } from '@/api/exchange'
+import SplashScreenFill from '@/components/ui/SplashScreenFill'
+
+const EXCHANGE_RESULT_DELAY_MS = 1400
 
 function fmt(n) {
   return Math.round(Number(n ?? 0)).toLocaleString('ko-KR')
 }
 
+function fmtUsd(n, minimumFractionDigits = 0, maximumFractionDigits = 4) {
+  return Number(n ?? 0).toLocaleString('en-US', {
+    minimumFractionDigits,
+    maximumFractionDigits,
+  })
+}
+
+function fmtRate(n) {
+  return Number(n ?? 0).toLocaleString('ko-KR', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+}
+
 function parseAmount(str) {
   return Number(str.replace(/,/g, '')) || 0
+}
+
+function normalizeInputRaw(value, direction) {
+  const sanitized = String(value ?? '').replace(/[^0-9.]/g, '')
+
+  if (direction === 'KRW_TO_USD') {
+    return sanitized.replace(/\./g, '')
+  }
+
+  const [integerPart = '', ...decimalParts] = sanitized.split('.')
+  return decimalParts.length > 0
+    ? `${integerPart}.${decimalParts.join('')}`
+    : integerPart
+}
+
+function getMaxInputRaw(balance, direction) {
+  if (direction === 'KRW_TO_USD') {
+    return String(Math.floor(Number(balance ?? 0)))
+  }
+
+  return normalizeInputRaw(String(balance ?? 0), direction)
 }
 
 export default function ExchangeModal({ onClose, krwBalance, usdBalance }) {
@@ -19,26 +57,23 @@ export default function ExchangeModal({ onClose, krwBalance, usdBalance }) {
   const [preview, setPreview] = useState(null)
   const [previewLoading, setPreviewLoading] = useState(false)
   const [previewError, setPreviewError] = useState(null)
+  const [resultLoading, setResultLoading] = useState(false)
   const [done, setDone] = useState(null)         // 완료된 ExchangeResponse
 
   const debounceRef = useRef(null)
+  const resultTimerRef = useRef(null)
 
   const fromCurrency = dir === 'KRW_TO_USD' ? 'KRW' : 'USD'
   const toCurrency   = dir === 'KRW_TO_USD' ? 'USD' : 'KRW'
   const maxBalance   = dir === 'KRW_TO_USD' ? krwBalance : usdBalance
   const unit         = dir === 'KRW_TO_USD' ? '원' : '$'
 
-  // 방향 전환 시 입력·프리뷰 초기화
-  function toggleDir() {
-    setDir((d) => d === 'KRW_TO_USD' ? 'USD_TO_KRW' : 'KRW_TO_USD')
-    setInputRaw('')
-    setPreview(null)
-    setPreviewError(null)
-  }
+  useEffect(() => () => {
+    clearTimeout(debounceRef.current)
+    clearTimeout(resultTimerRef.current)
+  }, [])
 
-  // 금액 입력 → 디바운스 후 프리뷰
-  function handleInput(e) {
-    const raw = e.target.value.replace(/[^0-9.]/g, '')
+  function requestPreview(raw, nextFromCurrency = fromCurrency, nextToCurrency = toCurrency) {
     setInputRaw(raw)
     setPreview(null)
     setPreviewError(null)
@@ -50,7 +85,7 @@ export default function ExchangeModal({ onClose, krwBalance, usdBalance }) {
     debounceRef.current = setTimeout(async () => {
       setPreviewLoading(true)
       try {
-        const data = await exchangeApi.getAvailable(fromCurrency, toCurrency, amount)
+        const data = await exchangeApi.getAvailable(nextFromCurrency, nextToCurrency, amount)
         setPreview(data)
       } catch {
         setPreviewError('환율 정보를 가져오지 못했습니다.')
@@ -60,9 +95,14 @@ export default function ExchangeModal({ onClose, krwBalance, usdBalance }) {
     }, 400)
   }
 
+  // 금액 입력 → 디바운스 후 프리뷰
+  function handleInput(e) {
+    requestPreview(normalizeInputRaw(e.target.value, dir))
+  }
+
   // 전액 입력
   function handleMax() {
-    setInputRaw(String(maxBalance))
+    requestPreview(getMaxInputRaw(maxBalance, dir))
   }
 
   // 환전 실행
@@ -73,12 +113,34 @@ export default function ExchangeModal({ onClose, krwBalance, usdBalance }) {
       // 잔고 관련 쿼리 갱신
       queryClient.invalidateQueries({ queryKey: ['balance'] })
       queryClient.invalidateQueries({ queryKey: ['portfolio'] })
-      setDone(data)
+      setResultLoading(true)
+      clearTimeout(resultTimerRef.current)
+      resultTimerRef.current = setTimeout(() => {
+        setResultLoading(false)
+        setDone(data)
+      }, EXCHANGE_RESULT_DELAY_MS)
     },
   })
 
   const amount = parseAmount(inputRaw)
-  const canSubmit = amount > 0 && amount <= maxBalance && preview && !isPending
+  const canSubmit = amount > 0 && amount <= maxBalance && preview && !isPending && !resultLoading
+
+  if (resultLoading) {
+    return (
+      <Overlay onClose={onClose}>
+        <div className="px-6 py-8 text-center min-h-[260px] flex flex-col items-center justify-center">
+          <div className="mb-6">
+            <SplashScreenFill inline animated />
+          </div>
+          <h2 className="text-lg font-extrabold text-foreground tracking-tight mb-1">환전 처리 중</h2>
+          <p className="text-[13px] text-foreground-disabled leading-[1.8]">
+            환전 결과를 정리하고 있어요.<br />
+            잠시만 기다려주세요.
+          </p>
+        </div>
+      </Overlay>
+    )
+  }
 
   // ── 완료 화면 ─────────────────────────────────────────────────
   if (done) {
@@ -86,21 +148,18 @@ export default function ExchangeModal({ onClose, krwBalance, usdBalance }) {
     return (
       <Overlay onClose={onClose}>
         <div className="flex flex-col items-center gap-4 py-2">
-          <div className="w-12 h-12 rounded-full bg-live/10 flex items-center justify-center">
-            <ArrowLeftRight className="w-5 h-5 text-live" strokeWidth={2.5} />
-          </div>
           <div className="text-center">
             <div className="text-[15px] font-bold text-foreground">환전 완료</div>
             <div className="text-[12px] text-foreground-disabled mt-1">
               {isKrwToUsd
-                ? `${fmt(done.requestAmount)}원 → $${fmt(done.receiveAmount)}`
-                : `$${fmt(done.requestAmount)} → ${fmt(done.receiveAmount)}원`}
+                ? `${fmt(done.requestAmount)}원 → $${fmtUsd(done.receiveAmount)}`
+                : `$${fmtUsd(done.requestAmount)} → ${fmt(done.receiveAmount)}원`}
             </div>
           </div>
           <div className="w-full flex flex-col gap-2 bg-surface-subtle rounded-xl p-3 text-[11px]">
-            <Row label="적용 환율" value={`${fmt(done.appliedRate)}원/USD`} />
-            <Row label="수수료" value={isKrwToUsd ? `${fmt(done.feeAmount)}원` : `$${fmt(done.feeAmount)}`} />
-            <Row label="수령 금액" value={isKrwToUsd ? `$${fmt(done.receiveAmount)}` : `${fmt(done.receiveAmount)}원`} bold />
+            <Row label="적용 환율" value={`${fmtRate(done.appliedRate)}원/USD`} />
+            <Row label="수수료 (1.75%)" value={isKrwToUsd ? `${fmtRate(done.feeAmount)}원` : `$${fmtUsd(done.feeAmount, 0, 4)}`} />
+            <Row label="수령 금액" value={isKrwToUsd ? `$${fmtUsd(done.receiveAmount)}` : `${fmt(done.receiveAmount)}원`} bold />
           </div>
           <button
             onClick={onClose}
@@ -124,7 +183,12 @@ export default function ExchangeModal({ onClose, krwBalance, usdBalance }) {
         ].map(({ key, label }) => (
           <button
             key={key}
-            onClick={() => { setDir(key); setInputRaw(''); setPreview(null) }}
+            onClick={() => {
+              setDir(key)
+              setInputRaw('')
+              setPreview(null)
+              setPreviewError(null)
+            }}
             className={`flex-1 py-2 rounded-xl text-[12px] font-semibold border transition-colors ${
               dir === key
                 ? 'border-primary bg-primary-light text-primary'
@@ -155,7 +219,7 @@ export default function ExchangeModal({ onClose, krwBalance, usdBalance }) {
       {/* 보유 잔고 + 전액 버튼 */}
       <div className="flex items-center justify-between mb-4">
         <span className="text-[10px] text-foreground-disabled">
-          보유 {fromCurrency}: {dir === 'KRW_TO_USD' ? `${fmt(maxBalance)}원` : `$${fmt(maxBalance)}`}
+          보유 {fromCurrency}: {dir === 'KRW_TO_USD' ? `${fmt(maxBalance)}원` : `$${fmtUsd(maxBalance)}`}
         </span>
         <button
           onClick={handleMax}
@@ -177,11 +241,17 @@ export default function ExchangeModal({ onClose, krwBalance, usdBalance }) {
       )}
       {preview && !previewLoading && (
         <div className="flex flex-col gap-2 bg-surface-subtle rounded-xl p-3 mb-4 text-[11px]">
-          <Row label="적용 환율" value={`${fmt(preview.exchangeRate)}원/USD`} />
+          <Row label="적용 환율" value={`${fmtRate(preview.exchangeRate)}원/USD`} />
+          <Row
+            label="수수료 (1.75%)"
+            value={dir === 'KRW_TO_USD'
+              ? `${fmtRate(preview.feeAmount)}원`
+              : `$${fmtUsd(preview.feeAmount)}`}
+          />
           <Row
             label="예상 수령액"
             value={dir === 'KRW_TO_USD'
-              ? `$${Number(preview.estimatedReceiveAmount).toFixed(2)}`
+              ? `$${fmtUsd(preview.estimatedReceiveAmount)}`
               : `${fmt(preview.estimatedReceiveAmount)}원`}
             bold
           />

--- a/src/components/invest/InvestOrderBookPanel.jsx
+++ b/src/components/invest/InvestOrderBookPanel.jsx
@@ -12,6 +12,9 @@ export default function InvestOrderBookPanel({
   displayCurrency,
   usdRate,
 }) {
+  const isUp = changeRate > 0
+  const isDown = changeRate < 0
+
   if (!orderBook) {
     return (
       <section className="flex w-[170px] shrink-0 flex-col overflow-hidden border-r border-stroke bg-surface">
@@ -53,8 +56,24 @@ export default function InvestOrderBookPanel({
           </button>
         ))}
 
-        <div className="flex items-center justify-between border-y-2 border-up-border bg-up-bg px-2 py-1.5">
-          <span className="text-[15px] font-black text-up">{formatVisiblePrice(currentPrice, { marketType, displayCurrency, usdRate })}</span>
+        <div
+          className={cn(
+            'flex items-center justify-between border-y-2 px-2 py-1.5',
+            isUp && 'border-up-border bg-up-bg',
+            isDown && 'border-down-border bg-down-bg',
+            !isUp && !isDown && 'border-stroke bg-surface-muted',
+          )}
+        >
+          <span
+            className={cn(
+              'text-[15px] font-black',
+              isUp && 'text-up',
+              isDown && 'text-down',
+              !isUp && !isDown && 'text-foreground',
+            )}
+          >
+            {formatVisiblePrice(currentPrice, { marketType, displayCurrency, usdRate })}
+          </span>
           {changeRate != null && !Number.isNaN(changeRate) && (
             <PriceChange value={changeRate} variant="badge" />
           )}

--- a/src/components/invest/InvestOrderPanel.jsx
+++ b/src/components/invest/InvestOrderPanel.jsx
@@ -6,14 +6,13 @@ import {
   formatDisplayPrice,
   formatNumber,
   getDisplayPriceUnitLabel,
-  toDisplayPriceInputValue,
 } from '@/features/invest/formatters'
 import { ORDER_TYPE_OPTIONS } from '@/mocks/invest'
 import { cn } from '@/lib/cn'
 import AccountPinKeypad from '@/components/signup/AccountPinKeypad'
 
-const SECTION_LABEL = 'mb-1.5 text-[10px] font-semibold uppercase tracking-[.04em] text-foreground-disabled'
-const TYPE_BTN_BASE = 'flex-1 rounded-[9px] border-[1.5px] py-[7px] text-xs font-semibold transition-colors'
+const SECTION_LABEL = 'mb-1 text-[9px] font-semibold uppercase tracking-[.04em] text-foreground-disabled'
+const TYPE_BTN_BASE = 'flex-1 rounded-[9px] border-[1.5px] py-1.5 text-[11px] font-semibold transition-colors'
 const TYPE_BTN_OFF  = 'border-stroke-input bg-surface text-foreground-tertiary'
 
 const ORDER_KIND_LABEL = { market: '시장가', limit: '지정가', current: '현재가' }
@@ -44,16 +43,20 @@ export default function InvestOrderPanel({
   onConfirm,
   onBack,
   onPinChange,
+  rememberPin,
+  onRememberPinChange,
   onPinDone,
   onPinClose,
   isSubmitting,
+  orderError = '',
 }) {
   const isBuy = side === 'buy'
   const totalAmount = quantity * unitPrice
   const isConfirm = step === 'confirm'
   const priceUnitLabel = getDisplayPriceUnitLabel({ marketType, displayCurrency })
-  const displaySelectedPrice = toDisplayPriceInputValue(selectedPrice, { marketType, displayCurrency, usdRate })
-  const priceInputStep = priceUnitLabel === '달러' ? '0.01' : '1'
+  const formattedSelectedPrice = selectedPrice == null
+    ? ''
+    : formatDisplayPrice(selectedPrice, { marketType, displayCurrency, usdRate })
 
   const tone = isBuy
     ? {
@@ -82,7 +85,7 @@ export default function InvestOrderPanel({
     <section className="flex w-[250px] shrink-0 flex-col overflow-hidden bg-surface">
 
       {/* 상단 탭 — 항상 고정 */}
-      <div className="border-b border-stroke px-3 py-2.5 shrink-0">
+      <div className="border-b border-stroke px-3 py-2 shrink-0">
         <div className="flex gap-0.5 rounded-[10px] bg-background p-0.5">
           {[{ key: 'buy', label: '매수' }, { key: 'sell', label: '매도' }].map((item) => {
             const isActive = side === item.key
@@ -92,7 +95,7 @@ export default function InvestOrderPanel({
                 key={item.key}
                 onClick={() => !isConfirm && onSideChange(item.key)}
                 className={cn(
-                  'flex-1 rounded-lg py-2 text-[13px] font-semibold transition-colors',
+                  'flex-1 rounded-lg py-1.5 text-[12px] font-semibold transition-colors',
                   isActive ? activeClass : 'text-foreground-disabled',
                   isConfirm && 'cursor-default',
                 )}
@@ -110,14 +113,14 @@ export default function InvestOrderPanel({
         {/* 입력 뷰 */}
         <div
           className={cn(
-            'absolute inset-0 overflow-y-auto px-3 py-3 flex flex-col gap-3.5 transition-opacity duration-200',
+            'absolute inset-0 overflow-y-auto px-3 py-2.5 flex flex-col gap-3 transition-opacity duration-200',
             isConfirm ? 'opacity-0 pointer-events-none' : 'opacity-100',
           )}
         >
           {/* 주문 유형 */}
           <div>
             <div className={SECTION_LABEL}>주문 유형</div>
-            <div className="flex gap-1">
+            <div className="flex gap-0.75">
               {ORDER_TYPE_OPTIONS.map((item) => {
                 const isOn = orderType === item.key
                 const onClass = isBuy
@@ -138,19 +141,19 @@ export default function InvestOrderPanel({
 
           {/* 주문 수량 */}
           <div>
-            <div className="mb-1.5 flex items-center justify-between">
+            <div className="mb-1 flex items-center justify-between">
               <span className={SECTION_LABEL.replace('mb-1.5 ', '')}>주문 수량</span>
               <span className="text-[10px] text-foreground-disabled">
                 {availabilityLabel}{' '}
                 <span className="font-bold text-primary">{availabilityValue}</span>
               </span>
             </div>
-            <div className="mb-1.5 flex items-center gap-1.5">
+            <div className="mb-1 flex items-center gap-1">
               <button type="button" onClick={() => onQuantityDelta(-1)}
-                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border-[1.5px] border-stroke-input bg-surface text-foreground-secondary transition-colors hover:border-primary hover:text-primary">
-                <Minus className="h-3.5 w-3.5" strokeWidth={2.5} />
+                className="flex h-7.5 w-7.5 shrink-0 items-center justify-center rounded-lg border-[1.5px] border-stroke-input bg-surface text-foreground-secondary transition-colors hover:border-primary hover:text-primary">
+                <Minus className="h-3 w-3" strokeWidth={2.5} />
               </button>
-              <div className="flex-1 rounded-[10px] border-[1.5px] border-stroke-input bg-surface px-3 py-1.5 text-center flex items-center justify-center focus-within:border-primary transition-colors">
+              <div className="flex-1 rounded-[10px] border-[1.5px] border-stroke-input bg-surface px-2.5 py-1 text-center flex items-center justify-center focus-within:border-primary transition-colors">
                 <input
                   type="number"
                   value={quantity}
@@ -162,22 +165,22 @@ export default function InvestOrderPanel({
                     const v = parseInt(e.target.value, 10)
                     onQuantityChange?.(isNaN(v) || v < 1 ? 1 : v)
                   }}
-                  className="w-full bg-transparent text-[20px] font-black text-foreground text-center outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                  className="w-full bg-transparent text-[18px] font-black text-foreground text-center outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
                 />
                 <span className="ml-1 shrink-0 text-[10px] text-foreground-disabled">주</span>
               </div>
               <button type="button" onClick={() => onQuantityDelta(1)}
-                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border-[1.5px] border-stroke-input bg-surface text-foreground-secondary transition-colors hover:border-primary hover:text-primary">
-                <Plus className="h-3.5 w-3.5" strokeWidth={2.5} />
+                className="flex h-7.5 w-7.5 shrink-0 items-center justify-center rounded-lg border-[1.5px] border-stroke-input bg-surface text-foreground-secondary transition-colors hover:border-primary hover:text-primary">
+                <Plus className="h-3 w-3" strokeWidth={2.5} />
               </button>
             </div>
-            <div className="flex gap-1">
+            <div className="flex gap-0.75">
               {QUICK_RATIOS.map((item) => {
                 const isMax = item.ratio === 1
                 return (
                   <button key={item.label} onClick={() => onPresetApply(item.ratio)}
                     className={cn(
-                      'flex-1 rounded-[7px] border-[1.5px] py-1.5 text-[10px] font-semibold transition-colors',
+                      'flex-1 rounded-[7px] border-[1.5px] py-1.25 text-[9px] font-semibold transition-colors',
                       isMax
                         ? isBuy ? 'border-up-border bg-up-bg text-up' : 'border-down-border bg-down-bg text-down'
                         : 'border-stroke-input bg-surface-subtle text-foreground-tertiary hover:border-primary hover:text-primary',
@@ -194,24 +197,26 @@ export default function InvestOrderPanel({
           <div>
             <div className={SECTION_LABEL}>주문 가격</div>
             <div className={cn(
-              'rounded-[10px] border-[1.5px] bg-surface px-3 py-2.5 flex items-center justify-between transition-colors',
+              'rounded-[10px] border-[1.5px] bg-surface px-3 py-2 flex items-center justify-between transition-colors',
               orderType === 'limit' ? 'border-stroke-input focus-within:border-primary' : 'border-stroke-input',
             )}>
               {orderType === 'limit' ? (
                 <input
-                  type="number"
-                  step={priceInputStep}
-                  value={displaySelectedPrice}
+                  type="text"
+                  inputMode={priceUnitLabel === '달러' ? 'decimal' : 'numeric'}
+                  value={formattedSelectedPrice}
                   onChange={(e) => {
-                    const v = Number(e.target.value)
+                    const rawValue = e.target.value.replaceAll(',', '').trim()
+                    if (rawValue === '') return
+                    const v = Number(rawValue)
                     const marketValue = convertDisplayValueToMarketValue(v, { marketType, displayCurrency, usdRate })
                     if (!isNaN(v) && v >= 0 && marketValue != null) onSelectPrice?.(marketValue)
                   }}
-                  className="w-full bg-transparent text-[17px] font-black text-foreground outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                  className="w-full bg-transparent text-[16px] font-black text-foreground outline-none"
                   placeholder="0"
                 />
               ) : (
-                <span className="text-[17px] font-black text-foreground">
+                <span className="text-[16px] font-black text-foreground">
                   {formatDisplayPrice(unitPrice, { marketType, displayCurrency, usdRate })}
                 </span>
               )}
@@ -220,22 +225,22 @@ export default function InvestOrderPanel({
           </div>
 
           {/* 주문 요약 */}
-          <div className={cn('rounded-[10px] border-[1.5px] p-3', tone.wrapper)}>
-            <div className="mb-2 flex items-center justify-between">
+          <div className={cn('rounded-[10px] border-[1.5px] p-2.5', tone.wrapper)}>
+            <div className="mb-1.5 flex items-center justify-between">
               <span className={cn('text-[10px] font-bold uppercase tracking-[.04em]', tone.title)}>
                 {isBuy ? '매수 요약' : '매도 요약'}
               </span>
-              <span className={cn('rounded-full px-2 py-0.5 text-[9px] font-bold', tone.badge)}>
+              <span className={cn('rounded-full px-1.5 py-0.5 text-[8px] font-bold', tone.badge)}>
                 {ORDER_TYPE_OPTIONS.find((o) => o.key === orderType)?.label}
               </span>
             </div>
-            <div className="flex flex-col gap-1.5">
+            <div className="flex flex-col gap-1">
               {[
                 { label: '종목', value: stockName },
                 { label: '수량', value: `${formatNumber(quantity)}주` },
                 { label: '단가', value: formatCurrency(unitPrice, { marketType, displayCurrency, usdRate }) },
               ].map(({ label, value }) => (
-                <div key={label} className="flex items-center justify-between text-[10px]">
+                <div key={label} className="flex items-center justify-between text-[9px]">
                   <span className="text-foreground-disabled">{label}</span>
                   <span className="font-semibold text-foreground">{value}</span>
                 </div>
@@ -245,10 +250,10 @@ export default function InvestOrderPanel({
                 <span className="text-[10px] text-foreground-disabled">
                   {isBuy ? '예상 합계' : '예상 매도금액'}
                 </span>
-                <span className={cn('text-[17px] font-black', tone.helper)}>
-                  {formatCurrency(totalAmount, { marketType, displayCurrency, usdRate })}
-                </span>
-              </div>
+                  <span className={cn('text-[16px] font-black', tone.helper)}>
+                    {formatCurrency(totalAmount, { marketType, displayCurrency, usdRate })}
+                  </span>
+                </div>
             </div>
           </div>
         </div>
@@ -261,8 +266,8 @@ export default function InvestOrderPanel({
           )}
         >
           {/* 주문 요약 (compact) */}
-          <div className="px-4 pt-4 pb-2 flex flex-col gap-2">
-            <div className={cn('text-[11px] font-bold uppercase tracking-wide', tone.title)}>
+          <div className="px-4 pt-3 pb-1.5 flex flex-col gap-1.5">
+            <div className={cn('text-[10px] font-bold uppercase tracking-wide', tone.title)}>
               주문 내용 확인
             </div>
             {[
@@ -273,17 +278,17 @@ export default function InvestOrderPanel({
                 value: formatCurrency(unitPrice, { marketType, displayCurrency, usdRate }),
               },
             ].map(({ label, value }) => (
-              <div key={label} className="flex items-center justify-between text-[12px]">
+              <div key={label} className="flex items-center justify-between text-[11px]">
                 <span className="text-foreground-disabled">{label}</span>
                 <span className="font-semibold text-foreground">{value}</span>
               </div>
             ))}
             <div className="h-px bg-stroke" />
             <div className="flex items-center justify-between">
-              <span className="text-[11px] text-foreground-disabled">
+              <span className="text-[10px] text-foreground-disabled">
                 {isBuy ? '예상 총 매수금액' : '예상 총 매도금액'}
               </span>
-              <span className={cn('text-[20px] font-black', tone.title)}>
+              <span className={cn('text-[18px] font-black', tone.title)}>
                 {formatCurrency(totalAmount, { marketType, displayCurrency, usdRate })}
               </span>
             </div>
@@ -291,12 +296,12 @@ export default function InvestOrderPanel({
 
           {/* PIN 입력 영역 */}
           {showPin && (
-            <div className="border-t border-stroke mt-1">
-              <div className="px-4 pt-3 pb-1">
+            <div className="border-t border-stroke mt-0.5">
+              <div className="px-4 pt-2.5 pb-0.5">
                 <div className="text-[10px] font-semibold text-foreground-disabled uppercase tracking-wide">계좌 비밀번호</div>
-              <div className="text-[9px] text-foreground-disabled mt-0.5 mb-2">인증 후 30분간 비밀번호를 기억해요</div>
+                <div className="text-[8px] text-foreground-disabled mt-0.5 mb-1.5">비밀번호 4자리를 입력해주세요</div>
                 {/* 도트 */}
-                <div className="flex justify-center gap-3 py-2">
+                <div className="flex justify-center gap-2 py-1">
                   {Array.from({ length: 4 }, (_, i) => (
                     <div
                       key={i}
@@ -311,7 +316,7 @@ export default function InvestOrderPanel({
                   <p className="text-center text-[10px] text-up mb-1">{pinError}</p>
                 )}
               </div>
-              <div className="sol-pin-keypad-compact px-3 pb-3">
+              <div className="sol-pin-keypad-compact px-2.5">
                 <AccountPinKeypad
                   isOpen
                   variant="desktop"
@@ -321,19 +326,67 @@ export default function InvestOrderPanel({
                   onClose={onPinClose}
                 />
               </div>
+              <div className="px-2.5 pb-2.5 pt-1">
+                <label
+                  className={cn(
+                    'flex cursor-pointer items-center justify-between rounded-[10px] border px-2.5 py-1.5 transition-colors',
+                    rememberPin
+                      ? 'border-primary-border bg-primary-light'
+                      : 'border-stroke-input bg-surface-subtle hover:bg-surface-muted',
+                  )}
+                >
+                  <input
+                    type="checkbox"
+                    checked={rememberPin}
+                    onChange={(e) => onRememberPinChange?.(e.target.checked)}
+                    className="sr-only"
+                  />
+                  <span className={cn('text-[9px] font-semibold', rememberPin ? 'text-primary' : 'text-foreground-secondary')}>
+                    30분간 비밀번호 기억하기
+                  </span>
+                  <span
+                    className={cn(
+                      'flex h-4 w-4 items-center justify-center rounded-[6px] border-[1.5px] text-[10px] font-black transition-colors',
+                      rememberPin
+                        ? 'border-primary bg-primary text-white'
+                        : 'border-stroke-input bg-surface text-transparent',
+                    )}
+                  >
+                    ✓
+                  </span>
+                </label>
+              </div>
             </div>
           )}
         </div>
       </div>
 
+      {orderError && (
+        <div className="shrink-0 px-3 pt-2">
+          <div
+            className={cn(
+              'w-full rounded-xl bg-surface px-3 py-2.5 shadow-sm',
+              isBuy ? 'border border-up-border' : 'border border-down-border',
+            )}
+          >
+            <div className="min-w-0">
+              <div className={cn('text-[10px] font-bold uppercase tracking-[.04em]', tone.title)}>주문 실패</div>
+              <div className="mt-0.75 text-[11px] leading-[1.45] text-foreground-secondary">
+                {orderError}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* 하단 버튼 — 항상 고정 */}
-      <div className="shrink-0 px-3 pb-4 pt-2 border-t border-stroke">
+      <div className="shrink-0 px-3 pb-3 pt-2 border-t border-stroke">
         {isConfirm ? (
           <div className="flex gap-2">
             <button
               onClick={showPin ? onPinClose : onBack}
               disabled={isSubmitting}
-              className="flex-1 py-3 rounded-xl border border-stroke-input text-[13px] font-semibold text-foreground-secondary hover:bg-surface-muted transition-colors disabled:opacity-50"
+              className="flex-1 py-2.5 rounded-xl border border-stroke-input text-[12px] font-semibold text-foreground-secondary hover:bg-surface-muted transition-colors disabled:opacity-50"
             >
               취소
             </button>
@@ -341,7 +394,7 @@ export default function InvestOrderPanel({
               <button
                 onClick={onConfirm}
                 disabled={isSubmitting}
-                className={cn('flex-1 py-3 rounded-xl text-[13px] font-bold transition-opacity disabled:opacity-60', tone.button)}
+                className={cn('flex-1 py-2.5 rounded-xl text-[12px] font-bold transition-opacity disabled:opacity-60', tone.button)}
               >
                 {isSubmitting ? '처리 중...' : (isBuy ? '매수 확정' : '매도 확정')}
               </button>
@@ -350,7 +403,7 @@ export default function InvestOrderPanel({
         ) : (
           <button
             onClick={onSubmit}
-            className={cn('w-full rounded-xl py-3 text-sm font-black', tone.button)}
+            className={cn('w-full rounded-xl py-2.5 text-[13px] font-black', tone.button)}
           >
             {tone.cta} →
           </button>

--- a/src/components/invest/InvestOrderSection.jsx
+++ b/src/components/invest/InvestOrderSection.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import InvestOrderBookPanel from '@/components/invest/InvestOrderBookPanel'
 import InvestOrderPanel from '@/components/invest/InvestOrderPanel'
@@ -7,6 +7,14 @@ import { orderApi, ORDER_SIDE, ORDER_KIND } from '@/api/order'
 import { isForeignMarketType } from '@/features/invest/formatters'
 import usePinAuth from '@/hooks/usePinAuth'
 import useAuthStore from '@/store/useAuthStore'
+
+function resolveOrderErrorMessage(error) {
+  if (typeof error?.message === 'string' && error.message.trim()) {
+    return error.message
+  }
+
+  return '주문을 접수하지 못했습니다.'
+}
 
 export default function InvestOrderSection({
   stockCode,
@@ -26,14 +34,18 @@ export default function InvestOrderSection({
   const [side, setSide] = useState('buy')
   const [orderType, setOrderType] = useState('market')
   const [quantity, setQuantity] = useState(1)
-  const [selectedPrice, setSelectedPrice] = useState(defaultPrice)
+  const [selectedPrice, setSelectedPrice] = useState(defaultPrice ?? null)
   const [confirmedUnitPrice, setConfirmedUnitPrice] = useState(null)
 
   const [step, setStep] = useState('input') // 'input' | 'confirm'
   const [showPin, setShowPin] = useState(false)
   const [pin, setPin] = useState('')
   const [pinError, setPinError] = useState('')
+  const [orderError, setOrderError] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [rememberPin, setRememberPin] = useState(true)
+  const [isPinVerified, setIsPinVerified] = useState(false)
+  const hasManualPriceSelectionRef = useRef(false)
 
   const marketPrice = currentPrice ?? defaultPrice
   const liveUnitPrice = orderType === 'limit' ? selectedPrice : marketPrice
@@ -66,6 +78,13 @@ export default function InvestOrderSection({
     ? Math.max(1, maxBuyableQuantity)
     : Math.max(1, availableSellQuantity)
 
+  useEffect(() => {
+    if (marketPrice == null) return
+    if (!hasManualPriceSelectionRef.current || selectedPrice == null) {
+      setSelectedPrice(marketPrice)
+    }
+  }, [marketPrice, selectedPrice])
+
   function getMaxOrderQuantity(nextSide = side, nextOrderType = orderType, nextSelectedPrice = selectedPrice) {
     if (nextSide === 'sell') return Math.max(1, availableSellQuantity)
     if (nextOrderType === 'limit') return Math.max(1, Math.floor(availableAmount / Math.max(nextSelectedPrice, 1)))
@@ -77,32 +96,42 @@ export default function InvestOrderSection({
   }
 
   function handleQuantityDelta(delta) {
+    setOrderError('')
     setQuantity((prev) => clampQuantity(prev + delta))
   }
 
   function handleQuantityChange(value) {
+    setOrderError('')
     setQuantity(clampQuantity(value))
   }
 
   function handleQuantityPreset(ratio) {
+    setOrderError('')
     const nextMax = getMaxOrderQuantity()
     setQuantity(clampQuantity(ratio === 1 ? nextMax : Math.max(1, Math.floor(nextMax * ratio))))
   }
 
   function handleSideChange(nextSide) {
     setConfirmedUnitPrice(null)
+    setOrderError('')
     setSide(nextSide)
     setQuantity((prev) => Math.min(prev, getMaxOrderQuantity(nextSide)))
   }
 
   function handleOrderTypeChange(nextOrderType) {
     setConfirmedUnitPrice(null)
+    setOrderError('')
     setOrderType(nextOrderType)
+    if (nextOrderType === 'limit' && marketPrice != null && !hasManualPriceSelectionRef.current) {
+      setSelectedPrice(marketPrice)
+    }
     setQuantity((prev) => Math.min(prev, getMaxOrderQuantity(side, nextOrderType)))
   }
 
   function handleSelectPrice(price) {
     setConfirmedUnitPrice(null)
+    setOrderError('')
+    hasManualPriceSelectionRef.current = true
     setSelectedPrice(price)
     setOrderType('limit')
     setQuantity((prev) => Math.min(prev, getMaxOrderQuantity(side, 'limit', price)))
@@ -125,9 +154,15 @@ export default function InvestOrderSection({
       setPin('')
       setPinError('')
       setConfirmedUnitPrice(null)
+      hasManualPriceSelectionRef.current = false
+      setSelectedPrice(marketPrice ?? defaultPrice ?? null)
       setQuantity(1)
+      setIsPinVerified(false)
+      setRememberPin(true)
       queryClient.invalidateQueries({ queryKey: ['balance'] })
       queryClient.invalidateQueries({ queryKey: ['orders'] })
+    } catch (error) {
+      setOrderError(resolveOrderErrorMessage(error))
     } finally {
       setIsSubmitting(false)
     }
@@ -135,12 +170,14 @@ export default function InvestOrderSection({
 
   // 매수 확정 클릭
   function handleConfirm() {
-    if (isPinCached()) {
+    setOrderError('')
+    if (isPinCached() || isPinVerified) {
       placeOrder()
     } else {
       setShowPin(true)
       setPin('')
       setPinError('')
+      setRememberPin(true)
     }
   }
 
@@ -153,8 +190,10 @@ export default function InvestOrderSection({
     setIsSubmitting(true)
     setPinError('')
     try {
-      await verifyAndCachePin(pin)
-      await placeOrder()
+      await verifyAndCachePin(pin, rememberPin)
+      setIsPinVerified(true)
+      setShowPin(false)
+      setPin('')
     } catch (err) {
       setPinError(err?.message ?? '비밀번호가 올바르지 않습니다.')
       setPin('')
@@ -168,15 +207,20 @@ export default function InvestOrderSection({
     setShowPin(false)
     setPin('')
     setPinError('')
+    setRememberPin(true)
+    setIsPinVerified(false)
   }
 
   // 뒤로 (confirm → input)
   function handleBack() {
     setConfirmedUnitPrice(null)
+    setOrderError('')
     setStep('input')
     setShowPin(false)
     setPin('')
     setPinError('')
+    setRememberPin(true)
+    setIsPinVerified(false)
   }
 
   return (
@@ -217,14 +261,18 @@ export default function InvestOrderSection({
         onPresetApply={handleQuantityPreset}
         onSubmit={() => {
           setConfirmedUnitPrice(liveUnitPrice)
+          setIsPinVerified(false)
           setStep('confirm')
         }}
         onConfirm={handleConfirm}
         onBack={handleBack}
         onPinChange={setPin}
+        rememberPin={rememberPin}
+        onRememberPinChange={setRememberPin}
         onPinDone={handlePinDone}
         onPinClose={handlePinClose}
         isSubmitting={isSubmitting}
+        orderError={orderError}
       />
     </>
   )

--- a/src/components/invest/panels/ExecutionHistoryPanel.jsx
+++ b/src/components/invest/panels/ExecutionHistoryPanel.jsx
@@ -1,8 +1,10 @@
 import { useQuery } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
 import StockAvatar from '@/components/ui/StockAvatar'
 import LockedOverlay from '@/components/ui/LockedOverlay'
 import { cn } from '@/lib/cn'
 import { formatCurrency, formatNumber, formatVisiblePrice } from '@/features/invest/formatters'
+import { buildInvestNavigationState } from '@/features/invest/navigation'
 import { orderApi } from '@/api/order'
 import useAuthStore from '@/store/useAuthStore'
 
@@ -14,6 +16,7 @@ function formatTime(dateStr) {
 }
 
 export default function ExecutionHistoryPanel({ stockCode, marketType, displayCurrency, usdRate }) {
+  const navigate = useNavigate()
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
   const isRestoring = useAuthStore((s) => s.isRestoring)
   const { data, isLoading } = useQuery({
@@ -75,10 +78,14 @@ export default function ExecutionHistoryPanel({ stockCode, marketType, displayCu
             className="grid grid-cols-[58px_minmax(0,1fr)_40px_72px_48px_90px] items-center gap-2 border-b border-stroke-subtle px-2.5 py-1.5"
           >
             <span className="text-[10px] text-foreground-disabled">{formatTime(row.filledAt ?? row.executedAt ?? row.requestedAt ?? row.createdAt)}</span>
-            <div className="flex min-w-0 items-center gap-1.5">
+            <button
+              type="button"
+              onClick={() => navigate(`/invest/${row.stockCode}`, { state: buildInvestNavigationState({ ...row, marketType: rowMarketType }) })}
+              className="flex min-w-0 items-center gap-1.5 text-left transition-opacity hover:opacity-80"
+            >
               <StockAvatar name={row.stockName ?? row.stockCode} stockCode={row.stockCode} marketType={rowMarketType} size="sm" />
               <span className="truncate text-[10px] font-semibold text-foreground">{row.stockName ?? row.stockCode}</span>
-            </div>
+            </button>
             <span className={cn('rounded-[4px] px-1 py-0.5 text-center text-[8px] font-bold', isBuy ? 'bg-up-bg text-up' : 'bg-down-bg text-down')}>
               {isBuy ? '매수' : '매도'}
             </span>

--- a/src/components/invest/panels/HoldingPanel.jsx
+++ b/src/components/invest/panels/HoldingPanel.jsx
@@ -1,5 +1,7 @@
+import { useNavigate } from 'react-router-dom'
 import { cn } from '@/lib/cn'
 import { formatCurrency, formatNumber } from '@/features/invest/formatters'
+import { buildInvestNavigationState } from '@/features/invest/navigation'
 import { useDomesticHoldings, useOverseasHoldings } from '@/api/balance'
 import StockAvatar from '@/components/ui/StockAvatar'
 import LockedOverlay from '@/components/ui/LockedOverlay'
@@ -7,6 +9,7 @@ import useAuthStore from '@/store/useAuthStore'
 
 
 export default function HoldingPanel({ displayCurrency, usdRate }) {
+  const navigate = useNavigate()
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
   const isRestoring = useAuthStore((s) => s.isRestoring)
   const { data: domestic = [], isLoading: domesticLoading } = useDomesticHoldings({ enabled: isAuthenticated && !isRestoring })
@@ -46,33 +49,40 @@ export default function HoldingPanel({ displayCurrency, usdRate }) {
       {holdings.map((h) => {
         const avgPrice     = h.avgPrice ?? h.avgBuyPrice ?? 0
         const quantity     = h.holdingQuantity ?? h.availableQuantity ?? 0
-        const evalPrice    = h.currentPrice ?? avgPrice
-        const profitLoss   = (evalPrice - avgPrice) * quantity
-        const profitRate   = avgPrice > 0 ? ((evalPrice - avgPrice) / avgPrice) * 100 : 0
-        const isProfit     = profitLoss >= 0
+        const hasCurrentPrice = h.currentPrice != null
+        const evalPrice    = hasCurrentPrice ? h.currentPrice : null
+        const profitLoss   = hasCurrentPrice ? (evalPrice - avgPrice) * quantity : null
+        const profitRate   = hasCurrentPrice && avgPrice > 0 ? ((evalPrice - avgPrice) / avgPrice) * 100 : null
+        const isProfit     = profitLoss != null ? profitLoss >= 0 : false
 
         return (
           <div
             key={h.stockCode}
             className="grid grid-cols-[28px_minmax(0,1fr)_56px_72px_72px] items-center gap-2 border-b border-stroke-subtle px-2.5 py-2"
           >
-            <StockAvatar name={h.stockName ?? h.stockCode} stockCode={h.stockCode} marketType={h.marketType} size="sm" />
-            <div className="min-w-0">
-              <div className="truncate text-[10px] font-semibold text-foreground">{h.stockName ?? h.stockCode}</div>
-              <div className="text-[9px] text-foreground-disabled">
-                {formatCurrency(evalPrice, { marketType: h.marketType, displayCurrency, usdRate })}
+            <button
+              type="button"
+              onClick={() => navigate(`/invest/${h.stockCode}`, { state: buildInvestNavigationState(h) })}
+              className="col-span-2 grid grid-cols-[28px_minmax(0,1fr)] items-center gap-2 text-left transition-opacity hover:opacity-80"
+            >
+              <StockAvatar name={h.stockName ?? h.stockCode} stockCode={h.stockCode} marketType={h.marketType} size="sm" />
+              <div className="min-w-0">
+                <div className="truncate text-[10px] font-semibold text-foreground">{h.stockName ?? h.stockCode}</div>
+                <div className="text-[9px] text-foreground-disabled">
+                  {hasCurrentPrice ? formatCurrency(evalPrice, { marketType: h.marketType, displayCurrency, usdRate }) : '-'}
+                </div>
               </div>
-            </div>
+            </button>
             <span className="text-[10px] text-right text-foreground">{formatNumber(quantity)}주</span>
             <span className="text-[10px] text-right text-foreground">
               {formatCurrency(avgPrice, { marketType: h.marketType, displayCurrency, usdRate })}
             </span>
             <div className="text-right">
-              <div className={cn('text-[10px] font-bold', isProfit ? 'text-up' : 'text-down')}>
-                {isProfit ? '+' : ''}{formatCurrency(profitLoss, { marketType: h.marketType, displayCurrency, usdRate })}
+              <div className={cn('text-[10px] font-bold', profitLoss == null ? 'text-foreground-disabled' : isProfit ? 'text-up' : 'text-down')}>
+                {profitLoss == null ? '-' : `${isProfit ? '+' : ''}${formatCurrency(profitLoss, { marketType: h.marketType, displayCurrency, usdRate })}`}
               </div>
-              <div className={cn('text-[9px]', isProfit ? 'text-up' : 'text-down')}>
-                {isProfit ? '+' : ''}{profitRate.toFixed(2)}%
+              <div className={cn('text-[9px]', profitRate == null ? 'text-foreground-disabled' : isProfit ? 'text-up' : 'text-down')}>
+                {profitRate == null ? '-' : `${isProfit ? '+' : ''}${profitRate.toFixed(2)}%`}
               </div>
             </div>
           </div>

--- a/src/components/invest/panels/PendingOrdersPanel.jsx
+++ b/src/components/invest/panels/PendingOrdersPanel.jsx
@@ -1,7 +1,9 @@
 import { useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
 import { cn } from '@/lib/cn'
 import { formatCurrency, formatNumber } from '@/features/invest/formatters'
+import { buildInvestNavigationState } from '@/features/invest/navigation'
 import { orderApi } from '@/api/order'
 import AccountPinKeypad from '@/components/signup/AccountPinKeypad'
 import StockAvatar from '@/components/ui/StockAvatar'
@@ -11,6 +13,7 @@ import useAuthStore from '@/store/useAuthStore'
 
 
 export default function PendingOrdersPanel({ stockCode, marketType, displayCurrency, usdRate }) {
+  const navigate = useNavigate()
   const queryClient = useQueryClient()
   const { isPinCached, verifyAndCachePin } = usePinAuth()
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
@@ -129,8 +132,16 @@ export default function PendingOrdersPanel({ stockCode, marketType, displayCurre
           return (
             <div key={row.orderId ?? row.id} className="flex items-center gap-2 border-b border-stroke-subtle px-2.5 py-1.5">
               <div className="grid flex-1 grid-cols-[24px_minmax(0,1fr)_40px_60px_80px] gap-2 items-center">
-                <StockAvatar name={row.stockName ?? row.stockCode} stockCode={row.stockCode} marketType={rowMarketType} size="sm" />
-                <span className="truncate text-[10px] font-semibold text-foreground">{row.stockName ?? row.stockCode}</span>
+                <button
+                  type="button"
+                  onClick={() => navigate(`/invest/${row.stockCode}`, { state: buildInvestNavigationState({ ...row, marketType: rowMarketType }) })}
+                  className="col-span-2 grid grid-cols-[24px_minmax(0,1fr)] items-center gap-2 text-left transition-opacity hover:opacity-80"
+                >
+                  <StockAvatar name={row.stockName ?? row.stockCode} stockCode={row.stockCode} marketType={rowMarketType} size="sm" />
+                  <span className="truncate text-[10px] font-semibold text-foreground">
+                    {row.stockName ?? row.stockCode}
+                  </span>
+                </button>
                 <span className={cn('rounded-[4px] px-1 py-0.5 text-center text-[8px] font-bold', isBuy ? 'bg-up-bg text-up' : 'bg-down-bg text-down')}>
                   {isBuy ? '매수' : '매도'}
                 </span>

--- a/src/components/layout/NavTabs.jsx
+++ b/src/components/layout/NavTabs.jsx
@@ -1,6 +1,9 @@
 import { useNavigate, useLocation } from 'react-router-dom'
 import { cn } from '@/lib/cn'
 
+const LAST_INVEST_PATH_KEY = 'invest.lastPath'
+const LAST_INVEST_STATE_KEY = 'invest.lastState'
+
 const TABS = [
   { label: '홈',  path: '/' },
   { label: '시세', path: '/market' },
@@ -11,17 +14,30 @@ const TABS = [
 export default function NavTabs() {
   const navigate = useNavigate()
   const { pathname } = useLocation()
-  
 
   const isActive = (path) =>
     path === '/' ? pathname === '/' : pathname.startsWith(path)
+
+  function handleNavigate(path) {
+    if (path !== '/invest') {
+      navigate(path)
+      return
+    }
+
+    const lastInvestPath = sessionStorage.getItem(LAST_INVEST_PATH_KEY) || '/invest'
+    const savedState = sessionStorage.getItem(LAST_INVEST_STATE_KEY)
+
+    navigate(lastInvestPath, {
+      state: savedState ? JSON.parse(savedState) : undefined,
+    })
+  }
 
   return (
     <nav className="flex items-center gap-0.5 bg-background rounded-xl p-1">
       {TABS.map(({ label, path }) => (
         <button
           key={path}
-          onClick={() => navigate(path)}
+          onClick={() => handleNavigate(path)}
           className={cn(
             'px-4 py-1.5 text-[12px] rounded-lg transition-colors duration-[150ms]',
             isActive(path)

--- a/src/components/layout/NavTabs.jsx
+++ b/src/components/layout/NavTabs.jsx
@@ -1,8 +1,6 @@
 import { useNavigate, useLocation } from 'react-router-dom'
 import { cn } from '@/lib/cn'
-
-const LAST_INVEST_PATH_KEY = 'invest.lastPath'
-const LAST_INVEST_STATE_KEY = 'invest.lastState'
+import { LAST_INVEST_PATH_KEY, LAST_INVEST_STATE_KEY } from '@/features/invest/navigation'
 
 const TABS = [
   { label: '홈',  path: '/' },
@@ -27,9 +25,14 @@ export default function NavTabs() {
     const lastInvestPath = sessionStorage.getItem(LAST_INVEST_PATH_KEY) || '/invest'
     const savedState = sessionStorage.getItem(LAST_INVEST_STATE_KEY)
 
-    navigate(lastInvestPath, {
-      state: savedState ? JSON.parse(savedState) : undefined,
-    })
+    let parsedState
+    try {
+      parsedState = savedState ? JSON.parse(savedState) : undefined
+    } catch {
+      parsedState = undefined
+    }
+
+    navigate(lastInvestPath, { state: parsedState })
   }
 
   return (

--- a/src/components/market/InvestStockChart.jsx
+++ b/src/components/market/InvestStockChart.jsx
@@ -24,6 +24,17 @@ function toChartTime(timestamp) {
   return Math.floor(timestamp / 1000)
 }
 
+function formatChartDateTime(time, { isIntraday, useUtc }) {
+  const date = new Date(time * 1000)
+  const yyyy = useUtc ? date.getUTCFullYear() : date.getFullYear()
+  const mm = String((useUtc ? date.getUTCMonth() : date.getMonth()) + 1).padStart(2, '0')
+  const dd = String(useUtc ? date.getUTCDate() : date.getDate()).padStart(2, '0')
+  const hh = String(useUtc ? date.getUTCHours() : date.getHours()).padStart(2, '0')
+  const mi = String(useUtc ? date.getUTCMinutes() : date.getMinutes()).padStart(2, '0')
+
+  return isIntraday ? `${yyyy}/${mm}/${dd} ${hh}:${mi}` : `${yyyy}/${mm}/${dd}`
+}
+
 const InvestStockChart = memo(function InvestStockChart({
   stockCode,
   overview,
@@ -88,7 +99,7 @@ const InvestStockChart = memo(function InvestStockChart({
   }, [chartType])
 
   const isIntraday = selectedPeriod === 'MINUTE'
-
+  const usesExchangeUtcSlot = !['KOSPI', 'KOSDAQ'].includes(marketType)
 // Effect 1: 차트 생성 — chartType / isIntraday 바뀔 때만 재생성
   useEffect(() => {
     const container = containerRef.current
@@ -118,6 +129,10 @@ const InvestStockChart = memo(function InvestStockChart({
         secondsVisible: false,
         rightOffset: 6,
         barSpacing: isIntraday ? 10 : 8,
+        tickMarkFormatter: (time) => {
+          const formatted = formatChartDateTime(time, { isIntraday, useUtc: usesExchangeUtcSlot })
+          return isIntraday ? formatted.slice(11) : formatted.slice(5)
+        },
       },
       crosshair: {
         mode: CrosshairMode.Normal,
@@ -130,15 +145,7 @@ const InvestStockChart = memo(function InvestStockChart({
         locale: 'ko-KR',
         dateFormat: 'yyyy/MM/dd',
         priceFormatter: (price) => formatVisiblePrice(price, { marketType, displayCurrency, usdRate }),
-        timeFormatter: (t) => {
-          const d = new Date((t + 9 * 3600) * 1000) // UTC → KST
-          const yyyy = d.getUTCFullYear()
-          const mm = String(d.getUTCMonth() + 1).padStart(2, '0')
-          const dd = String(d.getUTCDate()).padStart(2, '0')
-          const hh = String(d.getUTCHours()).padStart(2, '0')
-          const mi = String(d.getUTCMinutes()).padStart(2, '0')
-          return isIntraday ? `${yyyy}/${mm}/${dd} ${hh}:${mi}` : `${yyyy}/${mm}/${dd}`
-        },
+        timeFormatter: (time) => formatChartDateTime(time, { isIntraday, useUtc: usesExchangeUtcSlot }),
       },
     })
 
@@ -270,7 +277,7 @@ const InvestStockChart = memo(function InvestStockChart({
       volumeSeriesRef.current = null
       areaSeriesRef.current = null
     }
-  }, [chartType, displayCurrency, isIntraday, marketType, usdRate])
+  }, [chartType, displayCurrency, isIntraday, marketType, usdRate, usesExchangeUtcSlot])
 
   // Effect 2: 데이터 업데이트 — series 바뀔 때만 (차트 재생성 없음)
   useEffect(() => {

--- a/src/components/market/StockRow.jsx
+++ b/src/components/market/StockRow.jsx
@@ -4,20 +4,35 @@ import StockAvatar from '@/components/ui/StockAvatar'
 import PriceChange from '@/components/ui/PriceChange'
 import RatioBar from '@/components/ui/RatioBar'
 
-const GRID_WITH_VOL    = 'grid-cols-[32px_36px_1fr_110px_80px_88px_120px]'
-const GRID_WITHOUT_VOL = 'grid-cols-[32px_36px_1fr_110px_80px_120px]'
+export const MARKET_GRID_BY_SORT_FILTER = {
+  volume_value: 'grid-cols-[32px_36px_minmax(0,1fr)_110px_80px_90px_96px]',
+  volume: 'grid-cols-[32px_36px_minmax(0,1fr)_110px_80px_80px_90px]',
+  market_cap: 'grid-cols-[32px_36px_minmax(0,1fr)_110px_80px_90px_82px]',
+  rising: 'grid-cols-[32px_36px_minmax(0,1fr)_110px_80px_108px]',
+  falling: 'grid-cols-[32px_36px_minmax(0,1fr)_110px_80px_108px]',
+}
+
+export function hasPrimaryMetricColumn(sortFilter) {
+  return ['volume_value', 'volume', 'market_cap'].includes(sortFilter)
+}
+
+export function getMarketRowGrid(sortFilter) {
+  return MARKET_GRID_BY_SORT_FILTER[sortFilter] ?? MARKET_GRID_BY_SORT_FILTER.volume_value
+}
 
 
-export default function StockRow({ stock, showVolume = true, isWatched, onWatchToggle }) {
+export default function StockRow({ stock, sortFilter = 'volume_value', isWatched, onWatchToggle }) {
   const navigate = useNavigate()
   const isTop = stock.rank === 1
-  const grid = showVolume ? GRID_WITH_VOL : GRID_WITHOUT_VOL
+  const grid = getMarketRowGrid(sortFilter)
+  const showVolume = hasPrimaryMetricColumn(sortFilter)
   const secondaryMetric = stock.secondaryMetric ?? { value: '—' }
+  const marketType = stock.market ?? stock.marketType ?? null
 
   return (
     <div
       className={`grid ${grid} items-center px-4 py-2.5 border-b border-stroke-subtle hover:bg-surface-subtle transition-colors duration-[100ms] cursor-pointer last:border-b-0`}
-      onClick={() => navigate(`/invest/${stock.stockCode}`, { state: { stockName: stock.name, marketType: 'KOSPI' } })}
+      onClick={() => navigate(`/invest/${stock.stockCode}`, { state: { stockName: stock.name, marketType } })}
     >
       {/* 관심종목 */}
       <button
@@ -37,7 +52,7 @@ export default function StockRow({ stock, showVolume = true, isWatched, onWatchT
 
       {/* 종목명 */}
       <div className="flex items-center gap-2 min-w-0">
-        <StockAvatar name={stock.name} stockCode={stock.stockCode} marketType={stock.market ?? stock.marketType} color={stock.color} size="md" />
+        <StockAvatar name={stock.name} stockCode={stock.stockCode} marketType={marketType} color={stock.color} size="md" />
         <span className="text-[13px] font-semibold text-foreground truncate">{stock.name}</span>
         {stock.consecutiveDays > 0 && (
           <span className={`shrink-0 px-1.5 py-0.5 rounded-md text-[9px] font-bold ${
@@ -66,11 +81,11 @@ export default function StockRow({ stock, showVolume = true, isWatched, onWatchT
       )}
 
       {/* 보조 지표 */}
-      <div className="pl-2">
+      <div className="flex h-full items-center pl-2">
         {secondaryMetric.buyRatio != null
-          ? <RatioBar buyRatio={secondaryMetric.buyRatio} sellRatio={secondaryMetric.sellRatio} />
+          ? <RatioBar className="w-full" buyRatio={secondaryMetric.buyRatio} sellRatio={secondaryMetric.sellRatio} />
           : (
-            <div className="text-right text-[12px] font-medium text-foreground-secondary">
+            <div className="w-full text-right text-[12px] font-medium text-foreground-secondary">
               {secondaryMetric.value ?? '—'}
             </div>
           )}

--- a/src/components/signup/accountPinKeypad.css
+++ b/src/components/signup/accountPinKeypad.css
@@ -148,33 +148,33 @@
 
 /* ── compact 변형 (투자 패널 인라인 키패드) ── */
 .sol-pin-keypad-compact .sol-pin-keypad-shell--desktop {
-  padding: 10px !important;
-  border-radius: 14px !important;
+  padding: 8px !important;
+  border-radius: 12px !important;
   margin-top: 0 !important;
 }
 
 .sol-pin-keypad-compact .sol-pin-keyboard .hg-rows {
-  gap: 6px;
+  gap: 5px;
 }
 
 .sol-pin-keypad-compact .sol-pin-keyboard .hg-row {
-  gap: 6px;
+  gap: 5px;
 }
 
 .sol-pin-keypad-compact .sol-pin-keyboard .hg-button {
-  height: 38px !important;
-  font-size: 18px;
+  height: 34px !important;
+  font-size: 16px;
   border-radius: 8px !important;
 }
 
 .sol-pin-keypad-compact .sol-pin-keyboard .hg-button.sol-pin-keyboard__action {
-  height: 34px !important;
-  font-size: 11px;
+  height: 30px !important;
+  font-size: 10px;
 }
 
 .sol-pin-keypad-compact .sol-pin-keyboard .sol-pin-keyboard__lock {
-  height: 20px !important;
-  width: 20px !important;
+  height: 18px !important;
+  width: 18px !important;
 }
 
 .sol-pin-keypad-shell--mobile .sol-pin-keyboard .hg-button {

--- a/src/components/ui/RatioBar.jsx
+++ b/src/components/ui/RatioBar.jsx
@@ -7,12 +7,12 @@
  */
 export default function RatioBar({ buyRatio, sellRatio, className = '' }) {
   return (
-    <div className={className}>
-      <div className="h-1 rounded-full overflow-hidden flex bg-stroke">
+    <div className={`relative h-8 ${className}`}>
+      <div className="absolute inset-x-0 top-1/2 flex h-1 -translate-y-1/2 overflow-hidden rounded-full bg-stroke">
         <div className="bg-up h-full" style={{ width: `${buyRatio}%` }} />
         <div className="bg-down h-full" style={{ width: `${sellRatio}%` }} />
       </div>
-      <div className="flex justify-between mt-0.5">
+      <div className="absolute inset-x-0 bottom-0 flex justify-between">
         <span className="text-[9px] font-semibold text-up">{buyRatio}</span>
         <span className="text-[9px] font-semibold text-down">{sellRatio}</span>
       </div>

--- a/src/features/asset/useAssetPage.js
+++ b/src/features/asset/useAssetPage.js
@@ -8,20 +8,32 @@ import useCurrencyStore from '@/store/useCurrencyStore'
 const SEED_MONEY = 100_000_000
 const FALLBACK_USD_RATE = 1350
 
-function buildHoldingRow(h, usdRate) {
+function buildHoldingRow(h) {
   const qty = h.holdingQuantity ?? 0
-  const cur = Number(h.currentPrice ?? h.avgBuyPrice ?? 0)
+  const hasCurrentPrice = h.currentPrice != null
+  const cur = hasCurrentPrice ? Number(h.currentPrice) : null
   const avg = Number(h.avgBuyPrice ?? 0)
   const isKrw = h.currencyCode === 'KRW'
-  const rate = Number(h.avgBuyExchangeRate ?? usdRate)
-  const evalKrw = isKrw ? cur * qty : cur * qty * usdRate
-  const investedKrw = isKrw ? avg * qty : avg * qty * rate
-  const pnl = evalKrw - investedKrw
-  const pnlRate = investedKrw > 0 ? (pnl / investedKrw) * 100 : 0
-  return { ...h, qty, cur, avg, evalKrw, pnl, pnlRate, isUp: pnl >= 0, isKrw }
+  const evalKrw = h.evalAmount != null ? Number(h.evalAmount) : null
+  const investedLocal = Number(h.buyAmountLocal ?? (avg * qty))
+  const pnl = h.unrealizedProfitLoss != null ? Number(h.unrealizedProfitLoss) : null
+  const pnlRate = h.unrealizedProfitLossRate != null ? Number(h.unrealizedProfitLossRate) : null
+  return {
+    ...h,
+    qty,
+    cur,
+    avg,
+    investedLocal,
+    evalKrw,
+    pnl,
+    pnlRate,
+    hasCurrentPrice,
+    isUp: pnl != null ? pnl >= 0 : false,
+    isKrw,
+  }
 }
 
-export function useAssetPage(enabled) {
+export function useAssetPage(enabled, assetFlowRange = '1M') {
   const usdRate = useCurrencyStore((s) => s.rates['USD']?.rate ?? FALLBACK_USD_RATE)
 
   const { data: summary, isLoading: sl } = useQuery({
@@ -41,6 +53,13 @@ export function useAssetPage(enabled) {
     staleTime: 30_000,
   })
 
+  const { data: assetFlow, isLoading: fl } = useQuery({
+    queryKey: ['balance', 'flow', assetFlowRange],
+    queryFn: () => balanceApi.getAssetFlow(assetFlowRange),
+    enabled,
+    staleTime: 30_000,
+  })
+
   const { data: accountInfo } = useMyAccount()
 
   const { data: filledOrders = [] } = useQuery({
@@ -51,7 +70,7 @@ export function useAssetPage(enabled) {
   })
 
   return useMemo(() => {
-    const isLoading = enabled && (sl || dl || ol || pl)
+    const isLoading = enabled && (sl || dl || ol || pl || fl)
 
     // Cash
     const cashList = summary?.cashBalances ?? []
@@ -63,26 +82,27 @@ export function useAssetPage(enabled) {
 
     // Holdings rows
     const domesticRows = domestic
-      .map((h) => buildHoldingRow(h, usdRate))
+      .map((h) => buildHoldingRow(h))
       .filter((h) => h.qty > 0)
-      .sort((a, b) => b.evalKrw - a.evalKrw)
+      .sort((a, b) => (b.evalKrw ?? 0) - (a.evalKrw ?? 0))
 
     const overseasRows = overseas
-      .map((h) => buildHoldingRow(h, usdRate))
+      .map((h) => buildHoldingRow(h))
       .filter((h) => h.qty > 0)
-      .sort((a, b) => b.evalKrw - a.evalKrw)
+      .sort((a, b) => (b.evalKrw ?? 0) - (a.evalKrw ?? 0))
 
     // Totals
-    const domesticEval = domesticRows.reduce((s, h) => s + h.evalKrw, 0)
-    const domesticPnl = domesticRows.reduce((s, h) => s + h.pnl, 0)
-    const overseasEval = overseasRows.reduce((s, h) => s + h.evalKrw, 0)
-    const overseasPnl = overseasRows.reduce((s, h) => s + h.pnl, 0)
+    const domesticEval = domesticRows.reduce((s, h) => s + (h.evalKrw ?? 0), 0)
+    const domesticPnl = domesticRows.reduce((s, h) => s + (h.pnl ?? 0), 0)
+    const overseasEval = overseasRows.reduce((s, h) => s + (h.evalKrw ?? 0), 0)
+    const overseasPnl = overseasRows.reduce((s, h) => s + (h.pnl ?? 0), 0)
 
     const totalStockKrw = domesticEval + overseasEval
-    const totalInvestedKrw = domesticRows.reduce((s, h) => s + h.evalKrw - h.pnl, 0)
-      + overseasRows.reduce((s, h) => s + h.evalKrw - h.pnl, 0)
+    const totalInvestedKrw = domesticRows.reduce((s, h) => s + ((h.evalKrw ?? 0) - (h.pnl ?? 0)), 0)
+      + overseasRows.reduce((s, h) => s + ((h.evalKrw ?? 0) - (h.pnl ?? 0)), 0)
 
-    const totalAssets = krwDeposit + usdBal * usdRate + totalStockKrw
+    const computedTotalAssets = krwDeposit + usdBal * usdRate + totalStockKrw
+    const totalAssets = Number(summary?.totalAssets ?? computedTotalAssets)
 
     // 헤더: 백엔드 계좌 손익 (초기금 1억 대비)
     const accountProfit = Number(summary?.accountProfitLoss ?? (totalStockKrw - totalInvestedKrw))
@@ -100,6 +120,16 @@ export function useAssetPage(enabled) {
       : totalAssets > 0 ? ((totalAssets - SEED_MONEY) / SEED_MONEY) * 100 : 0
     const isSimProfit = simReturn >= 0
 
+    const assetFlowPoints = (assetFlow?.points ?? []).map((point) => ({
+      date: point.date,
+      totalAssets: Number(point.totalAssets ?? 0),
+      dailyReturnRate: Number(point.dailyReturnRate ?? 0),
+      cumulativeReturnRate: Number(point.cumulativeReturnRate ?? 0),
+    }))
+    const latestFlowPoint = assetFlowPoints[assetFlowPoints.length - 1] ?? null
+    const latestDailyReturnRate = latestFlowPoint?.dailyReturnRate ?? 0
+    const latestCumulativeReturnRate = latestFlowPoint?.cumulativeReturnRate ?? 0
+
     // Portfolio chart items — stocks first, cash last
     const rawItems = portfolio?.items ?? []
     const orderedItems = rawItems.filter((i) => i.type === 'STOCK')
@@ -112,17 +142,23 @@ export function useAssetPage(enabled) {
       const holding = holdingByName[item.label]
       return {
         label: item.label,
-        weight: Math.round(Number(item.weight ?? 0)),
+        weight: Number(item.weight ?? 0),
         type: item.type,
         stockCode: holding?.stockCode ?? null,
         marketType: holding?.marketType ?? null,
       }
     })
 
-    // Normalize weights
-    const weightSum = portfolioItems.reduce((s, i) => s + i.weight, 0)
-    if (weightSum > 0 && weightSum !== 100 && portfolioItems.length > 0) {
-      portfolioItems[portfolioItems.length - 1].weight += 100 - weightSum
+    // Cash를 제외한 주식 비중만으로 다시 100% 정규화
+    const stockWeightSum = portfolioItems.reduce((s, i) => s + i.weight, 0)
+    if (stockWeightSum > 0 && portfolioItems.length > 0) {
+      const normalized = portfolioItems.map((item) => ({
+        ...item,
+        weight: Math.round((item.weight / stockWeightSum) * 100),
+      }))
+      const normalizedSum = normalized.reduce((s, i) => s + i.weight, 0)
+      normalized[normalized.length - 1].weight += 100 - normalizedSum
+      portfolioItems.splice(0, portfolioItems.length, ...normalized)
     }
 
     return {
@@ -151,8 +187,10 @@ export function useAssetPage(enabled) {
       startDate,
       simReturn,
       isSimProfit,
+      assetFlowPoints,
+      latestDailyReturnRate,
+      latestCumulativeReturnRate,
       tradeCount: filledOrders.length,
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [summary, domestic, overseas, portfolio, accountInfo, filledOrders, usdRate, sl, dl, ol, pl, enabled])
+  }, [summary, domestic, overseas, portfolio, assetFlow, accountInfo, filledOrders, usdRate, sl, dl, ol, pl, fl, enabled])
 }

--- a/src/features/invest/foreign/normalize.js
+++ b/src/features/invest/foreign/normalize.js
@@ -1,4 +1,4 @@
-import { toLocalTimestamp, extractDateKey, computeDepth } from '@/features/invest/marketData'
+import { extractDateKey, computeDepth } from '@/features/invest/marketData'
 
 function toNumber(value, fallback = 0) {
   const parsed = Number(value)
@@ -9,11 +9,49 @@ function readOrderQuantity(entry) {
   return toNumber(entry?.remaining ?? entry?.volume ?? entry?.quantity)
 }
 
+function parseLsOrderBookEntries(raw, side, count = 10) {
+  const entries = []
+
+  for (let i = 1; i <= count; i += 1) {
+    const price = toNumber(raw?.[`${side}ho${i}`])
+    const quantity = toNumber(raw?.[`${side}rem${i}`])
+
+    if (price > 0) {
+      entries.push({ price, quantity })
+    }
+  }
+
+  return entries
+}
+
+function isLsRawFormat(raw) {
+  return raw?.offerho1 != null || raw?.bidho1 != null || raw?.totofferrem != null || raw?.totbidrem != null
+}
+
+function toExchangeLocalTimestamp(value, fallbackTime = '00:00:00') {
+  if (typeof value === 'string') {
+    const [datePart, timePart = fallbackTime] = value.includes('T')
+      ? value.split('T')
+      : [value, fallbackTime]
+    const [year, month, day] = datePart.split('-').map(Number)
+    const [hour = 0, minute = 0, second = 0] = timePart.split(':').map(Number)
+
+    return Date.UTC(year, (month ?? 1) - 1, day ?? 1, hour, minute, second)
+  }
+
+  if (Array.isArray(value)) {
+    const [year = 1970, month = 1, day = 1, hour = 0, minute = 0, second = 0] = value
+    return Date.UTC(year, month - 1, day, hour, minute, second)
+  }
+
+  return Number.NaN
+}
+
 export function normalizeForeignDailySeries(dataPoints) {
   return (dataPoints ?? [])
     .map((item) => ({
       date: extractDateKey(item.date),
-      timestamp: toLocalTimestamp(item.date),
+      timestamp: toExchangeLocalTimestamp(item.date),
       open: Number(item.open),
       high: Number(item.high),
       low: Number(item.low),
@@ -27,7 +65,7 @@ export function normalizeForeignMinuteSeries(dataPoints) {
   const now = Date.now()
   const normalized = (dataPoints ?? [])
     .map((item) => ({
-      timestamp: toLocalTimestamp(item.dateTime),
+      timestamp: toExchangeLocalTimestamp(item.dateTime),
       sessionDate: extractDateKey(item.dateTime),
       open: Number(item.open),
       high: Number(item.high),
@@ -45,17 +83,32 @@ export function normalizeForeignMinuteSeries(dataPoints) {
 export function normalizeForeignOrderBook(raw) {
   if (!raw) return null
 
-  const asks = (raw.asks ?? []).map((entry) => ({
-    price: toNumber(entry?.price),
-    quantity: readOrderQuantity(entry),
-  }))
-  const bids = (raw.bids ?? []).map((entry) => ({
-    price: toNumber(entry?.price),
-    quantity: readOrderQuantity(entry),
-  }))
+  const asks = isLsRawFormat(raw)
+    ? parseLsOrderBookEntries(raw, 'offer')
+    : (raw.asks ?? []).map((entry) => ({
+        price: toNumber(entry?.price),
+        quantity: readOrderQuantity(entry),
+      }))
 
-  const askTotal = toNumber(raw.askTotal ?? raw.totOfferRem, asks.reduce((sum, a) => sum + a.quantity, 0))
-  const bidTotal = toNumber(raw.bidTotal ?? raw.totBidRem, bids.reduce((sum, b) => sum + b.quantity, 0))
+  const bids = isLsRawFormat(raw)
+    ? parseLsOrderBookEntries(raw, 'bid')
+    : (raw.bids ?? []).map((entry) => ({
+        price: toNumber(entry?.price),
+        quantity: readOrderQuantity(entry),
+      }))
+
+  if (asks.length === 0 && bids.length === 0) {
+    return null
+  }
+
+  const askTotal = toNumber(
+    raw.askTotal ?? raw.totOfferRem ?? raw.totofferrem,
+    asks.reduce((sum, a) => sum + a.quantity, 0),
+  )
+  const bidTotal = toNumber(
+    raw.bidTotal ?? raw.totBidRem ?? raw.totbidrem,
+    bids.reduce((sum, b) => sum + b.quantity, 0),
+  )
   const maxVolume = Math.max(...asks.map((a) => a.quantity), ...bids.map((b) => b.quantity), 1)
 
   return {

--- a/src/features/invest/marketData.js
+++ b/src/features/invest/marketData.js
@@ -39,9 +39,9 @@ export function resolveStockMeta(stockCode, locationState) {
     sector: known?.sector ?? '-',
     isDomestic,
     availableAmount: known?.availableAmount ?? INVEST_STOCK.availableAmount,
-    price: known?.price ?? INVEST_STOCK.price,
-    diff: known?.diff ?? 0,
-    changeRate: known?.changeRate ?? 0,
+    price: locationState?.price ?? known?.price ?? null,
+    diff: locationState?.diff ?? known?.diff ?? 0,
+    changeRate: locationState?.changeRate ?? known?.changeRate ?? 0,
     open: known?.open ?? null,
     high: known?.high ?? null,
     low: known?.low ?? null,
@@ -52,8 +52,13 @@ export function resolveStockMeta(stockCode, locationState) {
 // 날짜/시간 파싱 유틸 (domestic/foreign normalize에서 공유)
 export function toLocalTimestamp(value, fallbackTime = '00:00:00') {
   if (typeof value === 'string') {
-    const normalized = value.includes('T') ? value : `${value}T${fallbackTime}`
-    return new Date(normalized).getTime()
+    const [datePart, timePart = fallbackTime] = value.includes('T')
+      ? value.split('T')
+      : [value, fallbackTime]
+    const [year, month, day] = datePart.split('-').map(Number)
+    const [hour = 0, minute = 0, second = 0] = timePart.split(':').map(Number)
+
+    return new Date(year, (month ?? 1) - 1, day ?? 1, hour, minute, second).getTime()
   }
 
   if (Array.isArray(value)) {

--- a/src/features/invest/navigation.js
+++ b/src/features/invest/navigation.js
@@ -1,0 +1,16 @@
+const EXCHANGE_CODE_BY_MARKET_TYPE = {
+  NASDAQ: 'NAS',
+  NYSE: 'NYS',
+  AMEX: 'AMS',
+}
+
+export function buildInvestNavigationState(stock) {
+  const marketType = stock?.marketType ?? null
+
+  return {
+    stockName: stock?.stockName ?? null,
+    stockNameEn: stock?.stockNameEn ?? null,
+    marketType,
+    exchangeCode: stock?.exchangeCode ?? EXCHANGE_CODE_BY_MARKET_TYPE[marketType] ?? null,
+  }
+}

--- a/src/features/invest/navigation.js
+++ b/src/features/invest/navigation.js
@@ -1,3 +1,6 @@
+export const LAST_INVEST_PATH_KEY = 'invest.lastPath'
+export const LAST_INVEST_STATE_KEY = 'invest.lastState'
+
 const EXCHANGE_CODE_BY_MARKET_TYPE = {
   NASDAQ: 'NAS',
   NYSE: 'NYS',

--- a/src/hooks/usePinAuth.js
+++ b/src/hooks/usePinAuth.js
@@ -17,13 +17,17 @@ function clearPin() {
   sessionStorage.removeItem(STORAGE_KEY)
 }
 
-async function verifyAndCachePin(pin) {
+async function verifyAndCachePin(pin, remember = true) {
   await fetchWithAuth('/api/accounts/verify-pin', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ accountPin: pin }),
   })
-  cachePin()
+  if (remember) {
+    cachePin()
+  } else {
+    clearPin()
+  }
 }
 
 export default function usePinAuth() {

--- a/src/pages/AssetPage.jsx
+++ b/src/pages/AssetPage.jsx
@@ -3,7 +3,6 @@ import { ArrowLeftRight } from 'lucide-react'
 import ReactECharts from 'echarts-for-react'
 import { getStockLogoUrl } from '@/lib/stockLogo'
 import { extractDominantColor } from '@/lib/extractLogoColor'
-import LiveDot from '@/components/ui/LiveDot'
 import StockAvatar from '@/components/ui/StockAvatar'
 import FilterChip from '@/components/ui/FilterChip'
 import ExchangeModal from '@/components/asset/ExchangeModal'
@@ -25,6 +24,33 @@ function fmtRate(r) {
   if (r == null) return '-'
   return (r >= 0 ? '+' : '') + Number(r).toFixed(2) + '%'
 }
+function fmtSigned(n, suffix = '') {
+  const value = Number(n ?? 0)
+  return `${value >= 0 ? '+' : '-'}${fmt(Math.abs(value))}${suffix}`
+}
+function fmtCompactCurrency(n) {
+  const value = Number(n ?? 0)
+  if (Math.abs(value) >= 100000000) return `${(value / 100000000).toFixed(1)}억`
+  if (Math.abs(value) >= 10000) return `${(value / 10000).toFixed(0)}만`
+  return fmt(value)
+}
+function fmtUsd(n) {
+  return Number(n ?? 0).toLocaleString('en-US', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  })
+}
+
+const ASSET_FLOW_RANGES = [
+  { key: '1W', label: '1주' },
+  { key: '1M', label: '1월' },
+  { key: 'ALL', label: '전체' },
+]
+
+const ASSET_FLOW_MODES = [
+  { key: 'assets', label: '총자산' },
+  { key: 'return', label: '누적수익률' },
+]
 
 // ── Hero 섹션 ─────────────────────────────────────────────────────
 function HeroSection({ data, user, onExchange }) {
@@ -32,7 +58,7 @@ function HeroSection({ data, user, onExchange }) {
   const blank = isLoading ? '-' : null
 
   return (
-    <div className="shrink-0 bg-surface border-b border-stroke px-6 py-4">
+    <div className="shrink-0 bg-surface border-b border-stroke px-6 py-2.5">
       <div className="flex items-center justify-between">
         <div>
           <div className="text-[11px] text-foreground-disabled mb-1">
@@ -70,7 +96,7 @@ function HeroSection({ data, user, onExchange }) {
             </div>
             <div className="text-right">
               <div className="text-[9px] font-semibold text-foreground-disabled mb-0.5">USD 잔고</div>
-              <div className="text-[13px] font-bold text-foreground">{blank ?? ('$' + fmt(usdBal))}</div>
+              <div className="text-[13px] font-bold text-foreground">{blank ?? ('$' + fmtUsd(usdBal))}</div>
             </div>
           </div>
           <div className="flex items-center gap-1.5">
@@ -96,15 +122,16 @@ function AccountCard({ data }) {
   const accountName = accountInfo?.accountName ?? '종합계좌'
 
   return (
-    <div className="bg-surface rounded-2xl border border-stroke p-4 flex flex-col gap-3">
-      <div className="text-[11px] font-bold text-foreground">계좌</div>
+    <section className="flex h-full min-w-0 flex-col border-r border-stroke-subtle">
+      <div className="px-5 py-2.5">
+        <div className="text-[13px] font-bold text-foreground">계좌</div>
+      </div>
       <div className="h-px bg-stroke-subtle" />
-      <div>
+      <div className="flex flex-1 flex-col gap-2 px-5 py-2.5">
         <div className="text-[13px] font-bold text-foreground">{accountName}</div>
         <div className="text-[11px] text-foreground-disabled mt-0.5">{accountNumber}</div>
       </div>
-      <div className="h-px bg-stroke-subtle" />
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-2 px-5 pb-2.5">
         <div className="flex items-center justify-between">
           <span className="text-[10px] text-foreground-disabled">현재 수익률</span>
           <span className={`text-[15px] font-black ${isSimProfit ? 'text-up' : 'text-down'}`}>
@@ -120,7 +147,7 @@ function AccountCard({ data }) {
           <span className="text-[11px] font-semibold text-foreground">1억원</span>
         </div>
       </div>
-    </div>
+    </section>
   )
 }
 
@@ -148,12 +175,16 @@ function AssetBreakdownCard({ data }) {
       rate: overseasRate,
     },
     { label: 'KRW 현금', value: blank ?? fmt(krwDeposit) + '원', pnl: null },
-    { label: 'USD 현금', value: blank ?? ('$' + fmt(usdBal)), pnl: null },
+    { label: 'USD 현금', value: blank ?? ('$' + fmtUsd(usdBal)), pnl: null },
   ]
 
   return (
-    <div className="bg-surface rounded-2xl border border-stroke p-4 flex flex-col gap-2.5">
-      <div className="text-[11px] font-bold text-foreground mb-0.5">자산 구성</div>
+    <section className="flex h-full min-w-0 flex-col border-r border-stroke-subtle">
+      <div className="px-5 py-2.5">
+        <div className="text-[13px] font-bold text-foreground">자산 구성</div>
+      </div>
+      <div className="h-px bg-stroke-subtle" />
+      <div className="flex flex-1 flex-col gap-1.5 px-5 py-2.5">
       {rows.map((row) => (
         <div key={row.label} className="flex items-center justify-between py-1.5 border-b border-stroke-subtle last:border-0">
           <span className="text-[11px] text-foreground-secondary">{row.label}</span>
@@ -167,44 +198,134 @@ function AssetBreakdownCard({ data }) {
           </div>
         </div>
       ))}
-    </div>
+      </div>
+    </section>
   )
 }
 
 // ── 자산 흐름 카드 ────────────────────────────────────────────────
-function AssetFlowCard({ data }) {
-  const { tradeCount, accountProfit, isAccountProfit, isLoading } = data
+function AssetFlowCard({ data, assetFlowRange, onChangeAssetFlowRange }) {
+  const { isAccountProfit, isLoading, assetFlowPoints, latestDailyReturnRate, latestCumulativeReturnRate } = data
+  const hasFlow = assetFlowPoints.length > 0
+  const [mode, setMode] = useState('assets')
 
-  // 거래 횟수 기반 간단한 bar sparkline (시각적 표현)
-  const bars = [28, 35, 30, 45, 40, 55, 50, 62, 58, 70, 65, 78, 72, 85, 80, 92, 88, 96, 90, 100]
+  const isAssetMode = mode === 'assets'
+  const seriesData = isAssetMode
+    ? assetFlowPoints.map((point) => point.totalAssets)
+    : assetFlowPoints.map((point) => point.cumulativeReturnRate)
+  const headlineValue = isAssetMode ? latestDailyReturnRate : latestCumulativeReturnRate
+  const headlineLabel = isAssetMode ? '전일 대비 수익률' : '누적 수익률'
+  const chartColor = isAssetMode
+    ? (isAccountProfit ? '#16A34A' : '#E11D48')
+    : (headlineValue >= 0 ? '#16A34A' : '#E11D48')
+
+  const chartOption = {
+    backgroundColor: 'transparent',
+    grid: { left: 50, right: 10, top: 8, bottom: 16, containLabel: false },
+    tooltip: {
+      trigger: 'axis',
+      appendToBody: true,
+      confine: false,
+      backgroundColor: '#FFFFFF',
+      borderColor: '#EAECF0',
+      borderWidth: 1,
+      borderRadius: 10,
+      padding: [10, 12],
+      textStyle: { color: '#191F28' },
+      extraCssText: 'box-shadow:0 8px 24px rgba(15,23,42,0.12); z-index: 9999;',
+      formatter: (params) => {
+        const point = params?.[0]
+        if (!point) return ''
+        const raw = assetFlowPoints[point.dataIndex]
+        return [
+          `<div style="font-size:12px;font-weight:700">${raw.date}</div>`,
+          `<div style="margin-top:4px;font-size:12px">총자산 <b>${fmt(raw.totalAssets)}원</b></div>`,
+          `<div style="font-size:12px">누적수익률 <b>${fmtRate(raw.cumulativeReturnRate)}</b></div>`,
+          `<div style="font-size:12px">전일대비 <b>${fmtRate(raw.dailyReturnRate)}</b></div>`,
+        ].join('')
+      },
+    },
+    xAxis: {
+      type: 'category',
+      boundaryGap: false,
+      data: assetFlowPoints.map((point) => point.date.slice(5).replace('-', '.')),
+      axisLine: { show: false },
+      axisTick: { show: false },
+      axisLabel: { color: '#9CA3AF', fontSize: 10, margin: 12 },
+    },
+    yAxis: {
+      type: 'value',
+      splitNumber: 3,
+      axisLine: { show: false },
+      axisTick: { show: false },
+      splitLine: { lineStyle: { color: '#F2F4F7' } },
+      axisLabel: {
+        color: '#9CA3AF',
+        fontSize: 10,
+        margin: 10,
+        formatter: (value) => isAssetMode ? `${fmtCompactCurrency(value)}원` : fmtRate(value),
+      },
+    },
+    series: [
+      {
+        type: 'line',
+        smooth: true,
+        showSymbol: assetFlowPoints.length === 1,
+        symbolSize: 7,
+        data: seriesData,
+        lineStyle: { width: 3, color: chartColor },
+        itemStyle: { color: chartColor },
+        areaStyle: {
+          color: chartColor === '#16A34A'
+            ? 'rgba(22,163,74,0.14)'
+            : 'rgba(225,29,72,0.14)',
+        },
+      },
+    ],
+  }
 
   return (
-    <div className="bg-surface rounded-2xl border border-stroke p-4 flex flex-col gap-3">
-      <div className="flex items-center justify-between">
-        <div className="text-[11px] font-bold text-foreground">자산 흐름</div>
-        <span className="text-[9px] text-foreground-disabled">누적 {tradeCount}회 거래</span>
+    <section className="flex h-full min-w-0 flex-col overflow-hidden">
+      <div className="flex items-center justify-between px-5 py-2.5">
+        <div className="text-[13px] font-bold text-foreground">자산 흐름</div>
       </div>
-
-      {/* 스파크라인 바 차트 */}
-      <div className="flex-1 flex items-end gap-px min-h-0 h-[60px]">
-        {bars.map((h, i) => (
-          <div
-            key={i}
-            className={`flex-1 rounded-sm h-[var(--bar-h)] ${isAccountProfit ? 'bg-up/40' : 'bg-down/40'}`}
-            style={{ '--bar-h': `${h}%` }}
-          />
-        ))}
-      </div>
-
       <div className="h-px bg-stroke-subtle" />
 
-      <div className="flex items-center justify-between">
-        <span className="text-[10px] text-foreground-disabled">총 평가손익</span>
-        <span className={`text-[14px] font-black ${isAccountProfit ? 'text-up' : 'text-down'}`}>
-          {isLoading ? '-' : ((isAccountProfit ? '+' : '') + fmt(accountProfit ?? 0) + '원')}
-        </span>
+      <div className="flex items-center justify-between gap-2 px-5 pt-2.5">
+        <div className="flex items-center gap-1.5">
+          {ASSET_FLOW_MODES.map(({ key, label }) => (
+            <FilterChip key={key} isActive={mode === key} onClick={() => setMode(key)}>
+              {label}
+            </FilterChip>
+          ))}
+        </div>
+        <div className="flex items-center gap-1.5">
+          {ASSET_FLOW_RANGES.map(({ key, label }) => (
+            <FilterChip key={key} isActive={assetFlowRange === key} onClick={() => onChangeAssetFlowRange(key)}>
+              {label}
+            </FilterChip>
+          ))}
+        </div>
       </div>
-    </div>
+
+      <div className="shrink-0 px-5 pt-2">
+        <div className="text-[9px] text-foreground-disabled">{headlineLabel}</div>
+        <div className={`text-[18px] font-black ${headlineValue >= 0 ? 'text-up' : 'text-down'}`}>
+          {isLoading ? '-' : fmtRate(headlineValue)}
+        </div>
+      </div>
+
+      <div className="h-[88px] overflow-hidden rounded-xl px-5">
+        {hasFlow ? (
+          <ReactECharts option={chartOption} className="w-full h-full" opts={{ renderer: 'svg' }} />
+        ) : (
+          <div className="flex items-center justify-center h-full text-[11px] text-foreground-disabled">
+            데이터 없음
+          </div>
+        )}
+      </div>
+
+    </section>
   )
 }
 
@@ -250,12 +371,17 @@ function useLogoColors(items) {
 
 // ── 포트폴리오 파이차트 패널 (하단 좌) ───────────────────────────
 function PortfolioPanel({ data }) {
-  const { portfolioItems, stockProfitRate, isStockProfit, isLoading } = data
+  const { portfolioItems } = data
 
   const getColor = useLogoColors(portfolioItems)
   const hasItems = portfolioItems.length > 0
 
   const sortedItems = [...portfolioItems].sort((a, b) => b.weight - a.weight)
+  const primaryItems = sortedItems.slice(0, 5)
+  const restWeight = sortedItems.slice(5).reduce((sum, item) => sum + item.weight, 0)
+  const summaryItems = restWeight > 0
+    ? [...primaryItems, { label: '기타', weight: restWeight, stockCode: null, marketType: null, type: 'STOCK' }]
+    : primaryItems
 
   const chartOption = {
     backgroundColor: 'transparent',
@@ -305,61 +431,42 @@ function PortfolioPanel({ data }) {
   }
 
   return (
-    <div className="flex-1 min-w-0 bg-surface rounded-2xl border border-stroke p-5 flex flex-col overflow-hidden">
-      <div className="flex items-center justify-between mb-2 shrink-0">
-        <div className="text-[11px] font-bold text-foreground">포트폴리오</div>
-        {!isLoading && (
-          <span className={`text-[11px] font-bold ${isStockProfit ? 'text-up' : 'text-down'}`}>
-            수익률 {fmtRate(stockProfitRate)}
-          </span>
-        )}
+    <div className="flex min-h-0 w-[490px] shrink-0 flex-col overflow-hidden border-r border-stroke bg-surface">
+      <div className="flex min-h-[44px] items-center border-b border-stroke px-4 py-2.5 shrink-0">
+        <div className="text-[13px] font-bold text-foreground">포트폴리오</div>
       </div>
 
-      {/* 도넛 차트 */}
-      <div className="relative shrink-0 h-[260px]">
+      <div className="flex min-h-0 flex-1 items-center gap-4 px-5 py-4">
         {hasItems ? (
           <>
-            <ReactECharts
-              option={chartOption}
-              className="w-full h-full"
-              opts={{ renderer: 'svg' }}
-            />
-            <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
-              <span className={`text-[15px] font-black ${isStockProfit ? 'text-up' : 'text-down'}`}>
-                {isLoading ? '-' : fmtRate(stockProfitRate)}
-              </span>
-              <span className="text-[9px] text-foreground-disabled mt-0.5">수익률</span>
+            <div className="relative h-[260px] w-[260px] shrink-0">
+              <ReactECharts
+                option={chartOption}
+                className="w-full h-full"
+                opts={{ renderer: 'svg' }}
+              />
+            </div>
+
+            <div className="flex min-w-0 flex-1 flex-col gap-3">
+              {summaryItems.map((item, i) => {
+                const color = getColor(item, i)
+                return (
+                  <div key={item.label} className="flex items-center justify-between gap-3 border-b border-stroke-subtle pb-2 last:border-0 last:pb-0">
+                    <div className="flex min-w-0 items-center gap-2">
+                      <div className="h-2.5 w-2.5 shrink-0 rounded-[3px] bg-[var(--dot-color)]" style={{ '--dot-color': color }} />
+                      <span className="truncate text-[12px] font-semibold text-foreground-secondary">{item.label}</span>
+                    </div>
+                    <span className="shrink-0 text-[18px] font-black text-foreground">{item.weight}%</span>
+                  </div>
+                )
+              })}
             </div>
           </>
         ) : (
-          <div className="flex items-center justify-center h-full">
+          <div className="flex h-full w-full items-center justify-center">
             <span className="text-[11px] text-foreground-disabled">데이터 없음</span>
           </div>
         )}
-      </div>
-
-      {/* 레전드 */}
-      <div className="flex flex-col gap-2 overflow-y-auto flex-1 mt-2">
-        {portfolioItems.length === 0 && !isLoading && (
-          <p className="text-[11px] text-foreground-disabled text-center">보유 종목 없음</p>
-        )}
-        {sortedItems.map((item, i) => {
-          const color = getColor(item, i)
-          return (
-            <div key={item.label} className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <div className="w-2.5 h-2.5 rounded-[3px] shrink-0 bg-[var(--dot-color)]" style={{ '--dot-color': color }} />
-                <span className="text-[12px] text-foreground-secondary">{item.label}</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <div className="w-[60px] h-1 rounded-full bg-surface-muted overflow-hidden">
-                  <div className="h-full rounded-full w-[var(--bar-w)] bg-[var(--bar-color)]" style={{ '--bar-w': `${item.weight}%`, '--bar-color': color }} />
-                </div>
-                <span className="text-[11px] font-bold text-foreground w-8 text-right">{item.weight}%</span>
-              </div>
-            </div>
-          )
-        })}
       </div>
     </div>
   )
@@ -367,15 +474,15 @@ function PortfolioPanel({ data }) {
 
 // ── 보유 종목 행 ──────────────────────────────────────────────────
 function HoldingRow({ h }) {
-  const { stockName, stockCode, marketType, qty, cur, avg, evalKrw, pnl, pnlRate, isUp, isKrw } = h
+  const { stockName, stockCode, marketType, qty, cur, avg, investedLocal, pnl, pnlRate, isUp, isKrw, hasCurrentPrice } = h
 
   return (
-    <div className="grid grid-cols-[1fr_80px_88px_108px] items-center px-4 py-2.5 border-b border-stroke-subtle cursor-pointer hover:bg-surface-subtle transition-colors">
+    <div className="grid grid-cols-[1fr_62px_82px_78px_92px] items-center px-4 py-2.5 border-b border-stroke-subtle cursor-pointer hover:bg-surface-subtle transition-colors">
       <div className="flex items-center gap-2.5">
         <StockAvatar name={stockName} stockCode={stockCode} marketType={marketType} size="md" />
         <div className="min-w-0">
           <div className="text-[12px] font-bold text-foreground truncate">{stockName}</div>
-          <div className="text-[9px] text-foreground-disabled">{marketType}{!isKrw && ' 🇺🇸'}</div>
+          <div className="text-[9px] text-foreground-disabled">{marketType}</div>
         </div>
       </div>
 
@@ -386,16 +493,22 @@ function HoldingRow({ h }) {
         </div>
       </div>
 
-      <div className={`text-right text-[13px] font-extrabold ${isUp ? 'text-up' : 'text-down'}`}>
-        {isKrw ? fmt(cur) : `$${Number(cur).toFixed(2)}`}
+      <div className="text-right text-[11px] font-bold text-foreground-secondary">
+        {isKrw ? `${fmtCompactCurrency(investedLocal)}원` : `$${fmtUsd(investedLocal)}`}
+      </div>
+
+      <div className={hasCurrentPrice ? `text-right text-[12px] font-extrabold ${isUp ? 'text-up' : 'text-down'}` : 'text-right text-[12px] font-bold text-foreground-disabled'}>
+        {hasCurrentPrice
+          ? (isKrw ? fmt(cur) : `$${Number(cur).toFixed(2)}`)
+          : '-'}
       </div>
 
       <div className="text-right">
-        <div className={`text-[12px] font-extrabold ${isUp ? 'text-up' : 'text-down'}`}>
-          {(isUp ? '+' : '') + fmt(Math.abs(pnl))}
+        <div className={pnl != null ? `text-[12px] font-extrabold ${isUp ? 'text-up' : 'text-down'}` : 'text-[12px] font-bold text-foreground-disabled'}>
+          {pnl != null ? fmtSigned(pnl) : '-'}
         </div>
-        <div className={`text-[9px] font-bold ${isUp ? 'text-up' : 'text-down'}`}>
-          {fmtRate(pnlRate)}
+        <div className={pnlRate != null ? `text-[9px] font-bold ${isUp ? 'text-up' : 'text-down'}` : 'text-[9px] font-semibold text-foreground-disabled'}>
+          {pnlRate != null ? fmtRate(pnlRate) : '-'}
         </div>
       </div>
     </div>
@@ -408,18 +521,15 @@ function HoldingsPanel({ data }) {
   const { domesticRows, overseasRows, isLoading } = data
 
   const allRows = [...domesticRows, ...overseasRows]
-    .sort((a, b) => b.evalKrw - a.evalKrw)
+    .sort((a, b) => (b.evalKrw ?? 0) - (a.evalKrw ?? 0))
 
   const rows = filter === 'domestic' ? domesticRows
     : filter === 'overseas' ? overseasRows
     : allRows
 
-  const totalEval = rows.reduce((s, h) => s + h.evalKrw, 0)
-  const totalPnl = rows.reduce((s, h) => s + h.pnl, 0)
+  const totalEval = rows.reduce((s, h) => s + (h.evalKrw ?? 0), 0)
+  const totalPnl = rows.reduce((s, h) => s + (h.pnl ?? 0), 0)
   const totalIsUp = totalPnl >= 0
-
-  const now = new Date()
-  const timeStr = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`
 
   const filters = [
     { key: 'all',      label: `전체 ${allRows.length}` },
@@ -428,31 +538,30 @@ function HoldingsPanel({ data }) {
   ]
 
   return (
-    <div className="flex-1 min-w-0 bg-surface rounded-2xl border border-stroke flex flex-col overflow-hidden">
+    <div className="flex-1 min-w-0 bg-surface flex flex-col overflow-hidden">
 
       {/* 헤더: 필터 + 시간 */}
-      <div className="shrink-0 flex items-center justify-between px-4 py-2.5 border-b border-stroke">
-        <div className="flex items-center gap-1.5">
+      <div className="shrink-0 flex min-h-[44px] items-center justify-between px-4 py-2.5 border-b border-stroke">
+        <div className="text-[13px] font-bold text-foreground">보유종목</div>
+        <div className="flex items-center gap-0.5">
           {filters.map(({ key, label }) => (
             <FilterChip
               key={key}
               isActive={filter === key}
               onClick={() => setFilter(key)}
+              className="px-1.5 py-0.5 text-[9px]"
             >
               {label}
             </FilterChip>
           ))}
         </div>
-        <div className="flex items-center gap-1">
-          <LiveDot size="sm" />
-          <span className="text-[9px] text-foreground-disabled">{timeStr} 기준</span>
-        </div>
       </div>
 
       {/* 컬럼 헤더 */}
-      <div className="shrink-0 grid grid-cols-[1fr_80px_88px_108px] items-center px-4 py-1.5 bg-surface-subtle border-b border-stroke text-[9px] font-semibold text-foreground-disabled">
+      <div className="shrink-0 grid grid-cols-[1fr_62px_82px_78px_92px] items-center px-4 py-1.5 bg-surface-subtle border-b border-stroke text-[9px] font-semibold text-foreground-disabled">
         <span>종목</span>
         <span className="text-right">수량 / 평균가</span>
+        <span className="text-right">매수금액</span>
         <span className="text-right">현재가</span>
         <span className="text-right">평가손익</span>
       </div>
@@ -474,12 +583,24 @@ function HoldingsPanel({ data }) {
 
       {/* 합계 */}
       {!isLoading && rows.length > 0 && (
-        <div className="shrink-0 grid grid-cols-[1fr_80px_88px_108px] items-center px-4 py-2.5 bg-primary-light border-t-2 border-primary-dim">
-          <div className="text-[12px] font-extrabold text-primary">합계</div>
-          <div />
-          <div className="text-right text-[12px] font-bold text-foreground">{fmt(totalEval)}원</div>
-          <div className={`text-right text-[12px] font-extrabold ${totalIsUp ? 'text-up' : 'text-down'}`}>
-            {(totalIsUp ? '+' : '') + fmt(Math.abs(totalPnl))}원
+        <div className="shrink-0 flex items-center justify-between gap-6 border-t border-stroke bg-surface-subtle px-4 py-2.5">
+          <div className="flex items-center gap-2">
+            <span className="text-[11px] font-bold text-foreground">합계</span>
+            <span className="text-[9px] text-foreground-disabled">{rows.length}종목</span>
+          </div>
+
+          <div className="flex items-center gap-5">
+            <div className="text-right">
+              <div className="text-[9px] text-foreground-disabled">평가금액</div>
+              <div className="text-[12px] font-bold text-foreground">{fmt(totalEval)}원</div>
+            </div>
+
+            <div className="text-right">
+              <div className="text-[9px] text-foreground-disabled">평가손익</div>
+              <div className={`text-[12px] font-extrabold ${totalIsUp ? 'text-up' : 'text-down'}`}>
+                {fmtSigned(totalPnl, '원')}
+              </div>
+            </div>
           </div>
         </div>
       )}
@@ -506,13 +627,14 @@ function AuthGuard() {
 // ── 메인 페이지 ───────────────────────────────────────────────────
 export default function AssetPage() {
   const { isAuthenticated, isRestoring, user } = useAuthStore()
-  const data = useAssetPage(isAuthenticated && !isRestoring)
+  const [assetFlowRange, setAssetFlowRange] = useState('1M')
+  const data = useAssetPage(isAuthenticated && !isRestoring, assetFlowRange)
   const [showExchange, setShowExchange] = useState(false)
 
   if (!isRestoring && !isAuthenticated) return <AuthGuard />
 
   return (
-    <div className="flex flex-col h-full overflow-hidden bg-background">
+    <div className="flex flex-col h-full overflow-hidden bg-surface">
 
       {/* 환전 모달 */}
       {showExchange && (
@@ -526,15 +648,19 @@ export default function AssetPage() {
       {/* Hero */}
       <HeroSection data={data} user={user} onExchange={() => setShowExchange(true)} />
 
-      {/* 상단 카드 3열 */}
-      <div className="shrink-0 grid grid-cols-3 gap-3 px-4 pt-3">
+      {/* 상단 요약 스트립 */}
+      <div className="shrink-0 grid grid-cols-[0.88fr_0.98fr_1.14fr] border-b border-stroke bg-surface">
         <AccountCard data={data} />
         <AssetBreakdownCard data={data} />
-        <AssetFlowCard data={data} />
+        <AssetFlowCard
+          data={data}
+          assetFlowRange={assetFlowRange}
+          onChangeAssetFlowRange={setAssetFlowRange}
+        />
       </div>
 
-      {/* 하단 2열: 파이차트 + 보유종목 */}
-      <div className="flex flex-1 min-h-0 gap-3 px-4 py-3">
+      {/* 하단 2열 보드 */}
+      <div className="flex flex-1 min-h-0 bg-surface">
         <PortfolioPanel data={data} />
         <HoldingsPanel data={data} />
       </div>

--- a/src/pages/InvestPage.jsx
+++ b/src/pages/InvestPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useLocation, useParams } from 'react-router-dom'
 import InvestBottomPanels from '@/components/invest/InvestBottomPanels'
 import InvestOrderSection from '@/components/invest/InvestOrderSection'
@@ -12,12 +12,18 @@ import useInvestMarketData from '@/features/invest/useInvestMarketData'
 import { INVEST_STOCK } from '@/mocks/invest'
 import useCurrencyStore from '@/store/useCurrencyStore'
 
+const LAST_INVEST_PATH_KEY = 'invest.lastPath'
+const LAST_INVEST_STATE_KEY = 'invest.lastState'
+const LEFT_TAB_KEY = 'invest.leftTab'
+const RIGHT_TAB_KEY = 'invest.rightTab'
+
 export default function InvestPage() {
   const { stockCode: routeStockCode } = useParams()
-  const { state: locationState } = useLocation()
+  const location = useLocation()
+  const locationState = location.state
   const stockCode = routeStockCode ?? INVEST_STOCK.code
-  const [leftTab, setLeftTab] = useState('daily')
-  const [rightTab, setRightTab] = useState('exec')
+  const [leftTab, setLeftTab] = useState(() => localStorage.getItem(LEFT_TAB_KEY) ?? 'daily')
+  const [rightTab, setRightTab] = useState(() => localStorage.getItem(RIGHT_TAB_KEY) ?? 'exec')
 
   const {
     stockMeta,
@@ -62,6 +68,26 @@ export default function InvestPage() {
       [stockCode]: nextCurrency,
     }))
   }
+
+  useEffect(() => {
+    localStorage.setItem(LEFT_TAB_KEY, leftTab)
+  }, [leftTab])
+
+  useEffect(() => {
+    localStorage.setItem(RIGHT_TAB_KEY, rightTab)
+  }, [rightTab])
+
+  useEffect(() => {
+    sessionStorage.setItem(LAST_INVEST_PATH_KEY, location.pathname)
+
+    const nextState = {
+      stockName: stockMeta.name,
+      stockNameEn: stockMeta.nameEn ?? null,
+      marketType,
+      exchangeCode: stockMeta.exchangeCode ?? null,
+    }
+    sessionStorage.setItem(LAST_INVEST_STATE_KEY, JSON.stringify(nextState))
+  }, [location.pathname, marketType, stockMeta.exchangeCode, stockMeta.name, stockMeta.nameEn])
 
   return (
     <div className="h-full overflow-x-auto bg-surface">

--- a/src/pages/InvestPage.jsx
+++ b/src/pages/InvestPage.jsx
@@ -8,12 +8,11 @@ import {
   FALLBACK_USD_RATE,
   isForeignMarketType,
 } from '@/features/invest/formatters'
+import { LAST_INVEST_PATH_KEY, LAST_INVEST_STATE_KEY } from '@/features/invest/navigation'
 import useInvestMarketData from '@/features/invest/useInvestMarketData'
 import { INVEST_STOCK } from '@/mocks/invest'
 import useCurrencyStore from '@/store/useCurrencyStore'
 
-const LAST_INVEST_PATH_KEY = 'invest.lastPath'
-const LAST_INVEST_STATE_KEY = 'invest.lastState'
 const LEFT_TAB_KEY = 'invest.leftTab'
 const RIGHT_TAB_KEY = 'invest.rightTab'
 

--- a/src/pages/MarketPage.jsx
+++ b/src/pages/MarketPage.jsx
@@ -1,7 +1,10 @@
 import { useState } from 'react'
 import FilterChip from '@/components/ui/FilterChip'
 import PriceChange from '@/components/ui/PriceChange'
-import StockRow from '@/components/market/StockRow'
+import StockRow, {
+  getMarketRowGrid,
+  hasPrimaryMetricColumn,
+} from '@/components/market/StockRow'
 import LiveDot from '@/components/ui/LiveDot'
 import useMarketRanking from '@/features/market/useMarketRanking'
 import useMarketIndices from '@/features/market/useMarketIndices'
@@ -78,12 +81,9 @@ function FilterBar({ marketFilter, setMarketFilter, sortFilter, setSortFilter })
   )
 }
 
-const GRID_WITH_VOL    = 'grid-cols-[32px_40px_2fr_1.5fr_1fr_1fr_1.5fr]'
-const GRID_WITHOUT_VOL = 'grid-cols-[32px_40px_2fr_1.5fr_1fr_1.5fr]'
-
 function StockTableHeader({ sortFilter }) {
-  const showVolume = sortFilter in VOLUME_COL_LABEL
-  const grid = showVolume ? GRID_WITH_VOL : GRID_WITHOUT_VOL
+  const showVolume = hasPrimaryMetricColumn(sortFilter)
+  const grid = getMarketRowGrid(sortFilter)
 
   return (
     <div className={`grid ${grid} items-center px-4 py-2.5 border-b border-stroke-subtle text-[10px] font-semibold text-foreground-disabled`}>
@@ -128,7 +128,7 @@ export default function MarketPage() {
           <StockRow
             key={stock.id}
             stock={stock}
-            showVolume={sortFilter in VOLUME_COL_LABEL}
+            sortFilter={sortFilter}
             isWatched={watchedSet.has(stock.stockCode)}
             onWatchToggle={toggle}
           />


### PR DESCRIPTION
## 연관된 이슈

> 없음

## 작업 내용

자산 화면, 환전 모달, 투자 화면, 시세 목록에서 확인된 흐름 문제와 표시 오류를 함께 정리했습니다.

- 자산 페이지에 자산 흐름 시각화와 평가 정보 보강을 반영했습니다.
- 환전 모달에서 수수료/예상 수령액/완료 연출을 정리하고 전액 입력 동작을 보완했습니다.
- 주문 패널에서 지정가 초기값, 포맷, 실패 메시지 노출, PIN 기억 옵션을 정리했습니다.
- 체결내역/미체결/보유 종목에서 종목 클릭 시 투자 페이지로 이동하도록 연결했습니다.
- 투자 페이지 복귀 시 마지막으로 보던 종목과 탭 상태를 유지하도록 보완했습니다.
- 해외 호가 파싱과 국내/해외 차트 시간 표시 기준을 조정했습니다.
- 시세 목록 헤더/행 컬럼 정렬과 거래 비율 셀 정렬을 보정했습니다.

### 세부 변경

- `AssetPage` / `useAssetPage`에서 자산 흐름 API 연동 및 자산 레이아웃을 개선했습니다.
- `ExchangeModal`에서 전액 입력, 수수료 표시, 완료 전 1.4초 처리 연출을 추가했습니다.
- `InvestOrderSection` / `InvestOrderPanel`에서 주문 실패 메시지와 지정가 입력 UX를 개선했습니다.
- `ExecutionHistoryPanel` / `PendingOrdersPanel` / `HoldingPanel`에 종목 클릭 이동을 추가했습니다.
- `NavTabs` / `InvestPage`에서 투자 페이지 경로와 탭 상태 복원을 추가했습니다.
- `foreign/normalize`와 `InvestStockChart`에서 해외 호가/차트 시간 포맷을 수정했습니다.
- `MarketPage` / `StockRow` / `RatioBar`에서 컬럼 폭과 거래 비율 표시를 정리했습니다.

### 스크린샷 (선택)

없음

## 체크리스트

- [ ] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항(선택)

- 투자 페이지 상태 복원 범위를 `종목/탭`까지만 두었는데, 주문 입력값까지 유지할 필요가 있는지 의견 부탁드립니다.
- 자산 페이지 상단/하단 보드 레이아웃 변경이 기존 디자인 톤과 잘 맞는지 확인 부탁드립니다.
- 차트 시간 포맷 로직이 국내/해외 모두 기대한 기준으로 동작하는지 중점적으로 봐주시면 좋겠습니다.
