### PR TITLE
feat(widget): stock-chart 기간별 캔들 차트 및 intraday 뷰 개선

### DIFF
--- a/src/components/ui/MiniChart.jsx
+++ b/src/components/ui/MiniChart.jsx
@@ -115,9 +115,14 @@ export default function MiniChart({ candleData, liveCandle, isIntraday = false, 
     if (candleData?.length) {
       series.setData(candleData)
     }
+    let scrollTimer
     if (isIntraday && !forcefit) {
       // 국내 1일: 09:00~15:25 사이 5분봉 최대 78개 슬롯을 고정 → 캔들 폭이 일정하게 유지
       chart.timeScale().setVisibleLogicalRange({ from: -0.5, to: 77.5 })
+      // STOMP 수신 여부와 무관하게 항상 최신 캔들로 스크롤 (9:01 → 현재 스르륵 효과)
+      scrollTimer = setTimeout(() => {
+        if (chartRef.current === chart) chart.timeScale().scrollToRealTime()
+      }, 300)
     } else if (candleData?.length) {
       chart.timeScale().fitContent()
     }
@@ -136,6 +141,7 @@ export default function MiniChart({ candleData, liveCandle, isIntraday = false, 
     ro.observe(el)
 
     return () => {
+      clearTimeout(scrollTimer)
       ro.disconnect()
       chart.remove()
       chartRef.current  = null

--- a/src/components/ui/MiniChart.jsx
+++ b/src/components/ui/MiniChart.jsx
@@ -31,14 +31,14 @@ function getChartColors() {
  * 위젯용 캔들 차트 (lightweight-charts)
  * @param {{ time: number, open, high, low, close: number }[]} candleData - 캔들 데이터 (unix seconds)
  * @param {{ time: number, open, high, low, close: number }}   liveCandle - STOMP 실시간 업데이트 포인트
- * @param {boolean} isMinute  - true면 X축 HH:MM / 좌측 고정, false면 M/D
+ * @param {boolean} isIntraday - true(1일): X축 HH:MM, 78슬롯 고정, 우측 오픈 / false: M/D, fitContent
  * @param {string}  className
  */
-export default function MiniChart({ candleData, liveCandle, isMinute = false, className = '' }) {
+export default function MiniChart({ candleData, liveCandle, isIntraday = false, tickOffset = 9 * 3600, forcefit = false, className = '' }) {
   const ref       = useRef(null)
   const seriesRef = useRef(null)
 
-  // 차트 생성 — candleData / isMinute 변경 시 재생성
+  // 차트 생성 — candleData / isIntraday 변경 시 재생성
   useEffect(() => {
     const el = ref.current
     if (!el) return
@@ -73,16 +73,15 @@ export default function MiniChart({ candleData, liveCandle, isMinute = false, cl
       },
       timeScale: {
         visible:        true,
-        timeVisible:    isMinute,
+        timeVisible:    isIntraday,
         secondsVisible: false,
         borderVisible:  false,
         ticksVisible:   false,
         fixLeftEdge:    true,
-        fixRightEdge:   !isMinute, // 분봉: 우측 열린 상태로 캔들이 오른쪽으로 추가됨
+        fixRightEdge:   !isIntraday, // 1일 분봉: 우측 열린 상태로 캔들이 오른쪽으로 추가됨
         tickMarkFormatter: (time, tickMarkType) => {
-          // UTC + 9h → KST (시세탭 InvestStockChart와 동일한 방식)
-          const d = new Date((time + 9 * 3600) * 1000)
-          if (isMinute) {
+          const d = new Date((time + tickOffset) * 1000)
+          if (isIntraday) {
             const hh = String(d.getUTCHours()).padStart(2, '0')
             const mm = String(d.getUTCMinutes()).padStart(2, '0')
             return `${hh}:${mm}`
@@ -106,17 +105,17 @@ export default function MiniChart({ candleData, liveCandle, isMinute = false, cl
       downColor:       down,
       borderDownColor: down,
       wickDownColor:   down,
-      priceLineVisible: false,
-      lastValueVisible: false,
+      priceLineVisible: true,
+      priceLineWidth:   1,
+      lastValueVisible: true,
     })
     seriesRef.current = series
 
     if (candleData?.length) {
       series.setData(candleData)
     }
-    if (isMinute) {
-      // 09:00~15:25 사이 5분봉 최대 78개 슬롯을 고정 → 캔들 폭이 일정하게 유지
-      // setVisibleRange는 데이터 밖 시간을 빈 공간으로 처리하지 못해 setVisibleLogicalRange 사용
+    if (isIntraday && !forcefit) {
+      // 국내 1일: 09:00~15:25 사이 5분봉 최대 78개 슬롯을 고정 → 캔들 폭이 일정하게 유지
       chart.timeScale().setVisibleLogicalRange({ from: -0.5, to: 77.5 })
     } else if (candleData?.length) {
       chart.timeScale().fitContent()
@@ -140,7 +139,7 @@ export default function MiniChart({ candleData, liveCandle, isMinute = false, cl
       chart.remove()
       seriesRef.current = null
     }
-  }, [candleData, isMinute])
+  }, [candleData, isIntraday, tickOffset, forcefit])
 
   // STOMP 실시간 캔들 업데이트 — 차트 재생성 없이 마지막 봉만 갱신
   useEffect(() => {

--- a/src/components/ui/MiniChart.jsx
+++ b/src/components/ui/MiniChart.jsx
@@ -66,7 +66,6 @@ export default function MiniChart({ candleData, liveCandle, isIntraday = false, 
         visible:       true,
         borderVisible: false,
         minimumWidth:  48,
-        entireTextOnly: true,
         scaleMargins:  priceScaleMargins,
       },
       localization: {

--- a/src/components/ui/MiniChart.jsx
+++ b/src/components/ui/MiniChart.jsx
@@ -52,10 +52,10 @@ function getChartColors() {
  * 위젯용 캔들 차트 (lightweight-charts)
  * @param {{ time: number, open, high, low, close: number }[]} candleData - 캔들 데이터 (unix seconds)
  * @param {{ time: number, open, high, low, close: number }}   liveCandle - STOMP 실시간 업데이트 포인트
- * @param {boolean} isIntraday - true(1일): X축 HH:MM, 79슬롯 고정, 우측 오픈 / false: M/D, fitContent
+ * @param {boolean} isIntraday - true(1일): X축 HH:MM, 79슬롯(09:00~15:30) 고정, 우측 오픈 / false: M/D, fitContent
  * @param {string}  className
  */
-export default function MiniChart({ candleData, liveCandle, isIntraday = false, tickOffset = 9 * 3600, forcefit = false, className = '' }) {
+export default function MiniChart({ candleData, liveCandle, isIntraday = false, tickOffset = 9 * 3600, isForceFit = false, className = '' }) {
   const ref      = useRef(null)
   const chartRef = useRef(null)
   const seriesRef = useRef(null)
@@ -136,7 +136,7 @@ export default function MiniChart({ candleData, liveCandle, isIntraday = false, 
     if (candleData?.length) {
       series.setData(candleData)
     }
-    if (isIntraday && !forcefit) {
+    if (isIntraday && !isForceFit) {
       // 국내 1일: 09:00~15:30 세션 슬롯(79개)에 맞춰 고정
       chart.timeScale().setVisibleLogicalRange(getIntradayFixedLogicalRange(candleData, tickOffset))
     } else if (candleData?.length) {

--- a/src/components/ui/MiniChart.jsx
+++ b/src/components/ui/MiniChart.jsx
@@ -35,7 +35,8 @@ function getChartColors() {
  * @param {string}  className
  */
 export default function MiniChart({ candleData, liveCandle, isIntraday = false, tickOffset = 9 * 3600, forcefit = false, className = '' }) {
-  const ref       = useRef(null)
+  const ref      = useRef(null)
+  const chartRef = useRef(null)
   const seriesRef = useRef(null)
 
   // 차트 생성 — candleData / isIntraday 변경 시 재생성
@@ -109,6 +110,7 @@ export default function MiniChart({ candleData, liveCandle, isIntraday = false, 
       priceLineWidth:   1,
       lastValueVisible: true,
     })
+    chartRef.current  = chart
     seriesRef.current = series
 
     if (candleData?.length) {
@@ -137,15 +139,20 @@ export default function MiniChart({ candleData, liveCandle, isIntraday = false, 
     return () => {
       ro.disconnect()
       chart.remove()
+      chartRef.current  = null
       seriesRef.current = null
     }
   }, [candleData, isIntraday, tickOffset, forcefit])
 
   // STOMP 실시간 캔들 업데이트 — 차트 재생성 없이 마지막 봉만 갱신
+  // isIntraday: 새 버킷이 78슬롯 밖으로 나갈 수 있으므로 최신 캔들이 보이도록 scrollToRealTime
   useEffect(() => {
     if (!seriesRef.current || !liveCandle) return
     seriesRef.current.update(liveCandle)
-  }, [liveCandle])
+    if (isIntraday && chartRef.current) {
+      chartRef.current.timeScale().scrollToRealTime()
+    }
+  }, [liveCandle, isIntraday])
 
   return <div ref={ref} className={className} />
 }

--- a/src/components/ui/MiniChart.jsx
+++ b/src/components/ui/MiniChart.jsx
@@ -1,6 +1,27 @@
 import { useEffect, useRef } from 'react'
 import { CandlestickSeries, createChart } from 'lightweight-charts'
 
+function getIntradayFixedLogicalRange(candleData, tickOffset) {
+  // 5분봉 세션 슬롯: 09:00 ~ 15:30 (총 79개)
+  const TOTAL_SLOTS = 79
+  const SESSION_OPEN_MINUTES = 9 * 60
+  const SLOT_MINUTES = 5
+
+  if (!candleData?.length) return { from: -0.5, to: TOTAL_SLOTS - 0.5 }
+
+  const first = candleData[0]
+  const d = new Date((first.time + tickOffset) * 1000)
+  const minutes = d.getUTCHours() * 60 + d.getUTCMinutes()
+  const rawSlotIndex = Math.floor((minutes - SESSION_OPEN_MINUTES) / SLOT_MINUTES)
+  const firstSlotIndex = Math.max(0, Math.min(TOTAL_SLOTS - 1, rawSlotIndex))
+
+  // 첫 캔들이 09:00이 아니어도 X축이 항상 09:00~15:30 구간을 표현하도록 보정
+  return {
+    from: -0.5 - firstSlotIndex,
+    to: TOTAL_SLOTS - 0.5 - firstSlotIndex,
+  }
+}
+
 function getPriceScaleMargins(height) {
   const h = Math.max(1, height || 0)
 
@@ -31,7 +52,7 @@ function getChartColors() {
  * 위젯용 캔들 차트 (lightweight-charts)
  * @param {{ time: number, open, high, low, close: number }[]} candleData - 캔들 데이터 (unix seconds)
  * @param {{ time: number, open, high, low, close: number }}   liveCandle - STOMP 실시간 업데이트 포인트
- * @param {boolean} isIntraday - true(1일): X축 HH:MM, 78슬롯 고정, 우측 오픈 / false: M/D, fitContent
+ * @param {boolean} isIntraday - true(1일): X축 HH:MM, 79슬롯 고정, 우측 오픈 / false: M/D, fitContent
  * @param {string}  className
  */
 export default function MiniChart({ candleData, liveCandle, isIntraday = false, tickOffset = 9 * 3600, forcefit = false, className = '' }) {
@@ -115,14 +136,9 @@ export default function MiniChart({ candleData, liveCandle, isIntraday = false, 
     if (candleData?.length) {
       series.setData(candleData)
     }
-    let scrollTimer
     if (isIntraday && !forcefit) {
-      // 국내 1일: 09:00~15:25 사이 5분봉 최대 78개 슬롯을 고정 → 캔들 폭이 일정하게 유지
-      chart.timeScale().setVisibleLogicalRange({ from: -0.5, to: 77.5 })
-      // STOMP 수신 여부와 무관하게 항상 최신 캔들로 스크롤 (9:01 → 현재 스르륵 효과)
-      scrollTimer = setTimeout(() => {
-        if (chartRef.current === chart) chart.timeScale().scrollToRealTime()
-      }, 300)
+      // 국내 1일: 09:00~15:30 세션 슬롯(79개)에 맞춰 고정
+      chart.timeScale().setVisibleLogicalRange(getIntradayFixedLogicalRange(candleData, tickOffset))
     } else if (candleData?.length) {
       chart.timeScale().fitContent()
     }
@@ -141,7 +157,6 @@ export default function MiniChart({ candleData, liveCandle, isIntraday = false, 
     ro.observe(el)
 
     return () => {
-      clearTimeout(scrollTimer)
       ro.disconnect()
       chart.remove()
       chartRef.current  = null
@@ -150,7 +165,7 @@ export default function MiniChart({ candleData, liveCandle, isIntraday = false, 
   }, [candleData, isIntraday, tickOffset, forcefit])
 
   // STOMP 실시간 캔들 업데이트 — 차트 재생성 없이 마지막 봉만 갱신
-  // isIntraday: 새 버킷이 78슬롯 밖으로 나갈 수 있으므로 최신 캔들이 보이도록 scrollToRealTime
+  // isIntraday: 새 버킷이 79슬롯 밖으로 나가면 최신 캔들이 보이도록 scrollToRealTime
   useEffect(() => {
     if (!seriesRef.current || !liveCandle) return
     seriesRef.current.update(liveCandle)

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -31,10 +31,12 @@ const EXCHCD_BY_EXCHANGE_CODE = { NAS: '82', NYS: '81', AMS: '81' }
 const EXCHCD_BY_MARKET_TYPE   = { NASDAQ: '82', NYSE: '81', AMEX: '81' }
 
 const PERIOD_CONFIG = {
-  '1일': { type: 'minute', ncnt: 5 },
-  '1주': { type: 'daily',  period: 'DAILY',  foreignPeriod: 'DAY', days: 7  },
-  '1달': { type: 'daily',  period: 'DAILY',  foreignPeriod: 'DAY', days: 30 },
-  '3달': { type: 'weekly', period: 'WEEKLY', foreignPeriod: 'DAY', days: 90 },
+  '1일': { type: 'minute', ncnt: 5,  nmin: 5,  filterToday: true,  tradingDays: null },
+  '1주': { type: 'minute', ncnt: 30, nmin: 30, filterToday: false, tradingDays: 5,
+           overseasType: 'daily', foreignPeriod: 'DAY', days: 7  },
+  '1달': { type: 'minute', ncnt: 60, nmin: 60, filterToday: false, tradingDays: 20,
+           overseasType: 'daily', foreignPeriod: 'DAY', days: 30 },
+  '3달': { type: 'daily',  period: 'DAILY',  foreignPeriod: 'DAY', days: 90 },
 }
 
 // 5분봉 버킷 타임스탬프 계산
@@ -136,11 +138,12 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
     if (!stockCode) return
     const end = formatApiDate(new Date())
     Object.values(PERIOD_CONFIG).forEach((cfg) => {
-      if (cfg.type === 'minute') {
+      const effectiveCfgType = isOverseas ? (cfg.overseasType ?? cfg.type) : cfg.type
+      if (effectiveCfgType === 'minute') {
         if (isOverseas) {
           queryClient.prefetchQuery({
-            queryKey: ['foreign', 'minuteChart', stockCode, exchcd, 5],
-            queryFn:  () => foreignMarketApi.getMinuteChart(stockCode, exchcd, { nmin: 5 }),
+            queryKey: ['foreign', 'minuteChart', stockCode, exchcd, cfg.nmin],
+            queryFn:  () => foreignMarketApi.getMinuteChart(stockCode, exchcd, { nmin: cfg.nmin }),
             staleTime: 60_000,
           })
         } else {
@@ -169,8 +172,10 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
     })
   }, [stockCode, exchcd, isOverseas, queryClient])
 
-  const periodCfg = PERIOD_CONFIG[activePeriod]
-  const isMinute  = periodCfg.type === 'minute'
+  const periodCfg    = PERIOD_CONFIG[activePeriod]
+  const effectiveType = isOverseas ? (periodCfg.overseasType ?? periodCfg.type) : periodCfg.type
+  const isMinute     = effectiveType === 'minute'
+  const isIntraday   = activePeriod === '1일'
 
   const endDate   = useMemo(() => formatApiDate(new Date()), [])
   const startDate = useMemo(
@@ -180,10 +185,10 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
 
   const { data: minuteRaw } = useQuery({
     queryKey: isOverseas
-      ? ['foreign', 'minuteChart', stockCode, exchcd, 5]
+      ? ['foreign', 'minuteChart', stockCode, exchcd, periodCfg.nmin]
       : ['stock', 'minute-chart', stockCode, periodCfg.ncnt],
     queryFn: isOverseas
-      ? () => foreignMarketApi.getMinuteChart(stockCode, exchcd, { nmin: 5 })
+      ? () => foreignMarketApi.getMinuteChart(stockCode, exchcd, { nmin: periodCfg.nmin })
       : () => marketApi.getMinuteChart(stockCode, { ncnt: periodCfg.ncnt }),
     enabled:  !!stockCode && isMinute,
     staleTime: 60_000,
@@ -214,8 +219,8 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
     if (chetime.length < 4) return
     const time = toMinuteBucketTime(chetime)
 
-    // 캔들 누적 (분봉 기간일 때만 차트 업데이트)
-    if (isMinute) {
+    // 캔들 누적 (1일 intraday에서만 5분봉 버킷으로 차트 업데이트)
+    if (isIntraday) {
       setLiveCandle((prev) => {
         if (!prev || prev.time !== time) {
           return { time, open: price, high: price, low: price, close: price }
@@ -227,7 +232,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
     const changeRate   = Number(liveTrade.drate ?? 0)
     const changeAmount = Number(liveTrade.change ?? 0) * (changeRate >= 0 ? 1 : -1)
     setLivePrice({ currentPrice: price, changeRate, changeAmount })
-  }, [liveTrade, isMinute])
+  }, [liveTrade, isIntraday])
 
   // ── 차트 데이터 ────────────────────────────────────────────────
   const { candleData, latestCandle } = useMemo(() => {
@@ -242,12 +247,22 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
         : normalizeDailySeries(chartRaw?.data)
     }
 
-    // 분봉: 오늘 세션만 표시
-    if (isMinute) {
+    // 기간별 데이터 필터
+    if (periodCfg.filterToday && !isOverseas) {
+      // 국내 1일: 분봉 API가 다일치 데이터를 반환하므로 KST 오늘 세션만 추출
+      // 해외 1일: chart-nmin은 한 세션치만 반환하므로 필터 불필요
       const today = new Date()
       const todayKey = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
       const todaySeries = series.filter((p) => p.sessionDate === todayKey)
       if (todaySeries.length > 0) series = todaySeries
+    } else if (periodCfg.tradingDays) {
+      // 분봉(국내 1주·1달): sessionDate 기반, 일봉(해외 1주·1달): date 기반
+      // days: 7/30 범위로 넉넉히 받은 뒤 최근 N거래일로 정확히 자름
+      const dateKey = (p) => p.sessionDate ?? p.date
+      const dates = [...new Set(series.map(dateKey))].sort()
+      const cutoffDate = dates[Math.max(0, dates.length - periodCfg.tradingDays)]
+      const filtered = series.filter((p) => dateKey(p) >= cutoffDate)
+      if (filtered.length > 0) series = filtered
     }
 
     const toTime = (p) => Math.floor(p.timestamp / 1000)
@@ -255,7 +270,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
       candleData:   series.map((p) => ({ time: toTime(p), open: p.open, high: p.high, low: p.low, close: p.close })),
       latestCandle: series[series.length - 1] ?? null,
     }
-  }, [isMinute, isOverseas, minuteRaw, chartRaw])
+  }, [isMinute, isOverseas, minuteRaw, chartRaw, periodCfg.filterToday, periodCfg.tradingDays])
 
   // ── 가격 표시용 (STOMP > REST 우선) ───────────────────────────
   const priceSource = livePrice ?? priceData
@@ -321,7 +336,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
                 }
               </div>
             </div>
-            <MiniChart candleData={candleData} liveCandle={isMinute ? liveCandle : null} isMinute={isMinute} className="flex-1 min-h-0" />
+            <MiniChart candleData={candleData} liveCandle={isIntraday ? liveCandle : null} isIntraday={isIntraday} tickOffset={isOverseas ? 0 : 9 * 3600} forcefit={isOverseas && isIntraday} className="flex-1 min-h-0" />
           </div>
         </WidgetCard>
         {selectModal}
@@ -352,7 +367,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
           <div className="flex items-center shrink-0 mb-1.5">
             {periodTabs}
           </div>
-          <MiniChart candleData={candleData} liveCandle={isMinute ? liveCandle : null} isMinute={isMinute} className="flex-1 min-h-0 rounded-xl" />
+          <MiniChart candleData={candleData} liveCandle={isIntraday ? liveCandle : null} isIntraday={isIntraday} tickOffset={isOverseas ? 0 : 9 * 3600} forcefit={isOverseas && isIntraday} className="flex-1 min-h-0 rounded-xl mb-1.5" />
           <div className="flex justify-between shrink-0 mt-1.5">
             {[
               { label: '시가',  val: stock.open },
@@ -395,7 +410,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
           <div className="flex shrink-0 mb-1">
             {periodTabs}
           </div>
-          <MiniChart candleData={candleData} liveCandle={isMinute ? liveCandle : null} isMinute={isMinute} className="flex-1 min-h-0 rounded-xl mb-1.5" />
+          <MiniChart candleData={candleData} liveCandle={isIntraday ? liveCandle : null} isIntraday={isIntraday} tickOffset={isOverseas ? 0 : 9 * 3600} forcefit={isOverseas && isIntraday} className="flex-1 min-h-0 rounded-xl mb-1.5" />
           <div className="flex justify-between shrink-0">
             {[
               { label: '시가', val: stock.open },

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -236,7 +236,10 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
   }, [liveTrade, isIntraday])
 
   // ── 차트 데이터 ────────────────────────────────────────────────
-  const { candleData, latestCandle } = useMemo(() => {
+  const today = new Date()
+  const todayKey = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
+
+  const { candleData, latestCandle, isCurrentSession } = useMemo(() => {
     let series
     if (isMinute) {
       series = isOverseas
@@ -249,11 +252,14 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
     }
 
     // 기간별 데이터 필터
+    let isCurrentSession = true
     if (periodCfg.filterToday && !isOverseas) {
       // 국내 1일: 분봉 API가 다일치 데이터를 반환하므로 가장 최근 거래 세션만 추출
       // (당일 데이터가 없는 경우에도 직전 거래일을 올바르게 표시)
       const latestSession = getLatestMinuteSession(series)
       if (latestSession.length > 0) series = latestSession
+      // 오늘 세션 여부: 9:01→현재 애니메이션 vs 과거 세션 fitContent 분기에 사용
+      isCurrentSession = series.some((p) => p.sessionDate === todayKey)
     } else if (periodCfg.tradingDays) {
       // 분봉(국내 1주·1달): sessionDate 기반, 일봉(해외 1주·1달): date 기반
       // days: 7/30 범위로 넉넉히 받은 뒤 최근 N거래일로 정확히 자름
@@ -268,8 +274,9 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
     return {
       candleData:   series.map((p) => ({ time: toTime(p), open: p.open, high: p.high, low: p.low, close: p.close })),
       latestCandle: series[series.length - 1] ?? null,
+      isCurrentSession,
     }
-  }, [isMinute, isOverseas, minuteRaw, chartRaw, periodCfg.filterToday, periodCfg.tradingDays])
+  }, [isMinute, isOverseas, minuteRaw, chartRaw, periodCfg.filterToday, periodCfg.tradingDays, todayKey])
 
   // ── 가격 표시용 (STOMP > REST 우선) ───────────────────────────
   const priceSource = livePrice ?? priceData
@@ -335,7 +342,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
                 }
               </div>
             </div>
-            <MiniChart candleData={candleData} liveCandle={isIntraday ? liveCandle : null} isIntraday={isIntraday} forcefit={isOverseas && isIntraday} className="flex-1 min-h-0" />
+            <MiniChart candleData={candleData} liveCandle={isIntraday ? liveCandle : null} isIntraday={isIntraday} forcefit={isIntraday && (isOverseas || !isCurrentSession)} className="flex-1 min-h-0" />
           </div>
         </WidgetCard>
         {selectModal}
@@ -366,7 +373,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
           <div className="flex items-center shrink-0 mb-1.5">
             {periodTabs}
           </div>
-          <MiniChart candleData={candleData} liveCandle={isIntraday ? liveCandle : null} isIntraday={isIntraday} forcefit={isOverseas && isIntraday} className="flex-1 min-h-0 rounded-xl mb-1.5" />
+          <MiniChart candleData={candleData} liveCandle={isIntraday ? liveCandle : null} isIntraday={isIntraday} forcefit={isIntraday && (isOverseas || !isCurrentSession)} className="flex-1 min-h-0 rounded-xl mb-1.5" />
           <div className="flex justify-between shrink-0 mt-1.5">
             {[
               { label: '시가',  val: stock.open },
@@ -409,7 +416,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
           <div className="flex shrink-0 mb-1">
             {periodTabs}
           </div>
-          <MiniChart candleData={candleData} liveCandle={isIntraday ? liveCandle : null} isIntraday={isIntraday} forcefit={isOverseas && isIntraday} className="flex-1 min-h-0 rounded-xl mb-1.5" />
+          <MiniChart candleData={candleData} liveCandle={isIntraday ? liveCandle : null} isIntraday={isIntraday} forcefit={isIntraday && (isOverseas || !isCurrentSession)} className="flex-1 min-h-0 rounded-xl mb-1.5" />
           <div className="flex justify-between shrink-0">
             {[
               { label: '시가', val: stock.open },

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -336,7 +336,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
                 }
               </div>
             </div>
-            <MiniChart candleData={candleData} liveCandle={isIntraday ? liveCandle : null} isIntraday={isIntraday} tickOffset={isOverseas ? 0 : 9 * 3600} forcefit={isOverseas && isIntraday} className="flex-1 min-h-0" />
+            <MiniChart candleData={candleData} liveCandle={isIntraday ? liveCandle : null} isIntraday={isIntraday} forcefit={isOverseas && isIntraday} className="flex-1 min-h-0" />
           </div>
         </WidgetCard>
         {selectModal}
@@ -367,7 +367,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
           <div className="flex items-center shrink-0 mb-1.5">
             {periodTabs}
           </div>
-          <MiniChart candleData={candleData} liveCandle={isIntraday ? liveCandle : null} isIntraday={isIntraday} tickOffset={isOverseas ? 0 : 9 * 3600} forcefit={isOverseas && isIntraday} className="flex-1 min-h-0 rounded-xl mb-1.5" />
+          <MiniChart candleData={candleData} liveCandle={isIntraday ? liveCandle : null} isIntraday={isIntraday} forcefit={isOverseas && isIntraday} className="flex-1 min-h-0 rounded-xl mb-1.5" />
           <div className="flex justify-between shrink-0 mt-1.5">
             {[
               { label: '시가',  val: stock.open },
@@ -410,7 +410,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
           <div className="flex shrink-0 mb-1">
             {periodTabs}
           </div>
-          <MiniChart candleData={candleData} liveCandle={isIntraday ? liveCandle : null} isIntraday={isIntraday} tickOffset={isOverseas ? 0 : 9 * 3600} forcefit={isOverseas && isIntraday} className="flex-1 min-h-0 rounded-xl mb-1.5" />
+          <MiniChart candleData={candleData} liveCandle={isIntraday ? liveCandle : null} isIntraday={isIntraday} forcefit={isOverseas && isIntraday} className="flex-1 min-h-0 rounded-xl mb-1.5" />
           <div className="flex justify-between shrink-0">
             {[
               { label: '시가', val: stock.open },

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -14,6 +14,7 @@ import useStompSubscription from '@/hooks/useStompSubscription'
 import { normalizeDailySeries, normalizeMinuteSeries } from '@/features/invest/domestic/normalize'
 import { normalizeForeignDailySeries, normalizeForeignMinuteSeries } from '@/features/invest/foreign/normalize'
 import { formatApiDate } from '@/features/invest/formatters'
+import { getLatestMinuteSession } from '@/features/invest/marketData'
 
 // config.stockId(레거시) → 종목코드 매핑
 const STOCK_CODE_MAP = {
@@ -249,12 +250,10 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
 
     // 기간별 데이터 필터
     if (periodCfg.filterToday && !isOverseas) {
-      // 국내 1일: 분봉 API가 다일치 데이터를 반환하므로 KST 오늘 세션만 추출
-      // 해외 1일: chart-nmin은 한 세션치만 반환하므로 필터 불필요
-      const today = new Date()
-      const todayKey = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
-      const todaySeries = series.filter((p) => p.sessionDate === todayKey)
-      if (todaySeries.length > 0) series = todaySeries
+      // 국내 1일: 분봉 API가 다일치 데이터를 반환하므로 가장 최근 거래 세션만 추출
+      // (당일 데이터가 없는 경우에도 직전 거래일을 올바르게 표시)
+      const latestSession = getLatestMinuteSession(series)
+      if (latestSession.length > 0) series = latestSession
     } else if (periodCfg.tradingDays) {
       // 분봉(국내 1주·1달): sessionDate 기반, 일봉(해외 1주·1달): date 기반
       // days: 7/30 범위로 넉넉히 받은 뒤 최근 N거래일로 정확히 자름

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -57,6 +57,14 @@ function fmtVolume(v) {
   return v.toLocaleString('ko-KR')
 }
 
+function isWithinRegularSession(timestampMs) {
+  const d = new Date(timestampMs)
+  const minutes = d.getHours() * 60 + d.getMinutes()
+  const open = 9 * 60
+  const close = 15 * 60 + 30
+  return minutes >= open && minutes <= close
+}
+
 export default function StockChartWidget({ instanceId, variant = 'stock-sm', colSpan = 1, rowSpan = 1, onDelete, config = {} }) {
   const [activePeriod, setActivePeriod] = useState(
     () => localStorage.getItem(`widget.period.${instanceId}`) ?? '1일'
@@ -257,7 +265,12 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
       // 국내 1일: 분봉 API가 다일치 데이터를 반환하므로 가장 최근 거래 세션만 추출
       // (당일 데이터가 없는 경우에도 직전 거래일을 올바르게 표시)
       const latestSession = getLatestMinuteSession(series)
-      if (latestSession.length > 0) series = latestSession
+      if (latestSession.length > 0) {
+        // 초기 렌더에서는 정규장(09:00~15:30)만 노출.
+        // 장후 봉은 STOMP liveCandle 업데이트가 들어올 때 우측으로 밀리며 추가되게 유지한다.
+        const regularSession = latestSession.filter((p) => isWithinRegularSession(p.timestamp))
+        series = regularSession.length > 0 ? regularSession : latestSession
+      }
       // 오늘 세션 여부: 9:01→현재 애니메이션 vs 과거 세션 fitContent 분기에 사용
       isCurrentSession = series.some((p) => p.sessionDate === todayKey)
     } else if (periodCfg.tradingDays) {
@@ -277,6 +290,8 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
       isCurrentSession,
     }
   }, [isMinute, isOverseas, minuteRaw, chartRaw, periodCfg.filterToday, periodCfg.tradingDays, todayKey])
+
+  const isForceFit = isIntraday && (isOverseas || !isCurrentSession)
 
   // ── 가격 표시용 (STOMP > REST 우선) ───────────────────────────
   const priceSource = livePrice ?? priceData
@@ -342,7 +357,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
                 }
               </div>
             </div>
-            <MiniChart candleData={candleData} liveCandle={isIntraday ? liveCandle : null} isIntraday={isIntraday} forcefit={isIntraday && (isOverseas || !isCurrentSession)} className="flex-1 min-h-0" />
+            <MiniChart candleData={candleData} liveCandle={isIntraday ? liveCandle : null} isIntraday={isIntraday} isForceFit={isForceFit} className="flex-1 min-h-0" />
           </div>
         </WidgetCard>
         {selectModal}
@@ -373,7 +388,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
           <div className="flex items-center shrink-0 mb-1.5">
             {periodTabs}
           </div>
-          <MiniChart candleData={candleData} liveCandle={isIntraday ? liveCandle : null} isIntraday={isIntraday} forcefit={isIntraday && (isOverseas || !isCurrentSession)} className="flex-1 min-h-0 rounded-xl mb-1.5" />
+          <MiniChart candleData={candleData} liveCandle={isIntraday ? liveCandle : null} isIntraday={isIntraday} isForceFit={isForceFit} className="flex-1 min-h-0 rounded-xl mb-1.5" />
           <div className="flex justify-between shrink-0 mt-1.5">
             {[
               { label: '시가',  val: stock.open },
@@ -416,7 +431,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
           <div className="flex shrink-0 mb-1">
             {periodTabs}
           </div>
-          <MiniChart candleData={candleData} liveCandle={isIntraday ? liveCandle : null} isIntraday={isIntraday} forcefit={isIntraday && (isOverseas || !isCurrentSession)} className="flex-1 min-h-0 rounded-xl mb-1.5" />
+          <MiniChart candleData={candleData} liveCandle={isIntraday ? liveCandle : null} isIntraday={isIntraday} isForceFit={isForceFit} className="flex-1 min-h-0 rounded-xl mb-1.5" />
           <div className="flex justify-between shrink-0">
             {[
               { label: '시가', val: stock.open },

--- a/src/features/invest/foreign/normalize.js
+++ b/src/features/invest/foreign/normalize.js
@@ -1,4 +1,4 @@
-import { extractDateKey, computeDepth } from '@/features/invest/marketData'
+import { toLocalTimestamp, extractDateKey, computeDepth } from '@/features/invest/marketData'
 
 function toNumber(value, fallback = 0) {
   const parsed = Number(value)
@@ -62,10 +62,9 @@ export function normalizeForeignDailySeries(dataPoints) {
 }
 
 export function normalizeForeignMinuteSeries(dataPoints) {
-  const now = Date.now()
-  const normalized = (dataPoints ?? [])
+  return (dataPoints ?? [])
     .map((item) => ({
-      timestamp: toExchangeLocalTimestamp(item.dateTime),
+      timestamp: toLocalTimestamp(item.dateTime),
       sessionDate: extractDateKey(item.dateTime),
       open: Number(item.open),
       high: Number(item.high),
@@ -75,9 +74,6 @@ export function normalizeForeignMinuteSeries(dataPoints) {
     }))
     .filter((item) => Number.isFinite(item.timestamp) && item.sessionDate)
     .sort((left, right) => left.timestamp - right.timestamp)
-
-  const visibleItems = normalized.filter((item) => item.timestamp <= now)
-  return visibleItems.length > 0 ? visibleItems : normalized
 }
 
 export function normalizeForeignOrderBook(raw) {


### PR DESCRIPTION
## 개요

stock-chart 위젯 기간별 캔들 로직 분리 및 국내 1일(intraday) 차트 뷰 정확도 개선.

## 변경 사항

### MiniChart (`src/components/ui/MiniChart.jsx`)
- `isIntraday` · `tickOffset` · `isForceFit` prop 추가 — 1일/기간 차트 분기 처리
- `priceLineVisible: true`, `lastValueVisible: true` 활성화
- intraday 첫 캔들 슬롯 위치 기준으로 논리 범위(09:00~15:30, 79슬롯) 동적 보정
- `entireTextOnly` 제거로 가격 박스-점선 Y축 불일치 수정
- intraday live candle이 79슬롯 밖으로 나갈 때 `scrollToRealTime` 적용

### StockChartWidget (`src/components/widgets/StockChartWidget.jsx`)
- `PERIOD_CONFIG` 확장: `filterToday`, `tradingDays`, `overseasType`, `nmin`
- `effectiveType`, `isIntraday` 분리: 해외 여부·기간에 따라 API·차트 렌더링 독립 제어
- 국내 1일 분봉 `filterToday` → `getLatestMinuteSession`으로 교체
- STOMP liveCandle 업데이트를 `isIntraday`(국내 1일) 탭에서만 적용
- 1일 과거 세션은 `fitContent`, 오늘 세션만 79슬롯 고정 + 애니메이션
- `isForceFit` 변수 추출 — 3곳의 중복 계산식 통일

### normalize (`src/features/invest/foreign/normalize.js`)
- `normalizeForeignMinuteSeries`: `visibleItems` 필터 제거
- 해외 분봉 X축 KST 변환 복원 (`parseOverseasDateTime` 제거)

## 최종 위젯 동작

### 국내

| 기간 | API | 봉 종류 | 필터 | X축 |
|------|-----|---------|------|-----|
| 1일 | `minute-chart` (ncnt=5) | 5분봉 | 최신 세션(KST) | HH:MM · 79슬롯(09:00~15:30) 고정 |
| 1주 | `minute-chart` (ncnt=30) | 30분봉 | 최근 5거래일 | HH:MM · fitContent |
| 1달 | `minute-chart` (ncnt=60) | 60분봉 | 최근 20거래일 | HH:MM · fitContent |
| 3달 | `chart` (DAILY) | 일봉 | — | M/D · fitContent |

### 해외

| 기간 | API | 봉 종류 | 필터 | X축 |
|------|-----|---------|------|-----|
| 1일 | `chart-nmin` (nmin=5) | 5분봉 | 없음 | HH:MM (KST) · fitContent |
| 1주 | `chart` (DAY, 7일) | 일봉 | 최근 5거래일 | M/D · fitContent |
| 1달 | `chart` (DAY, 30일) | 일봉 | 최근 20거래일 | M/D · fitContent |
| 3달 | `chart` (DAY, 90일) | 일봉 | — | M/D · fitContent |

## 테스트 체크리스트

- [ ] 국내 종목 1일 차트: 09:00~15:30 슬롯(79개)이 정확히 표시됨
- [ ] 국내 종목 1일 차트: 오늘 세션 진입 시 79슬롯 고정 + scrollToRealTime 동작
- [ ] 국내 종목 1일 차트: 과거 세션은 fitContent 적용
- [ ] 해외 종목 분봉: X축 시간이 KST 기준으로 표시됨
- [ ] live candle 업데이트 시 화면 이탈 없이 최신 캔들로 스크롤
- [ ] 가격 박스와 점선이 Y축 동일 위치에 표시됨

closes #93