### PR TITLE
fix(ui): MiniChart useEffect 의존성 배열 forcefit → isForceFit 누락 수정

### DIFF
--- a/src/components/ui/MiniChart.jsx
+++ b/src/components/ui/MiniChart.jsx
@@ -162,7 +162,7 @@ export default function MiniChart({ candleData, liveCandle, isIntraday = false, 
       chartRef.current  = null
       seriesRef.current = null
     }
-  }, [candleData, isIntraday, tickOffset, forcefit])
+  }, [candleData, isIntraday, tickOffset, isForceFit])
 
   // STOMP 실시간 캔들 업데이트 — 차트 재생성 없이 마지막 봉만 갱신
   // isIntraday: 새 버킷이 79슬롯 밖으로 나가면 최신 캔들이 보이도록 scrollToRealTime


### PR DESCRIPTION
## 원인

`forcefit` → `isForceFit` prop 리네이밍 시 `useEffect` 의존성 배열 업데이트 누락.

```js
// 수정 전
}, [candleData, isIntraday, tickOffset, forcefit])  // forcefit은 존재하지 않는 변수

// 수정 후
}, [candleData, isIntraday, tickOffset, isForceFit])
```

## 영향

`ReferenceError: forcefit is not defined` 런타임 에러 발생.

closes #93