### PR TITLE
fix(home): 신규 로그인 시 빈 대시보드 처리 및 위젯 추가 유도 UI 구현

### DIFF
--- a/src/hooks/useDashboardSync.js
+++ b/src/hooks/useDashboardSync.js
@@ -23,16 +23,22 @@ export function useDashboardLoad() {
     if (!isAuthenticated) resetLayout()
   }, [isAuthenticated, resetLayout])
 
-  const { data } = useQuery({
+  const { data, isError } = useQuery({
     queryKey: ['dashboard', 'me'],
     queryFn: dashboardApi.getMyDashboard,
     enabled: isAuthenticated && !isLoaded,
     staleTime: Infinity,
+    retry: false,
   })
 
   useEffect(() => {
     if (data) loadFromServer(data)
   }, [data, loadFromServer])
+
+  // 서버에 대시보드 없음(404 등) → 빈 배열로 처리 → INITIAL 레이아웃 유지
+  useEffect(() => {
+    if (isError) loadFromServer([])
+  }, [isError, loadFromServer])
 }
 
 /**

--- a/src/hooks/useDashboardSync.js
+++ b/src/hooks/useDashboardSync.js
@@ -28,7 +28,8 @@ export function useDashboardLoad() {
     queryFn: dashboardApi.getMyDashboard,
     enabled: isAuthenticated && !isLoaded,
     staleTime: Infinity,
-    retry: false,
+    // 404(데이터 없음)는 즉시 폴백, 일시적 오류(네트워크·5xx)는 3회 재시도
+    retry: (failureCount, error) => error?.response?.status !== 404 && failureCount < 3,
   })
 
   useEffect(() => {

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -155,7 +155,7 @@ export default function HomePage() {
             </div>
             <button
               onClick={() => { snapshotWidgets(); enterEditMode() }}
-              className="flex items-center gap-1.5 px-4 py-2 rounded-xl bg-primary text-white text-[12px] font-semibold hover:bg-primary-hover transition-colors duration-[150ms] shadow-primary-btn"
+              className="flex items-center gap-1.5 px-4 py-2 rounded-xl bg-primary text-white text-xs font-semibold hover:bg-primary-hover transition-colors duration-150 shadow-primary-btn"
             >
               <Plus className="w-3.5 h-3.5" strokeWidth={2.5} />
               위젯 추가하기

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useCallback, useState } from 'react'
-import { Pencil } from 'lucide-react'
+import { Pencil, LayoutGrid, Plus } from 'lucide-react'
 import { useDroppable } from '@dnd-kit/core'
 import LiveDot from '@/components/ui/LiveDot'
 import useEditModeStore from '@/store/useEditModeStore'
@@ -28,9 +28,9 @@ function PhantomSlot({ colSpan, rowSpan, gridCol, gridRow }) {
 }
 
 export default function HomePage() {
-  const { isEditMode } = useEditModeStore()
+  const { isEditMode, enterEditMode } = useEditModeStore()
   const { setCellSize, setPreviewCellSize } = useGridStore()
-  const { widgets, isLoaded, removeWidget, phantomWidget, isDraggingNewWidget, pages, currentPageId, switchPage } = useWidgetStore()
+  const { widgets, isLoaded, removeWidget, phantomWidget, isDraggingNewWidget, pages, currentPageId, switchPage, snapshotWidgets } = useWidgetStore()
   const { isAuthenticated, isRestoring } = useAuthStore()
   const [isPageEditOpen, setIsPageEditOpen] = useState(false)
 
@@ -145,6 +145,23 @@ export default function HomePage() {
         'flex-1 min-h-0',
         isEditMode ? 'overflow-visible' : 'overflow-auto',
       )}>
+        {/* 로그인 상태이고 위젯이 없을 때 빈 상태 안내 */}
+        {isAuthenticated && isLoaded && safeWidgets.length === 0 && !isEditMode ? (
+          <div className="w-full h-full flex flex-col items-center justify-center gap-4">
+            <div className="flex flex-col items-center gap-2 text-center">
+              <LayoutGrid className="w-10 h-10 text-foreground-disabled" strokeWidth={1.5} />
+              <p className="text-sm font-semibold text-foreground">대시보드가 비어있어요</p>
+              <p className="text-xs text-foreground-disabled">원하는 위젯을 추가해 나만의 대시보드를 만들어보세요.</p>
+            </div>
+            <button
+              onClick={() => { snapshotWidgets(); enterEditMode() }}
+              className="flex items-center gap-1.5 px-4 py-2 rounded-xl bg-primary text-white text-[12px] font-semibold hover:bg-primary-hover transition-colors duration-[150ms] shadow-primary-btn"
+            >
+              <Plus className="w-3.5 h-3.5" strokeWidth={2.5} />
+              위젯 추가하기
+            </button>
+          </div>
+        ) : (
         <div
           ref={setGridRef}
           className={cn(
@@ -192,6 +209,7 @@ export default function HomePage() {
             )
           })}
         </div>
+        )}
       </div>
     </div>
 

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -207,11 +207,13 @@ const useWidgetStore = create((set) => ({
   isLoaded: false,
 
   // GET /api/dashboards/me 응답으로 store를 교체.
-  // 빈 배열이면 INITIAL 레이아웃 유지.
+  // 빈 배열이거나 모든 페이지에 위젯이 없으면 INITIAL 레이아웃 유지.
+  // (신규 가입 시 서버가 빈 페이지를 생성하는 경우 기본 레이아웃을 보여주기 위함)
   loadFromServer: (apiData) =>
     set(() => {
       const pages = fromApiResponse(Array.isArray(apiData) ? apiData : apiData.pages ?? [])
-      if (pages.length === 0) return { isLoaded: true }
+      const totalWidgets = pages.reduce((sum, p) => sum + p.widgets.length, 0)
+      if (pages.length === 0 || totalWidgets === 0) return { isLoaded: true }
       const currentPage = pages[0]
       return {
         pages,

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -207,13 +207,17 @@ const useWidgetStore = create((set) => ({
   isLoaded: false,
 
   // GET /api/dashboards/me 응답으로 store를 교체.
-  // 빈 배열이거나 모든 페이지에 위젯이 없으면 INITIAL 레이아웃 유지.
-  // (신규 가입 시 서버가 빈 페이지를 생성하는 경우 기본 레이아웃을 보여주기 위함)
+  // - 서버에 데이터 없음(빈 배열): 빈 위젯으로 로드 완료 → 로그인 유저는 빈 화면 표시
+  // - 서버에 데이터 있음: 서버 데이터로 교체
+  // 미로그인 프리셋(INITIAL_WIDGETS)은 resetLayout에서만 사용
   loadFromServer: (apiData) =>
     set(() => {
       const pages = fromApiResponse(Array.isArray(apiData) ? apiData : apiData.pages ?? [])
-      const totalWidgets = pages.reduce((sum, p) => sum + p.widgets.length, 0)
-      if (pages.length === 0 || totalWidgets === 0) return { isLoaded: true }
+      if (pages.length === 0) {
+        // 서버에 대시보드 없음 → 빈 상태로 로드 완료
+        const emptyPage = { id: 'page-1', name: '대시보드 1', widgets: [] }
+        return { pages: [emptyPage], currentPageId: 'page-1', widgets: [], isLoaded: true }
+      }
       const currentPage = pages[0]
       return {
         pages,


### PR DESCRIPTION
## 변경 사항

- `useWidgetStore.loadFromServer` — 서버 응답이 비어있을 때 `widgets: []`로 명시 설정 (기존: INITIAL_WIDGETS 유지)
- `useDashboardSync` — 쿼리 에러(404 등) 시 `loadFromServer([])` 폴백, `retry: false`
- `HomePage` — 로그인 + 위젯 없음 상태에서 빈 화면 안내 + **위젯 추가하기** 버튼 표시

## 동작 정의

| 상태 | 화면 |
|---|---|
| 미로그인 | `INITIAL_WIDGETS` 프리셋 |
| 로그인 + DB 없음 | 빈 화면 + 위젯 추가하기 버튼 |
| 로그인 + DB 있음 | 서버 저장 위젯 |

## 빈 화면 UX

**위젯 추가하기** 버튼 클릭 시 `snapshotWidgets() + enterEditMode()` 호출 → AppHeader 위젯 편집 버튼과 동일하게 편집 모드 진입.

closes #81