### PR TITLE
feat(widget): 위젯 상세 모달 및 프리셋 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-simple-keyboard": "^3.8.176",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.5.0",
+    "vaul": "^1.1.2",
     "zod": "^4.3.6",
     "zustand": "^5.0.12"
   },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lightweight-charts": "^5.1.0",
     "lucide-react": "^0.577.0",
     "react": "^19.2.4",
+    "react-day-picker": "^9.14.0",
     "react-dom": "^19.2.4",
     "react-hook-form": "^7.71.2",
     "react-markdown": "^10.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       react:
         specifier: ^19.2.4
         version: 19.2.4
+      react-day-picker:
+        specifier: ^9.14.0
+        version: 9.14.0(react@19.2.4)
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
@@ -186,6 +189,9 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@date-fns/tz@1.4.1':
+    resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -748,6 +754,10 @@ packages:
   '@stomp/stompjs@7.3.0':
     resolution: {integrity: sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ==}
 
+  '@tabby_ai/hijri-converter@1.0.5':
+    resolution: {integrity: sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==}
+    engines: {node: '>=16.0.0'}
+
   '@tailwindcss/node@4.2.2':
     resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
 
@@ -1003,6 +1013,12 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  date-fns-jalali@4.1.0-0:
+    resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1578,6 +1594,12 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  react-day-picker@9.14.0:
+    resolution: {integrity: sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=16.8.0'
+
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
@@ -1994,6 +2016,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@date-fns/tz@1.4.1': {}
 
   '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
     dependencies:
@@ -2509,6 +2533,8 @@ snapshots:
 
   '@stomp/stompjs@7.3.0': {}
 
+  '@tabby_ai/hijri-converter@1.0.5': {}
+
   '@tailwindcss/node@4.2.2':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -2714,6 +2740,10 @@ snapshots:
       which: 2.0.2
 
   csstype@3.2.3: {}
+
+  date-fns-jalali@4.1.0-0: {}
+
+  date-fns@4.1.0: {}
 
   debug@4.4.3:
     dependencies:
@@ -3466,6 +3496,14 @@ snapshots:
   property-information@7.1.0: {}
 
   punycode@2.3.1: {}
+
+  react-day-picker@9.14.0(react@19.2.4):
+    dependencies:
+      '@date-fns/tz': 1.4.1
+      '@tabby_ai/hijri-converter': 1.0.5
+      date-fns: 4.1.0
+      date-fns-jalali: 4.1.0-0
+      react: 19.2.4
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+      vaul:
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1816,6 +1819,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -3754,6 +3763,15 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
+
+  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   vfile-message@4.0.3:
     dependencies:

--- a/src/api/market.js
+++ b/src/api/market.js
@@ -45,6 +45,8 @@ async function get(path, params, options = {}) {
 
 export const marketApi = {
   getIndices: () => get('/indices'),
+  getIndexChart: (code, params) => get(`/indices/${encodeURIComponent(code)}/chart`, params),
+  getIndexMinuteChart: (code, params) => get(`/indices/${encodeURIComponent(code)}/minute-chart`, params),
   getRanking: (params) => get('/stocks/ranking', params),
   getCurrentPrice: (stockCode) => get(`/stocks/${stockCode}/price`),
   getDailyPrice: (stockCode, params) => get(`/stocks/${stockCode}/daily`, params),

--- a/src/api/market.js
+++ b/src/api/market.js
@@ -60,6 +60,7 @@ export const marketApi = {
   getFinance: (stockCode) => get(`/stocks/${stockCode}/finance`),
   getStockInfo: (stockCode) => get(`/stocks/${stockCode}/info`),
   searchStocks: (keyword) => get('/stocks/search', { keyword }),
+  getForexChart: (params) => get('/forex/chart', params),
 }
 
 export const foreignMarketApi = {

--- a/src/api/news.js
+++ b/src/api/news.js
@@ -1,0 +1,17 @@
+const BASE = '/api/news'
+const STOCK_BASE = '/api/stock-news'
+
+export const newsApi = {
+  getLatestNews: (params) => {
+    const query = params ? `?${new URLSearchParams(params).toString()}` : ''
+    return fetch(`${BASE}${query}`, { credentials: 'include' }).then((r) => r.json())
+  },
+  getStockNews: (stockCode, size = 5) => {
+    const query = new URLSearchParams({ stockCode, size }).toString()
+    return fetch(`${STOCK_BASE}?${query}`, { credentials: 'include' }).then((r) => r.json())
+  },
+  getNewsDetail: (newsId) =>
+    fetch(`${BASE}/${encodeURIComponent(newsId)}`, { credentials: 'include' }).then((r) => r.json()),
+  getStockNewsDetail: (newsId) =>
+    fetch(`${STOCK_BASE}/${encodeURIComponent(newsId)}`, { credentials: 'include' }).then((r) => r.json()),
+}

--- a/src/components/invest/InvestStockOverview.jsx
+++ b/src/components/invest/InvestStockOverview.jsx
@@ -40,6 +40,8 @@ export default function InvestStockOverview({
   displayCurrency,
   usdRate,
   onDisplayCurrencyChange,
+  hideSearch = false,
+  className = '',
 }) {
   const marketType = stockMeta.marketType ?? stockMeta.market
   const isForeignMarket = isForeignMarketType(marketType)
@@ -49,8 +51,8 @@ export default function InvestStockOverview({
   const changeTone = getDirectionClass(changeAmount)
 
   return (
-    <section className="flex min-w-0 basis-0 flex-1 flex-col overflow-hidden border-r border-stroke bg-surface">
-      <div className="border-b border-stroke px-[14px] py-2.5 shrink-0">
+    <section className={cn('flex min-w-0 basis-0 flex-1 flex-col overflow-hidden border-r border-stroke bg-surface', className)}>
+      {!hideSearch && <div className="border-b border-stroke px-[14px] py-2.5 shrink-0">
         <div className="flex items-center gap-2">
           <div className="min-w-0 flex-1">
             <InvestStockSearch stockMeta={stockMeta} />
@@ -82,7 +84,7 @@ export default function InvestStockOverview({
         {errorMessage && (
           <div className="mt-1.5 text-[10px] text-danger">{errorMessage}</div>
         )}
-      </div>
+      </div>}
 
       <div className="border-b border-stroke px-[14px] py-2.5 shrink-0">
         <div className="flex items-center gap-2">

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -11,6 +11,7 @@ import {
 import AppHeader from './AppHeader'
 import RightPanel from './RightPanel'
 import CurrencySync from './CurrencySync'
+import WidgetDetailModal from '@/components/widgets/WidgetDetailModal'
 import useWidgetStore, { canPlaceAt, findPushAsidePlanAt } from '@/store/useWidgetStore'
 import useEditModeStore from '@/store/useEditModeStore'
 import useGridStore from '@/store/useGridStore'
@@ -252,8 +253,9 @@ export default function AppShell() {
         <CurrencySync />
         <AppHeader />
         <div className="flex flex-1 overflow-hidden">
-          <main className="flex-1 overflow-hidden bg-background">
+          <main className="relative flex-1 overflow-hidden bg-background">
             <Outlet />
+            <WidgetDetailModal />
           </main>
           <RightPanel />
         </div>

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -253,7 +253,7 @@ export default function AppShell() {
         <CurrencySync />
         <AppHeader />
         <div className="flex flex-1 overflow-hidden">
-          <main className="relative flex-1 overflow-hidden bg-background">
+          <main className="relative flex-1 overflow-hidden bg-background isolate">
             <Outlet />
             <WidgetDetailModal />
           </main>

--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -28,7 +28,7 @@ function calcAspectRatio(colSpan, rowSpan, cw, ch) {
 }
 
 /* ── 위젯별 미리보기 콘텐츠 ─────────────────────────────── */
-function PreviewContent({ type }) {
+export function PreviewContent({ type }) {
   switch (type) {
 
     /* 계좌 잔고 — 소형 1×1 */

--- a/src/components/layout/PageEditModal.jsx
+++ b/src/components/layout/PageEditModal.jsx
@@ -33,7 +33,7 @@ function PageThumbnail({ widgets }) {
           className="bg-surface rounded-[3px] p-1 overflow-hidden min-w-0 min-h-0"
           style={{
             gridColumn: `${w.gridCol} / span ${w.colSpan}`,
-            gridRow: `${w.gridRow} / span ${w.rowSpan}`,
+            gridRow:    `${w.gridRow} / span ${w.rowSpan}`,
           }}
         >
           <span className="text-[5px] font-semibold text-foreground-disabled leading-none block truncate">
@@ -114,7 +114,6 @@ function AddPageSlot({ onClick }) {
 export default function PageEditModal({ onClose }) {
   const { pages, currentPageId, applyPageChanges } = useWidgetStore()
 
-  // 취소 지원을 위한 로컬 staged 상태
   const [stagedPages, setStagedPages] = useState(() => pages.map((p) => ({ ...p })))
   const [stagedCurrentId] = useState(currentPageId)
 
@@ -133,7 +132,6 @@ export default function PageEditModal({ onClose }) {
   }
 
   function handleSave() {
-    // 삭제된 페이지가 현재 페이지일 경우 첫 번째 페이지로 fallback
     const targetId = stagedPages.find((p) => p.id === stagedCurrentId)
       ? stagedCurrentId
       : stagedPages[0].id

--- a/src/components/ui/PriceChange.jsx
+++ b/src/components/ui/PriceChange.jsx
@@ -6,6 +6,10 @@
  * @param {string}  className
  */
 export default function PriceChange({ value, variant = 'text', paren = false, className = '' }) {
+  if (value == null) {
+    return <span className={`font-bold text-foreground-disabled ${className}`}>-</span>
+  }
+
   const isUp = value > 0
   const isZero = value === 0
   const sign = isUp ? '+' : isZero ? '' : '-'

--- a/src/components/ui/SparklineChart.jsx
+++ b/src/components/ui/SparklineChart.jsx
@@ -1,0 +1,46 @@
+/**
+ * 간단한 SVG 라인 스파크라인
+ * @param {{ close: number }[]} data
+ * @param {boolean} isUp  - true: 빨강(상승), false: 파랑(하락)
+ */
+export default function SparklineChart({ data = [], isUp = true, className = '' }) {
+  if (data.length < 2) return <div className={className} />
+
+  const prices = data.map((d) => d.close)
+  const min    = Math.min(...prices)
+  const max    = Math.max(...prices)
+  const range  = max - min || 1
+
+  const W = 80
+  const H = 32
+  const PAD = 2
+
+  const points = prices
+    .map((p, i) => {
+      const x = PAD + (i / (prices.length - 1)) * (W - PAD * 2)
+      const y = PAD + (1 - (p - min) / range) * (H - PAD * 2)
+      return `${x.toFixed(1)},${y.toFixed(1)}`
+    })
+    .join(' ')
+
+  const color = isUp ? 'var(--color-up)' : 'var(--color-down)'
+
+  return (
+    <svg
+      width={W}
+      height={H}
+      viewBox={`0 0 ${W} ${H}`}
+      preserveAspectRatio="none"
+      className={className}
+    >
+      <polyline
+        points={points}
+        fill="none"
+        stroke={color}
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}

--- a/src/components/widgets/BalanceWidget.jsx
+++ b/src/components/widgets/BalanceWidget.jsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import LockedOverlay from '@/components/ui/LockedOverlay'
 import useAuthStore from '@/store/useAuthStore'
+import useWidgetDetailStore from '@/store/useWidgetDetailStore'
 import WidgetCard from './WidgetCard'
 import { balanceApi, useDomesticHoldings } from '@/api/balance'
 
@@ -47,9 +48,10 @@ function useBalance(enabled) {
 export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, rowSpan = 1, onDelete }) {
   const { isAuthenticated, isRestoring } = useAuthStore()
   const BALANCE = useBalance(isAuthenticated && !isRestoring)
+  const open = useWidgetDetailStore((s) => s.open)
 
   return (
-    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={() => open({ widgetTypeId: 'balance', config: {} })}>
       <div className="mb-2 shrink-0">
         <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">계좌 잔고</span>
       </div>

--- a/src/components/widgets/BalanceWidget.jsx
+++ b/src/components/widgets/BalanceWidget.jsx
@@ -61,19 +61,19 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
   return (
     <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={() => open({ widgetTypeId: 'balance', config: {} })}>
       <div className="mb-2 shrink-0">
-        <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">계좌 잔고</span>
+        <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">계좌 잔고</span>
       </div>
 
       {variant === 'balance-lg' ? (
         <div className="flex flex-col flex-1 gap-1.5 min-h-0">
           <div className="shrink-0">
-            <div className="text-[8px] text-foreground-disabled">총 평가자산</div>
-            <div className="text-[18px] font-bold leading-tight tracking-tight text-foreground mt-0.5">
+            <div className="text-widget-8 text-foreground-disabled">총 평가자산</div>
+            <div className="text-widget-18 font-bold leading-tight tracking-tight text-foreground mt-0.5">
               {BALANCE.total}
             </div>
             {BALANCE.isLoading
-              ? <div className="text-[9px] text-foreground-disabled mt-0.5">-</div>
-              : <div className={`text-[9px] font-semibold mt-0.5 ${BALANCE.isProfit ? 'text-up' : 'text-down'}`}>{BALANCE.isProfit ? '▲' : '▼'} {BALANCE.profit} ({BALANCE.profitRate})</div>
+              ? <div className="text-widget-9 text-foreground-disabled mt-0.5">-</div>
+              : <div className={`text-widget-9 font-semibold mt-0.5 ${BALANCE.isProfit ? 'text-up' : 'text-down'}`}>{BALANCE.isProfit ? '▲' : '▼'} {BALANCE.profit} ({BALANCE.profitRate})</div>
             }
           </div>
           <div className="h-px bg-stroke-subtle shrink-0" />
@@ -84,8 +84,8 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
               { label: '주문가능', val: BALANCE.available, color: 'text-foreground' },
             ].map(({ label, val, color }) => (
               <div key={label} className="flex-1 min-w-0">
-                <div className="text-[10px] text-foreground-disabled">{label}</div>
-                <div className={`text-[13px] font-semibold truncate ${color}`}>{val}</div>
+                <div className="text-widget-10 text-foreground-disabled">{label}</div>
+                <div className={`text-widget-13 font-semibold truncate ${color}`}>{val}</div>
               </div>
             ))}
           </div>
@@ -94,28 +94,28 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
         <div className="flex flex-1 gap-4 min-h-0">
           <div className="flex flex-col flex-1 min-w-0">
             <div className="flex-1 flex flex-col justify-center">
-              <div className="text-[9px] text-foreground-disabled">총 평가자산</div>
-              <div className="text-[22px] font-bold leading-tight tracking-tight text-foreground mt-0.5">
+              <div className="text-widget-9 text-foreground-disabled">총 평가자산</div>
+              <div className="text-widget-22 font-bold leading-tight tracking-tight text-foreground mt-0.5">
                 {BALANCE.total}
               </div>
               {BALANCE.isLoading
-                ? <div className="text-[10px] text-foreground-disabled mt-0.5">-</div>
-                : <div className={`text-[10px] font-semibold mt-0.5 ${BALANCE.isProfit ? 'text-up' : 'text-down'}`}>{BALANCE.isProfit ? '▲' : '▼'} {BALANCE.profit} ({BALANCE.profitRate})</div>
+                ? <div className="text-widget-10 text-foreground-disabled mt-0.5">-</div>
+                : <div className={`text-widget-10 font-semibold mt-0.5 ${BALANCE.isProfit ? 'text-up' : 'text-down'}`}>{BALANCE.isProfit ? '▲' : '▼'} {BALANCE.profit} ({BALANCE.profitRate})</div>
               }
             </div>
             <div className="flex gap-6 shrink-0">
               <div>
-                <div className="text-[9px] text-foreground-disabled">투자원금</div>
-                <div className="text-[11px] font-semibold text-foreground">{BALANCE.invested}</div>
+                <div className="text-widget-9 text-foreground-disabled">투자원금</div>
+                <div className="text-widget-11 font-semibold text-foreground">{BALANCE.invested}</div>
               </div>
               <div>
-                <div className="text-[9px] text-foreground-disabled">주문가능</div>
-                <div className="text-[11px] font-semibold text-foreground">{BALANCE.available}</div>
+                <div className="text-widget-9 text-foreground-disabled">주문가능</div>
+                <div className="text-widget-11 font-semibold text-foreground">{BALANCE.available}</div>
               </div>
             </div>
           </div>
           <div className="flex flex-col flex-1 min-w-0 pl-4 border-l border-stroke">
-            <div className="text-[9px] text-foreground-disabled shrink-0">수익 추이 (7일)</div>
+            <div className="text-widget-9 text-foreground-disabled shrink-0">수익 추이 (7일)</div>
             <div className="flex-1 min-h-0 relative my-2">
               {BALANCE.flowPoints.length > 1 ? (() => {
                 const pts = BALANCE.flowPoints
@@ -154,11 +154,11 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
                   </svg>
                 )
               })() : (
-                <div className="absolute inset-0 flex items-center justify-center text-[8px] text-foreground-disabled">데이터 없음</div>
+                <div className="absolute inset-0 flex items-center justify-center text-widget-8 text-foreground-disabled">데이터 없음</div>
               )}
             </div>
             {BALANCE.flowPoints.length > 0 && (
-              <div className={cn('text-[9px] text-right shrink-0', BALANCE.flowPoints[BALANCE.flowPoints.length - 1] >= 0 ? 'text-up' : 'text-down')}>
+              <div className={cn('text-widget-9 text-right shrink-0', BALANCE.flowPoints[BALANCE.flowPoints.length - 1] >= 0 ? 'text-up' : 'text-down')}>
                 {`${BALANCE.flowPoints[BALANCE.flowPoints.length - 1] >= 0 ? '+' : ''}${BALANCE.flowPoints[BALANCE.flowPoints.length - 1].toFixed(2)}%`}
               </div>
             )}
@@ -167,13 +167,13 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
       ) : variant === 'balance-2x2' ? (
         <div className="flex flex-col flex-1 gap-2.5">
           <div>
-            <div className="text-[10px] text-foreground-disabled">총 평가자산</div>
-            <div className="text-[22px] font-bold leading-tight tracking-tight text-foreground mt-0.5">
-              {BALANCE.total}<span className="text-[12px] font-medium text-foreground-tertiary ml-0.5">원</span>
+            <div className="text-widget-10 text-foreground-disabled">총 평가자산</div>
+            <div className="text-widget-22 font-bold leading-tight tracking-tight text-foreground mt-0.5">
+              {BALANCE.total}<span className="text-widget-12 font-medium text-foreground-tertiary ml-0.5">원</span>
             </div>
             {BALANCE.isLoading
-              ? <div className="text-[12px] text-foreground-disabled mt-0.5">-</div>
-              : <div className={`text-[12px] font-semibold mt-0.5 ${BALANCE.isProfit ? 'text-up' : 'text-down'}`}>{BALANCE.isProfit ? '▲' : '▼'} {BALANCE.profit} ({BALANCE.profitRate})</div>
+              ? <div className="text-widget-12 text-foreground-disabled mt-0.5">-</div>
+              : <div className={`text-widget-12 font-semibold mt-0.5 ${BALANCE.isProfit ? 'text-up' : 'text-down'}`}>{BALANCE.isProfit ? '▲' : '▼'} {BALANCE.profit} ({BALANCE.profitRate})</div>
             }
           </div>
           <div className="grid grid-cols-2 gap-2 shrink-0">
@@ -184,8 +184,8 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
               { label: '수익률',   val: BALANCE.profitRate,  color: BALANCE.isProfit ? 'text-up' : 'text-down' },
             ].map(({ label, val, color }) => (
               <div key={label} className="bg-background rounded-xl px-3 py-2">
-                <div className="text-[9px] text-foreground-disabled">{label}</div>
-                <div className={`text-[12px] font-bold ${color} mt-0.5`}>{val}</div>
+                <div className="text-widget-9 text-foreground-disabled">{label}</div>
+                <div className={`text-widget-12 font-bold ${color} mt-0.5`}>{val}</div>
               </div>
             ))}
           </div>
@@ -198,13 +198,13 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
       ) : (
         /* balance-sm (default) */
         <div className="flex-1 flex flex-col justify-end min-h-0">
-          <div className="text-[10px] text-foreground-disabled mb-0.5">총 평가자산</div>
-          <div className="text-[18px] font-bold leading-tight tracking-tight text-foreground">
+          <div className="text-widget-10 text-foreground-disabled mb-0.5">총 평가자산</div>
+          <div className="text-widget-18 font-bold leading-tight tracking-tight text-foreground">
             {BALANCE.total}
           </div>
           {BALANCE.isLoading
-            ? <div className="text-[11px] text-foreground-disabled mt-1">-</div>
-            : <div className={`text-[11px] font-semibold mt-1 ${BALANCE.isProfit ? 'text-up' : 'text-down'}`}>{BALANCE.isProfit ? '▲' : '▼'} {BALANCE.profit} ({BALANCE.profitRate})</div>
+            ? <div className="text-widget-11 text-foreground-disabled mt-1">-</div>
+            : <div className={`text-widget-11 font-semibold mt-1 ${BALANCE.isProfit ? 'text-up' : 'text-down'}`}>{BALANCE.isProfit ? '▲' : '▼'} {BALANCE.profit} ({BALANCE.profitRate})</div>
           }
         </div>
       )}

--- a/src/components/widgets/BalanceWidget.jsx
+++ b/src/components/widgets/BalanceWidget.jsx
@@ -4,44 +4,52 @@ import useAuthStore from '@/store/useAuthStore'
 import useWidgetDetailStore from '@/store/useWidgetDetailStore'
 import WidgetCard from './WidgetCard'
 import { balanceApi, useDomesticHoldings } from '@/api/balance'
+import { cn } from '@/lib/cn'
 
 function fmt(n) {
-  return Number(n ?? 0).toLocaleString('ko-KR')
+  return Math.floor(Number(n ?? 0)).toLocaleString('ko-KR')
 }
 
 function useBalance(enabled) {
-  const { data: holdings = [], isLoading: holdingsLoading } = useDomesticHoldings({ enabled })
-  const { data: cashData, isLoading: cashLoading } = useQuery({
-    queryKey: ['balance', 'cash'],
-    queryFn:  balanceApi.getCashBalances,
+  const { data: summary, isLoading: summaryLoading } = useQuery({
+    queryKey: ['balance', 'summary'],
+    queryFn:  balanceApi.getBalanceSummary,
+    enabled,
+    staleTime: 30_000,
+  })
+  const { data: assetFlow } = useQuery({
+    queryKey: ['balance', 'flow', '1W'],
+    queryFn:  () => balanceApi.getAssetFlow('1W'),
     enabled,
     staleTime: 30_000,
   })
 
-  const isLoading = enabled && (holdingsLoading || cashLoading)
+  const isLoading = enabled && summaryLoading
 
   if (isLoading) {
-    return { total: '-', profit: '-', profitRate: '-', invested: '-', available: '-', isProfit: true, isLoading: true }
+    return { total: '-', profit: '-', profitRate: '-', invested: '-', available: '-', isProfit: true, isLoading: true, flowPoints: [] }
   }
 
-  const krwEntry  = Array.isArray(cashData)
-    ? (cashData.find((c) => c.currencyCode === 'KRW') ?? cashData[0])
-    : cashData
-  const cash      = krwEntry?.totalAmount ?? krwEntry?.availableAmount ?? 0
-  const invested  = holdings.reduce((s, h) => s + (h.avgPrice ?? h.avgBuyPrice ?? 0) * (h.holdingQuantity ?? h.availableQuantity ?? 0), 0)
-  const stockVal  = holdings.reduce((s, h) => s + (h.currentPrice ?? h.avgPrice ?? h.avgBuyPrice ?? 0) * (h.holdingQuantity ?? h.availableQuantity ?? 0), 0)
-  const total     = stockVal + cash
-  const profit    = stockVal - invested
-  const profitRate = invested > 0 ? (profit / invested) * 100 : 0
+  const cashList  = summary?.cashBalances ?? []
+  const krwEntry  = cashList.find((c) => c.currencyCode === 'KRW') ?? {}
+  const total     = Number(summary?.totalAssets ?? 0)
+  const profit    = Number(summary?.accountProfitLoss ?? 0)
+  const profitRate = Number(summary?.accountProfitLossRate ?? 0)
+  const invested  = total - profit - Number(krwEntry.totalAmount ?? 0)
+
+  const flowPoints = (assetFlow?.points ?? []).map((p) => Number(p.cumulativeReturnRate ?? 0))
+  const maxRate    = flowPoints.reduce((m, r) => Math.max(m, Math.abs(r)), 0)
 
   return {
     total:      fmt(total),
     profit:     (profit >= 0 ? '+' : '-') + fmt(Math.abs(profit)),
     profitRate: (profitRate >= 0 ? '+' : '') + profitRate.toFixed(2) + '%',
-    invested:   fmt(invested),
-    available:  fmt(krwEntry?.availableAmount ?? cash),
+    invested:   fmt(Math.max(0, invested)),
+    available:  fmt(Number(krwEntry.availableAmount ?? krwEntry.totalAmount ?? 0)),
     isProfit:   profit >= 0,
     isLoading:  false,
+    flowPoints,
+    maxRate,
   }
 }
 
@@ -107,13 +115,53 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
             </div>
           </div>
           <div className="flex flex-col flex-1 min-w-0 pl-4 border-l border-stroke">
-            <div className="text-[9px] text-foreground-disabled shrink-0">수익 추이 (30일)</div>
-            <div className="flex-1 min-h-0 flex items-end gap-px my-2">
-              {[30,38,35,50,55,65,70,80,85,92].map((h, i) => (
-                <div key={i} className="flex-1 bg-up/50 rounded-sm" style={{ height: `${h}%` }} />
-              ))}
+            <div className="text-[9px] text-foreground-disabled shrink-0">수익 추이 (7일)</div>
+            <div className="flex-1 min-h-0 relative my-2">
+              {BALANCE.flowPoints.length > 1 ? (() => {
+                const pts = BALANCE.flowPoints
+                const min = Math.min(...pts)
+                const max = Math.max(...pts)
+                const range = max - min || 1
+                const W = 100 / (pts.length - 1)
+                const isUp = pts[pts.length - 1] >= pts[0]
+                return (
+                  <svg className="absolute inset-0 w-full h-full" viewBox="0 0 100 100" preserveAspectRatio="none">
+                    <polyline
+                      points={pts.map((r, i) => {
+                        const x = i * W
+                        const y = 10 + (1 - (r - min) / range) * 80
+                        return `${x},${y}`
+                      }).join(' ')}
+                      fill="none"
+                      stroke={isUp ? 'var(--color-up)' : 'var(--color-down)'}
+                      strokeWidth="2"
+                      vectorEffect="non-scaling-stroke"
+                    />
+                    {pts.map((r, i) => {
+                      const x = i * W
+                      const y = 10 + (1 - (r - min) / range) * 80
+                      return (
+                        <circle
+                          key={i}
+                          cx={x}
+                          cy={y}
+                          r="3"
+                          fill={r >= 0 ? 'var(--color-up)' : 'var(--color-down)'}
+                          vectorEffect="non-scaling-stroke"
+                        />
+                      )
+                    })}
+                  </svg>
+                )
+              })() : (
+                <div className="absolute inset-0 flex items-center justify-center text-[8px] text-foreground-disabled">데이터 없음</div>
+              )}
             </div>
-            <div className="text-[9px] text-foreground-disabled text-right shrink-0">최고 +5.2%</div>
+            {BALANCE.flowPoints.length > 0 && (
+              <div className={cn('text-[9px] text-right shrink-0', BALANCE.flowPoints[BALANCE.flowPoints.length - 1] >= 0 ? 'text-up' : 'text-down')}>
+                {`${BALANCE.flowPoints[BALANCE.flowPoints.length - 1] >= 0 ? '+' : ''}${BALANCE.flowPoints[BALANCE.flowPoints.length - 1].toFixed(2)}%`}
+              </div>
+            )}
           </div>
         </div>
       ) : variant === 'balance-2x2' ? (

--- a/src/components/widgets/ExchangeWidget.jsx
+++ b/src/components/widgets/ExchangeWidget.jsx
@@ -8,6 +8,7 @@ import WidgetCard from './WidgetCard'
 import ExchangeConfigModal from './ExchangeConfigModal'
 import useWidgetStore from '@/store/useWidgetStore'
 import { useDashboardSave } from '@/hooks/useDashboardSync'
+import useWidgetDetailStore from '@/store/useWidgetDetailStore'
 
 
 const ALL_CURRENCIES = [
@@ -57,6 +58,12 @@ export default function ExchangeWidget({ instanceId, variant = 'exchange-sm', co
   const { mutate: saveDashboard } = useDashboardSave()
   const [isConfigOpen, setIsConfigOpen] = useState(false)
 
+  const open = useWidgetDetailStore((s) => s.open)
+  const handleCurrencyClick = (e, code) => {
+    e.stopPropagation()
+    open({ widgetTypeId: 'exchange', config: { currency: code } })
+  }
+
   const liveUsd = useCurrencyRate('USD')
   const liveJpy = useCurrencyRate('JPY')
   const liveEur = useCurrencyRate('EUR')
@@ -104,11 +111,16 @@ export default function ExchangeWidget({ instanceId, variant = 'exchange-sm', co
             {settingsBtn}
           </div>
           <div className="flex flex-1 min-h-0 divide-x divide-stroke">
-            {currencies.map(({ pair, live }, i) => {
+            {currencies.map(({ code, pair, live }, i) => {
               const isUp = (live?.change ?? 0) > 0
               const { pr, pl } = paddings[i] ?? { pr: '', pl: 'pl-2.5' }
               return (
-                <div key={pair} className={`flex flex-col justify-center ${pr} ${pl}`} style={{ flex: flexValues[i] ?? '1' }}>
+                <div
+                  key={pair}
+                  className={`relative flex flex-col justify-center ${pr} ${pl} cursor-pointer group`}
+                  style={{ flex: flexValues[i] ?? '1' }}
+                  onClick={(e) => handleCurrencyClick(e, code)}
+                >
                   <div className="text-center">
                     <div className="text-[9px] text-foreground-disabled">{pair}</div>
                     <div className={`${rateSize[i] ?? 'text-[16px]'} font-bold text-foreground leading-tight`}>{formatRate(live?.rate)}</div>
@@ -118,6 +130,7 @@ export default function ExchangeWidget({ instanceId, variant = 'exchange-sm', co
                       </div>
                     )}
                   </div>
+                  <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary opacity-0 group-hover:opacity-100 transition-opacity" />
                 </div>
               )
             })}
@@ -138,14 +151,19 @@ export default function ExchangeWidget({ instanceId, variant = 'exchange-sm', co
             {settingsBtn}
           </div>
           <div className="flex flex-1 min-h-0 divide-x divide-stroke">
-            {currencies.map(({ pair, live }, i) => {
+            {currencies.map(({ code, pair, live }, i) => {
               const isUp = (live?.change ?? 0) > 0
               const rateSize = i === 0 ? 'text-[20px]' : 'text-[16px]'
               const pr = i === 0 ? 'pr-3' : ''
               const pl = i > 0 ? 'pl-3' : ''
               const flex = i === 0 ? '1.2' : '1'
               return (
-                <div key={pair} className={`flex flex-col justify-center ${pr} ${pl}`} style={{ flex }}>
+                <div
+                  key={pair}
+                  className={`relative flex flex-col justify-center ${pr} ${pl} cursor-pointer group`}
+                  style={{ flex }}
+                  onClick={(e) => handleCurrencyClick(e, code)}
+                >
                   <div className="text-center">
                     <div className="text-[9px] text-foreground-disabled">{pair}</div>
                     <div className={`${rateSize} font-bold text-foreground leading-tight`}>{formatRate(live?.rate)}</div>
@@ -155,6 +173,7 @@ export default function ExchangeWidget({ instanceId, variant = 'exchange-sm', co
                       </div>
                     )}
                   </div>
+                  <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary opacity-0 group-hover:opacity-100 transition-opacity" />
                 </div>
               )
             })}
@@ -176,16 +195,23 @@ export default function ExchangeWidget({ instanceId, variant = 'exchange-sm', co
             <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
             {settingsBtn}
           </div>
-          <div className="shrink-0">
+          <div
+            className="shrink-0 cursor-pointer"
+            onClick={(e) => handleCurrencyClick(e, primary?.code ?? 'USD')}
+          >
             <div className="text-[9px] text-foreground-disabled">{primary?.pair ?? 'USD / KRW'}</div>
             <RateDisplay live={primary?.live} rateClassName="text-[22px]" />
           </div>
 
           <div className="flex-1 flex flex-col gap-2 min-h-0 overflow-y-auto">
-            {rest.map(({ flag, pair, live }) => {
+            {rest.map(({ code, flag, pair, live }) => {
               const isUp = (live?.change ?? 0) > 0
               return (
-                <div key={pair} className="flex items-center justify-between px-1">
+                <div
+                  key={pair}
+                  className="flex items-center justify-between px-1 cursor-pointer rounded-lg hover:bg-surface-muted transition-colors"
+                  onClick={(e) => handleCurrencyClick(e, code)}
+                >
                   <div className="flex items-center gap-2">
                     <span className="text-[14px]">{flag}</span>
                     <span className="text-[10px] text-foreground-secondary">{pair}</span>
@@ -224,7 +250,12 @@ export default function ExchangeWidget({ instanceId, variant = 'exchange-sm', co
 
   return (
     <>
-      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+      <WidgetCard
+        colSpan={colSpan}
+        rowSpan={rowSpan}
+        onDelete={onDelete}
+        onClick={(e) => handleCurrencyClick(e, 'USD')}
+      >
         <div className="flex items-center justify-between shrink-0">
           <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
         </div>

--- a/src/components/widgets/ExchangeWidget.jsx
+++ b/src/components/widgets/ExchangeWidget.jsx
@@ -3,6 +3,7 @@ import { Settings2 } from 'lucide-react'
 import LockedOverlay from '@/components/ui/LockedOverlay'
 import useAuthStore from '@/store/useAuthStore'
 import useCurrencyRate from '@/hooks/useCurrencyRate'
+import useMarketIndices from '@/features/market/useMarketIndices'
 import WidgetCard from './WidgetCard'
 import ExchangeConfigModal from './ExchangeConfigModal'
 import useWidgetStore from '@/store/useWidgetStore'
@@ -214,18 +215,22 @@ export default function ExchangeWidget({ instanceId, variant = 'exchange-sm', co
     )
   }
 
-  /* exchange-sm (default) */
-  const primary = currencies[0]
+  /* exchange-sm (default, 1x1) */
+  const { indices } = useMarketIndices()
+  const usdIdx = indices.find((i) => i.code === 'USD')
+  const smLive = usdIdx
+    ? { rate: usdIdx.price, change: usdIdx.change, drate: usdIdx.changeRate }
+    : currencies[0]?.live ?? null
+
   return (
     <>
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
         <div className="flex items-center justify-between shrink-0">
           <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
-          {settingsBtn}
         </div>
         <div className="flex-1 flex flex-col justify-center min-h-0">
-          <div className="text-[9px] text-foreground-disabled">{primary?.pair ?? 'USD / KRW'}</div>
-          <RateDisplay live={primary?.live} rateClassName="text-[18px]" />
+          <div className="text-[9px] text-foreground-disabled">USD / KRW</div>
+          <RateDisplay live={smLive} rateClassName="text-[18px]" />
         </div>
         {!isRestoring && !isAuthenticated && <LockedOverlay message="환율 정보를 보려면" />}
       </WidgetCard>

--- a/src/components/widgets/ExchangeWidget.jsx
+++ b/src/components/widgets/ExchangeWidget.jsx
@@ -36,7 +36,7 @@ function formatPct(drate) {
   return `${drate > 0 ? '+' : ''}${drate.toFixed(2)}%`
 }
 
-function RateDisplay({ live, rateClassName = 'text-[15px]' }) {
+function RateDisplay({ live, rateClassName = 'text-widget-15' }) {
   const isUp = (live?.change ?? 0) > 0
   return (
     <>
@@ -44,7 +44,7 @@ function RateDisplay({ live, rateClassName = 'text-[15px]' }) {
         {formatRate(live?.rate)}
       </div>
       {live && (
-        <div className={`text-[9px] ${isUp ? 'text-up' : 'text-down'}`}>
+        <div className={`text-widget-9 ${isUp ? 'text-up' : 'text-down'}`}>
           {isUp ? '▲' : '▼'} {Math.abs(live.change)} ({formatPct(live.drate)})
         </div>
       )}
@@ -102,12 +102,12 @@ export default function ExchangeWidget({ instanceId, variant = 'exchange-sm', co
   if (variant === 'exchange-3x1') {
     const flexValues = ['1.2', '1', '1']
     const paddings   = [{ pr: 'pr-3', pl: '' }, { pr: 'pr-2.5', pl: 'pl-2.5' }, { pr: '', pl: 'pl-2.5' }]
-    const rateSize   = ['text-[20px]', 'text-[16px]', 'text-[16px]']
+    const rateSize   = ['text-widget-20', 'text-widget-16', 'text-widget-16']
     return (
       <>
         <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
           <div className="flex items-center justify-between mb-1 shrink-0">
-            <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
+            <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
             {settingsBtn}
           </div>
           <div className="flex flex-1 min-h-0 divide-x divide-stroke">
@@ -122,10 +122,10 @@ export default function ExchangeWidget({ instanceId, variant = 'exchange-sm', co
                   onClick={(e) => handleCurrencyClick(e, code)}
                 >
                   <div className="text-center">
-                    <div className="text-[9px] text-foreground-disabled">{pair}</div>
-                    <div className={`${rateSize[i] ?? 'text-[16px]'} font-bold text-foreground leading-tight`}>{formatRate(live?.rate)}</div>
+                    <div className="text-widget-9 text-foreground-disabled">{pair}</div>
+                    <div className={`${rateSize[i] ?? 'text-widget-16'} font-bold text-foreground leading-tight`}>{formatRate(live?.rate)}</div>
                     {live && (
-                      <div className={`text-[9px] ${isUp ? 'text-up' : 'text-down'}`}>
+                      <div className={`text-widget-9 ${isUp ? 'text-up' : 'text-down'}`}>
                         {isUp ? '▲' : '▼'} {Math.abs(live.change)}
                       </div>
                     )}
@@ -147,13 +147,13 @@ export default function ExchangeWidget({ instanceId, variant = 'exchange-sm', co
       <>
         <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
           <div className="flex items-center justify-between mb-1 shrink-0">
-            <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
+            <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
             {settingsBtn}
           </div>
           <div className="flex flex-1 min-h-0 divide-x divide-stroke">
             {currencies.map(({ code, pair, live }, i) => {
               const isUp = (live?.change ?? 0) > 0
-              const rateSize = i === 0 ? 'text-[20px]' : 'text-[16px]'
+              const rateSize = i === 0 ? 'text-widget-20' : 'text-widget-16'
               const pr = i === 0 ? 'pr-3' : ''
               const pl = i > 0 ? 'pl-3' : ''
               const flex = i === 0 ? '1.2' : '1'
@@ -165,10 +165,10 @@ export default function ExchangeWidget({ instanceId, variant = 'exchange-sm', co
                   onClick={(e) => handleCurrencyClick(e, code)}
                 >
                   <div className="text-center">
-                    <div className="text-[9px] text-foreground-disabled">{pair}</div>
+                    <div className="text-widget-9 text-foreground-disabled">{pair}</div>
                     <div className={`${rateSize} font-bold text-foreground leading-tight`}>{formatRate(live?.rate)}</div>
                     {live && (
-                      <div className={`text-[9px] ${isUp ? 'text-up' : 'text-down'}`}>
+                      <div className={`text-widget-9 ${isUp ? 'text-up' : 'text-down'}`}>
                         {isUp ? '▲' : '▼'} {Math.abs(live.change)}
                       </div>
                     )}
@@ -192,15 +192,15 @@ export default function ExchangeWidget({ instanceId, variant = 'exchange-sm', co
       <>
         <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
           <div className="flex items-center justify-between mb-1 shrink-0">
-            <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
+            <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
             {settingsBtn}
           </div>
           <div
             className="shrink-0 cursor-pointer"
             onClick={(e) => handleCurrencyClick(e, primary?.code ?? 'USD')}
           >
-            <div className="text-[9px] text-foreground-disabled">{primary?.pair ?? 'USD / KRW'}</div>
-            <RateDisplay live={primary?.live} rateClassName="text-[22px]" />
+            <div className="text-widget-9 text-foreground-disabled">{primary?.pair ?? 'USD / KRW'}</div>
+            <RateDisplay live={primary?.live} rateClassName="text-widget-22" />
           </div>
 
           <div className="flex-1 flex flex-col gap-2 min-h-0 overflow-y-auto">
@@ -213,13 +213,13 @@ export default function ExchangeWidget({ instanceId, variant = 'exchange-sm', co
                   onClick={(e) => handleCurrencyClick(e, code)}
                 >
                   <div className="flex items-center gap-2">
-                    <span className="text-[14px]">{flag}</span>
-                    <span className="text-[10px] text-foreground-secondary">{pair}</span>
+                    <span className="text-widget-14">{flag}</span>
+                    <span className="text-widget-10 text-foreground-secondary">{pair}</span>
                   </div>
                   <div className="text-right">
-                    <span className="text-[12px] font-semibold text-foreground">{formatRate(live?.rate)}</span>
+                    <span className="text-widget-12 font-semibold text-foreground">{formatRate(live?.rate)}</span>
                     {live && (
-                      <span className={`text-[9px] ml-1.5 ${isUp ? 'text-up' : 'text-down'}`}>
+                      <span className={`text-widget-9 ml-1.5 ${isUp ? 'text-up' : 'text-down'}`}>
                         {isUp ? '▲' : '▼'} {Math.abs(live.change)}
                       </span>
                     )}
@@ -230,7 +230,7 @@ export default function ExchangeWidget({ instanceId, variant = 'exchange-sm', co
           </div>
           <button
             onClick={(e) => e.stopPropagation()}
-            className="w-full py-1.5 rounded-xl bg-primary-light text-primary text-[10px] font-bold hover:bg-primary-dim transition-colors duration-[150ms] mt-2 shrink-0"
+            className="w-full py-1.5 rounded-xl bg-primary-light text-primary text-widget-10 font-bold hover:bg-primary-dim transition-colors duration-[150ms] mt-2 shrink-0"
           >
             환전하기 →
           </button>
@@ -257,11 +257,11 @@ export default function ExchangeWidget({ instanceId, variant = 'exchange-sm', co
         onClick={(e) => handleCurrencyClick(e, 'USD')}
       >
         <div className="flex items-center justify-between shrink-0">
-          <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
+          <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
         </div>
         <div className="flex-1 flex flex-col justify-center min-h-0">
-          <div className="text-[9px] text-foreground-disabled">USD / KRW</div>
-          <RateDisplay live={smLive} rateClassName="text-[18px]" />
+          <div className="text-widget-9 text-foreground-disabled">USD / KRW</div>
+          <RateDisplay live={smLive} rateClassName="text-widget-18" />
         </div>
         {!isRestoring && !isAuthenticated && <LockedOverlay message="환율 정보를 보려면" />}
       </WidgetCard>

--- a/src/components/widgets/ExchangeWidget.jsx
+++ b/src/components/widgets/ExchangeWidget.jsx
@@ -117,8 +117,8 @@ export default function ExchangeWidget({ instanceId, variant = 'exchange-sm', co
               return (
                 <div
                   key={pair}
-                  className={`relative flex flex-col justify-center ${pr} ${pl} cursor-pointer group`}
-                  style={{ flex: flexValues[i] ?? '1' }}
+                  className={`relative flex flex-col justify-center ${pr} ${pl} cursor-pointer group [flex:var(--flex-val)]`}
+                  style={{ '--flex-val': flexValues[i] ?? '1' }}
                   onClick={(e) => handleCurrencyClick(e, code)}
                 >
                   <div className="text-center">
@@ -160,8 +160,8 @@ export default function ExchangeWidget({ instanceId, variant = 'exchange-sm', co
               return (
                 <div
                   key={pair}
-                  className={`relative flex flex-col justify-center ${pr} ${pl} cursor-pointer group`}
-                  style={{ flex }}
+                  className={`relative flex flex-col justify-center ${pr} ${pl} cursor-pointer group [flex:var(--flex-val)]`}
+                  style={{ '--flex-val': flex }}
                   onClick={(e) => handleCurrencyClick(e, code)}
                 >
                   <div className="text-center">

--- a/src/components/widgets/IndexConfigModal.jsx
+++ b/src/components/widgets/IndexConfigModal.jsx
@@ -3,7 +3,7 @@ import { X } from 'lucide-react'
 
 const ALL_INDICES = [
   { code: '001',      label: 'KOSPI' },
-  { code: '101',      label: 'KOSDAQ' },
+  { code: '301',      label: 'KOSDAQ' },
   { code: 'NAS@IXIC', label: 'NASDAQ' },
   { code: 'SPI@SPX',  label: 'S&P 500' },
 ]

--- a/src/components/widgets/IndexWidget.jsx
+++ b/src/components/widgets/IndexWidget.jsx
@@ -89,13 +89,13 @@ export default function IndexWidget({ instanceId, variant = 'index-wide', colSpa
       <>
         <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={(e) => handleIndexClick(e, shown.code)}>
           <div className="flex items-center justify-between shrink-0">
-            <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">주요 지수</span>
+            <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">주요 지수</span>
             <SettingsButton onClick={() => setIsConfigOpen(true)} />
           </div>
           <div className="relative flex-1 flex flex-col justify-center items-center text-center min-h-0 group">
-            <div className="text-[9px] text-foreground-disabled">{shown.label}</div>
-            <div className="text-[18px] font-bold text-foreground leading-tight">{shown.value}</div>
-            <ChangeLabel changeAmt={shown.changeAmt} changeRate={shown.changeRate} className="text-[9px]" />
+            <div className="text-widget-9 text-foreground-disabled">{shown.label}</div>
+            <div className="text-widget-18 font-bold text-foreground leading-tight">{shown.value}</div>
+            <ChangeLabel changeAmt={shown.changeAmt} changeRate={shown.changeRate} className="text-widget-9" />
             <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary opacity-0 group-hover:opacity-100 transition-opacity" />
           </div>
         </WidgetCard>
@@ -116,7 +116,7 @@ export default function IndexWidget({ instanceId, variant = 'index-wide', colSpa
       <>
         <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
           <div className="flex items-center justify-between shrink-0">
-            <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">주요 지수</span>
+            <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">주요 지수</span>
             <SettingsButton onClick={() => setIsConfigOpen(true)} />
           </div>
           <div className="flex flex-1 min-h-0 divide-x divide-stroke mt-1">
@@ -126,9 +126,9 @@ export default function IndexWidget({ instanceId, variant = 'index-wide', colSpa
                 className="relative flex-1 flex flex-col justify-center items-center text-center px-2 cursor-pointer group"
                 onClick={(e) => handleIndexClick(e, idx.code)}
               >
-                <div className="text-[9px] text-foreground-disabled">{idx.label}</div>
-                <div className="text-[17px] font-bold text-foreground leading-tight">{idx.value}</div>
-                <ChangeLabel changeAmt={idx.changeAmt} changeRate={idx.changeRate} className="text-[10px]" />
+                <div className="text-widget-9 text-foreground-disabled">{idx.label}</div>
+                <div className="text-widget-17 font-bold text-foreground leading-tight">{idx.value}</div>
+                <ChangeLabel changeAmt={idx.changeAmt} changeRate={idx.changeRate} className="text-widget-10" />
                 <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary opacity-0 group-hover:opacity-100 transition-opacity" />
               </div>
             ))}
@@ -151,7 +151,7 @@ export default function IndexWidget({ instanceId, variant = 'index-wide', colSpa
       <>
         <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
           <div className="flex items-center justify-between mb-2 shrink-0">
-            <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">주요 지수</span>
+            <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">주요 지수</span>
             <SettingsButton onClick={() => setIsConfigOpen(true)} />
           </div>
           <div className="flex flex-col flex-1 justify-center gap-3">
@@ -161,9 +161,9 @@ export default function IndexWidget({ instanceId, variant = 'index-wide', colSpa
                 className="relative flex-1 min-w-0 cursor-pointer px-1 group"
                 onClick={(e) => handleIndexClick(e, idx.code)}
               >
-                <div className="text-[9px] text-foreground-disabled">{idx.label}</div>
-                <div className="text-[15px] font-bold text-foreground leading-tight">{idx.value}</div>
-                <ChangeLabel changeAmt={idx.changeAmt} changeRate={idx.changeRate} className="text-[10px]" />
+                <div className="text-widget-9 text-foreground-disabled">{idx.label}</div>
+                <div className="text-widget-15 font-bold text-foreground leading-tight">{idx.value}</div>
+                <ChangeLabel changeAmt={idx.changeAmt} changeRate={idx.changeRate} className="text-widget-10" />
                 <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary opacity-0 group-hover:opacity-100 transition-opacity" />
               </div>
             ))}
@@ -186,7 +186,7 @@ export default function IndexWidget({ instanceId, variant = 'index-wide', colSpa
     <>
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
         <div className="flex items-center justify-between shrink-0">
-          <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">주요 지수</span>
+          <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">주요 지수</span>
           <SettingsButton onClick={() => setIsConfigOpen(true)} />
         </div>
         <div className="flex flex-1 min-h-0 divide-x divide-stroke mt-1">
@@ -196,9 +196,9 @@ export default function IndexWidget({ instanceId, variant = 'index-wide', colSpa
               className="relative flex-1 flex flex-col justify-center items-center text-center px-3 py-1 cursor-pointer group"
               onClick={(e) => handleIndexClick(e, idx.code)}
             >
-              <div className="text-[9px] text-foreground-disabled">{idx.label}</div>
-              <div className="text-[16px] font-bold text-foreground leading-tight">{idx.value}</div>
-              <ChangeLabel changeAmt={idx.changeAmt} changeRate={idx.changeRate} className="text-[9px]" />
+              <div className="text-widget-9 text-foreground-disabled">{idx.label}</div>
+              <div className="text-widget-16 font-bold text-foreground leading-tight">{idx.value}</div>
+              <ChangeLabel changeAmt={idx.changeAmt} changeRate={idx.changeRate} className="text-widget-9" />
               <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary opacity-0 group-hover:opacity-100 transition-opacity" />
             </div>
           ))}

--- a/src/components/widgets/IndexWidget.jsx
+++ b/src/components/widgets/IndexWidget.jsx
@@ -1,24 +1,24 @@
 import { useState } from 'react'
 import { Settings2 } from 'lucide-react'
-import PriceChange from '@/components/ui/PriceChange'
 import WidgetCard from './WidgetCard'
 import IndexConfigModal from './IndexConfigModal'
 import useMarketIndices from '@/features/market/useMarketIndices'
 import useWidgetStore from '@/store/useWidgetStore'
 import { useDashboardSave } from '@/hooks/useDashboardSync'
+import useWidgetDetailStore from '@/store/useWidgetDetailStore'
 
 const INDEX_META = {
   '001':      { key: 'kospi',  label: 'KOSPI',   order: 0 },
-  '101':      { key: 'kosdaq', label: 'KOSDAQ',  order: 1 },
+  '301':      { key: 'kosdaq', label: 'KOSDAQ',  order: 1 },
   'NAS@IXIC': { key: 'nasdaq', label: 'NASDAQ',  order: 2 },
   'SPI@SPX':  { key: 'sp500',  label: 'S&P 500', order: 3 },
 }
 
 const DEFAULT_INDICES = {
   'index-sm':   ['001'],
-  'index-wide': ['001', '101'],
-  'index-3x1':  ['001', '101', 'NAS@IXIC'],
-  'index-2x2':  ['001', '101', 'NAS@IXIC'],
+  'index-wide': ['001', '301'],
+  'index-3x1':  ['001', '301', 'NAS@IXIC'],
+  'index-2x2':  ['001', '301', 'NAS@IXIC'],
 }
 
 function useIndices(selectedCodes) {
@@ -29,14 +29,28 @@ function useIndices(selectedCodes) {
     const meta = INDEX_META[code]
     return {
       code,
-      key:    meta?.key   ?? code,
-      label:  meta?.label ?? code,
-      value:  idx ? Number(idx.price).toLocaleString('ko-KR') : '-',
-      change: idx?.changeRate ?? null,
+      key:        meta?.key   ?? code,
+      label:      meta?.label ?? code,
+      value:      idx ? Number(idx.price).toLocaleString('ko-KR') : '-',
+      changeAmt:  idx?.change     ?? null,
+      changeRate: idx?.changeRate ?? null,
     }
   })
 }
 
+function ChangeLabel({ changeAmt, changeRate, className = '' }) {
+  if (changeAmt == null || changeRate == null) {
+    return <span className={`text-foreground-disabled ${className}`}>-</span>
+  }
+  const isUp    = changeRate >= 0
+  const color   = isUp ? 'text-up' : 'text-down'
+  const sign    = isUp ? '+' : ''
+  const absRate = Math.abs(changeRate).toFixed(2)
+  const amt     = `${sign}${Number(changeAmt).toLocaleString('ko-KR', { maximumFractionDigits: 2 })}`
+  return (
+    <span className={`${color} ${className}`}>{amt} ({absRate}%)</span>
+  )
+}
 
 function SettingsButton({ onClick }) {
   return (
@@ -53,9 +67,15 @@ export default function IndexWidget({ instanceId, variant = 'index-wide', colSpa
   const updateWidgetConfig = useWidgetStore((s) => s.updateWidgetConfig)
   const { mutate: saveDashboard } = useDashboardSave()
   const [isConfigOpen, setIsConfigOpen] = useState(false)
+  const open = useWidgetDetailStore((s) => s.open)
 
   const selectedCodes = config.indices ?? DEFAULT_INDICES[variant] ?? DEFAULT_INDICES['index-wide']
   const indices = useIndices(selectedCodes)
+
+  const handleIndexClick = (e, code) => {
+    e.stopPropagation()
+    open({ widgetTypeId: 'index', config: { code } })
+  }
 
   function handleSave(newIndices) {
     updateWidgetConfig(instanceId, { indices: newIndices })
@@ -64,21 +84,19 @@ export default function IndexWidget({ instanceId, variant = 'index-wide', colSpa
   }
 
   if (variant === 'index-sm') {
-    const shown = indices[0] ?? { key: 'kospi', label: 'KOSPI', value: '-', change: null }
+    const shown = indices[0] ?? { code: '001', key: 'kospi', label: 'KOSPI', value: '-', change: null }
     return (
       <>
-        <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+        <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={(e) => handleIndexClick(e, shown.code)}>
           <div className="flex items-center justify-between shrink-0">
             <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">주요 지수</span>
             <SettingsButton onClick={() => setIsConfigOpen(true)} />
           </div>
-          <div className="flex-1 flex flex-col justify-center items-center text-center min-h-0">
+          <div className="relative flex-1 flex flex-col justify-center items-center text-center min-h-0 group">
             <div className="text-[9px] text-foreground-disabled">{shown.label}</div>
             <div className="text-[18px] font-bold text-foreground leading-tight">{shown.value}</div>
-            {shown.change != null
-              ? <PriceChange value={shown.change} className="text-[9px]" />
-              : <span className="text-[9px] text-foreground-disabled">-</span>
-            }
+            <ChangeLabel changeAmt={shown.changeAmt} changeRate={shown.changeRate} className="text-[9px]" />
+            <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary opacity-0 group-hover:opacity-100 transition-opacity" />
           </div>
         </WidgetCard>
         {isConfigOpen && (
@@ -103,13 +121,15 @@ export default function IndexWidget({ instanceId, variant = 'index-wide', colSpa
           </div>
           <div className="flex flex-1 min-h-0 divide-x divide-stroke mt-1">
             {indices.map((idx) => (
-              <div key={idx.key} className="flex-1 flex flex-col justify-center items-center text-center px-2">
+              <div
+                key={idx.key}
+                className="relative flex-1 flex flex-col justify-center items-center text-center px-2 cursor-pointer group"
+                onClick={(e) => handleIndexClick(e, idx.code)}
+              >
                 <div className="text-[9px] text-foreground-disabled">{idx.label}</div>
                 <div className="text-[17px] font-bold text-foreground leading-tight">{idx.value}</div>
-                {idx.change != null
-                  ? <PriceChange value={idx.change} className="text-[10px]" />
-                  : <span className="text-[10px] text-foreground-disabled">-</span>
-                }
+                <ChangeLabel changeAmt={idx.changeAmt} changeRate={idx.changeRate} className="text-[10px]" />
+                <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary opacity-0 group-hover:opacity-100 transition-opacity" />
               </div>
             ))}
           </div>
@@ -136,13 +156,15 @@ export default function IndexWidget({ instanceId, variant = 'index-wide', colSpa
           </div>
           <div className="flex flex-col flex-1 justify-center gap-3">
             {indices.map((idx) => (
-              <div key={idx.key} className="flex-1 min-w-0">
+              <div
+                key={idx.key}
+                className="relative flex-1 min-w-0 cursor-pointer px-1 group"
+                onClick={(e) => handleIndexClick(e, idx.code)}
+              >
                 <div className="text-[9px] text-foreground-disabled">{idx.label}</div>
                 <div className="text-[15px] font-bold text-foreground leading-tight">{idx.value}</div>
-                {idx.change != null
-                  ? <PriceChange value={idx.change} className="text-[10px]" />
-                  : <span className="text-[10px] text-foreground-disabled">-</span>
-                }
+                <ChangeLabel changeAmt={idx.changeAmt} changeRate={idx.changeRate} className="text-[10px]" />
+                <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary opacity-0 group-hover:opacity-100 transition-opacity" />
               </div>
             ))}
           </div>
@@ -169,13 +191,15 @@ export default function IndexWidget({ instanceId, variant = 'index-wide', colSpa
         </div>
         <div className="flex flex-1 min-h-0 divide-x divide-stroke mt-1">
           {indices.map((idx) => (
-            <div key={idx.key} className="flex-1 flex flex-col justify-center items-center text-center px-3 py-1">
+            <div
+              key={idx.key}
+              className="relative flex-1 flex flex-col justify-center items-center text-center px-3 py-1 cursor-pointer group"
+              onClick={(e) => handleIndexClick(e, idx.code)}
+            >
               <div className="text-[9px] text-foreground-disabled">{idx.label}</div>
               <div className="text-[16px] font-bold text-foreground leading-tight">{idx.value}</div>
-              {idx.change != null
-                ? <PriceChange value={idx.change} className="text-[9px]" />
-                : <span className="text-[9px] text-foreground-disabled">-</span>
-              }
+              <ChangeLabel changeAmt={idx.changeAmt} changeRate={idx.changeRate} className="text-[9px]" />
+              <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary opacity-0 group-hover:opacity-100 transition-opacity" />
             </div>
           ))}
         </div>

--- a/src/components/widgets/MarketOverviewWidget.jsx
+++ b/src/components/widgets/MarketOverviewWidget.jsx
@@ -15,7 +15,7 @@ function NewsCard({ item, showSummary = false, onClickNews }) {
       className="group flex flex-col gap-0.5 py-2 border-b border-stroke last:border-b-0 cursor-pointer pl-2 border-l-2 border-l-transparent hover:border-l-primary transition-colors"
       onClick={(e) => { e.stopPropagation(); onClickNews(item.newsId) }}
     >
-      <p className="text-[11px] font-semibold text-foreground leading-snug line-clamp-2">
+      <p className="text-widget-11 font-semibold text-foreground leading-snug line-clamp-2">
         {item.title}
       </p>
       {showSummary && item.oneLineSummary && (
@@ -25,12 +25,12 @@ function NewsCard({ item, showSummary = false, onClickNews }) {
       )}
       <div className="flex items-center gap-1.5 mt-0.5">
         {item.source && (
-          <span className="text-[9px] text-foreground-disabled">{item.source}</span>
+          <span className="text-widget-9 text-foreground-disabled">{item.source}</span>
         )}
         {item.publishedAt && (
           <>
-            {item.source && <span className="text-[9px] text-stroke">·</span>}
-            <span className="text-[9px] text-foreground-disabled">{item.publishedAt}</span>
+            {item.source && <span className="text-widget-9 text-stroke">·</span>}
+            <span className="text-widget-9 text-foreground-disabled">{item.publishedAt}</span>
           </>
         )}
       </div>
@@ -45,8 +45,8 @@ function NewsListCompact({ items, onClickNews }) {
       className="flex items-start gap-1.5 py-1 border-b border-stroke last:border-b-0 cursor-pointer pl-2 border-l-2 border-l-transparent hover:border-l-primary transition-colors"
       onClick={(e) => { e.stopPropagation(); onClickNews(item.newsId) }}
     >
-      <span className="text-[9px] font-bold text-primary mt-[1px] shrink-0">{i + 1}</span>
-      <p className="text-[10px] text-foreground leading-snug line-clamp-2">{item.title}</p>
+      <span className="text-widget-9 font-bold text-primary mt-[1px] shrink-0">{i + 1}</span>
+      <p className="text-widget-10 text-foreground leading-snug line-clamp-2">{item.title}</p>
     </div>
   ))
 }
@@ -73,7 +73,7 @@ export default function MarketOverviewWidget({ variant = 'market-sm', colSpan = 
           type="button"
           onClick={(e) => { e.stopPropagation(); setTab(t.key) }}
           className={cn(
-            'px-2 py-0.5 text-[9px] font-semibold rounded-md transition-colors',
+            'px-2 py-0.5 text-widget-9 font-semibold rounded-md transition-colors',
             tab === t.key
               ? 'bg-primary text-white'
               : 'text-foreground-disabled hover:text-foreground-secondary',
@@ -85,14 +85,14 @@ export default function MarketOverviewWidget({ variant = 'market-sm', colSpan = 
     </div>
   )
 
-  const empty = <div className="text-[10px] text-foreground-disabled py-2">뉴스가 없습니다.</div>
-  const loading = <div className="text-[10px] text-foreground-disabled py-2">불러오는 중...</div>
+  const empty = <div className="text-widget-10 text-foreground-disabled py-2">뉴스가 없습니다.</div>
+  const loading = <div className="text-widget-10 text-foreground-disabled py-2">불러오는 중...</div>
 
   if (variant === 'market-2x2') {
     return (
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
         <div className="flex items-center justify-between mb-1 shrink-0">
-          <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">오늘의 시황</span>
+          <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">오늘의 시황</span>
           {tabBar}
         </div>
         <div className="flex-1 min-h-0 overflow-y-auto">
@@ -108,7 +108,7 @@ export default function MarketOverviewWidget({ variant = 'market-sm', colSpan = 
     return (
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
         <div className="flex items-center justify-between mb-1 shrink-0">
-          <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">오늘의 시황</span>
+          <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">오늘의 시황</span>
           {tabBar}
         </div>
         <div className="flex-1 min-h-0 overflow-y-auto">
@@ -124,7 +124,7 @@ export default function MarketOverviewWidget({ variant = 'market-sm', colSpan = 
   return (
     <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
       <div className="flex items-center justify-between mb-1 shrink-0">
-        <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">오늘의 시황</span>
+        <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">오늘의 시황</span>
         {tabBar}
       </div>
       <div className="flex-1 flex flex-col overflow-hidden">

--- a/src/components/widgets/MarketOverviewWidget.jsx
+++ b/src/components/widgets/MarketOverviewWidget.jsx
@@ -1,28 +1,103 @@
+import { useState } from 'react'
 import WidgetCard from './WidgetCard'
-import { MARKET_OVERVIEW } from '@/mocks/home'
+import useLatestNews from '@/features/market/useLatestNews'
+import useWidgetDetailStore from '@/store/useWidgetDetailStore'
+import { cn } from '@/lib/cn'
+
+const TABS = [
+  { key: 'kr', label: '한국' },
+  { key: 'us', label: '미국' },
+]
+
+function NewsCard({ item, showSummary = false, onClickNews }) {
+  return (
+    <div
+      className="group flex flex-col gap-0.5 py-2 border-b border-stroke last:border-b-0 cursor-pointer pl-2 border-l-2 border-l-transparent hover:border-l-primary transition-colors"
+      onClick={(e) => { e.stopPropagation(); onClickNews(item.newsId) }}
+    >
+      <p className="text-[11px] font-semibold text-foreground leading-snug line-clamp-2">
+        {item.title}
+      </p>
+      {showSummary && item.oneLineSummary && (
+        <p className="text-[9.5px] text-foreground-secondary leading-relaxed line-clamp-2">
+          {item.oneLineSummary}
+        </p>
+      )}
+      <div className="flex items-center gap-1.5 mt-0.5">
+        {item.source && (
+          <span className="text-[9px] text-foreground-disabled">{item.source}</span>
+        )}
+        {item.publishedAt && (
+          <>
+            {item.source && <span className="text-[9px] text-stroke">·</span>}
+            <span className="text-[9px] text-foreground-disabled">{item.publishedAt}</span>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function NewsListCompact({ items, onClickNews }) {
+  return items.map((item, i) => (
+    <div
+      key={item.newsId ?? i}
+      className="flex items-start gap-1.5 py-1 border-b border-stroke last:border-b-0 cursor-pointer pl-2 border-l-2 border-l-transparent hover:border-l-primary transition-colors"
+      onClick={(e) => { e.stopPropagation(); onClickNews(item.newsId) }}
+    >
+      <span className="text-[9px] font-bold text-primary mt-[1px] shrink-0">{i + 1}</span>
+      <p className="text-[10px] text-foreground leading-snug line-clamp-2">{item.title}</p>
+    </div>
+  ))
+}
 
 export default function MarketOverviewWidget({ variant = 'market-sm', colSpan = 1, rowSpan = 1, onDelete }) {
-  const { news } = MARKET_OVERVIEW
+  const [tab, setTab] = useState('kr')
+  const { krNews, usNews, isLoading } = useLatestNews(10)
+  const items = tab === 'kr' ? krNews : usNews
+  const openDetail = useWidgetDetailStore((s) => s.open)
+
+  function handleWidgetClick() {
+    openDetail({ widgetTypeId: 'market-overview', config: { tab } })
+  }
+
+  function handleNewsClick(newsId) {
+    openDetail({ widgetTypeId: 'market-overview', config: { tab, newsId } })
+  }
+
+  const tabBar = (
+    <div className="flex gap-1">
+      {TABS.map((t) => (
+        <button
+          key={t.key}
+          type="button"
+          onClick={(e) => { e.stopPropagation(); setTab(t.key) }}
+          className={cn(
+            'px-2 py-0.5 text-[9px] font-semibold rounded-md transition-colors',
+            tab === t.key
+              ? 'bg-primary text-white'
+              : 'text-foreground-disabled hover:text-foreground-secondary',
+          )}
+        >
+          {t.label}
+        </button>
+      ))}
+    </div>
+  )
+
+  const empty = <div className="text-[10px] text-foreground-disabled py-2">뉴스가 없습니다.</div>
+  const loading = <div className="text-[10px] text-foreground-disabled py-2">불러오는 중...</div>
 
   if (variant === 'market-2x2') {
     return (
-      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-        <div className="flex items-center justify-between mb-2 shrink-0">
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
+        <div className="flex items-center justify-between mb-1 shrink-0">
           <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">오늘의 시황</span>
+          {tabBar}
         </div>
-        <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-2">
-          {news.slice(0, 3).map((item, i) => (
-            <div
-              key={i}
-              className={`px-2.5 py-2 rounded-xl border-l-[3px] ${
-                i === 0
-                  ? 'bg-primary-light border-primary'
-                  : 'bg-surface-subtle border-stroke'
-              }`}
-            >
-              <p className="text-[11px] font-bold text-foreground leading-snug">{item.title}</p>
-              <p className="text-[9px] text-foreground-disabled leading-relaxed mt-0.5">{item.desc}</p>
-            </div>
+        <div className="flex-1 min-h-0 overflow-y-auto">
+          {isLoading ? loading : !items.length ? empty : items.slice(0, 4).map((item, i) => (
+            <NewsCard key={item.newsId ?? i} item={item} showSummary onClickNews={handleNewsClick} />
           ))}
         </div>
       </WidgetCard>
@@ -31,46 +106,29 @@ export default function MarketOverviewWidget({ variant = 'market-sm', colSpan = 
 
   if (variant === 'market-wide') {
     return (
-      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-        <div className="flex items-center justify-between mb-2 shrink-0">
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
+        <div className="flex items-center justify-between mb-1 shrink-0">
           <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">오늘의 시황</span>
+          {tabBar}
         </div>
-        <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-2">
-          {news.slice(0, 2).map((item, i) => (
-            <div
-              key={i}
-              className={`px-2 py-1.5 rounded-lg border-l-[3px] ${
-                i === 0
-                  ? 'bg-primary-light border-primary'
-                  : 'bg-surface-subtle border-stroke'
-              }`}
-            >
-              <p className="text-[10px] font-bold text-foreground leading-snug">{item.title}</p>
-              <p className="text-[9px] text-foreground-disabled leading-relaxed mt-0.5">{item.desc}</p>
-            </div>
+        <div className="flex-1 min-h-0 overflow-y-auto">
+          {isLoading ? loading : !items.length ? empty : items.slice(0, 2).map((item, i) => (
+            <NewsCard key={item.newsId ?? i} item={item} showSummary onClickNews={handleNewsClick} />
           ))}
         </div>
       </WidgetCard>
     )
   }
 
-  /* market-sm (default) — 헤드라인 3줄 */
+  /* market-sm */
   return (
-    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-      <div className="flex items-center justify-between mb-2">
+    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
+      <div className="flex items-center justify-between mb-1 shrink-0">
         <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">오늘의 시황</span>
+        {tabBar}
       </div>
-      <div className="flex-1 flex flex-col gap-1.5 overflow-hidden">
-        {news.slice(0, 3).map((item, i) => (
-          <p
-            key={i}
-            className={`text-[10px] leading-snug truncate ${
-              i === 0 ? 'font-bold text-foreground' : 'text-foreground-disabled'
-            }`}
-          >
-            {item.title}
-          </p>
-        ))}
+      <div className="flex-1 flex flex-col overflow-hidden">
+        {isLoading ? loading : !items.length ? empty : <NewsListCompact items={items.slice(0, 3)} onClickNews={handleNewsClick} />}
       </div>
     </WidgetCard>
   )

--- a/src/components/widgets/PortfolioWidget.jsx
+++ b/src/components/widgets/PortfolioWidget.jsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import LockedOverlay from '@/components/ui/LockedOverlay'
 import useAuthStore from '@/store/useAuthStore'
+import useWidgetDetailStore from '@/store/useWidgetDetailStore'
 import WidgetCard from './WidgetCard'
 import { useDomesticHoldings } from '@/api/balance'
 
@@ -68,6 +69,7 @@ function usePortfolio(enabled) {
 
 export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1, rowSpan = 1, onDelete }) {
   const { isAuthenticated, isRestoring } = useAuthStore()
+  const { open } = useWidgetDetailStore()
   const portfolio = usePortfolio(isAuthenticated && !isRestoring)
 
   const conicStops = portfolio.items.reduce((acc, item, i) => {
@@ -82,7 +84,7 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
   const returnRateColor = (portfolio.returnRate ?? 0) >= 0 ? 'text-up' : 'text-down'
 
   return (
-    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={() => open({ widgetTypeId: 'balance', config: {} })}>
       {variant === 'portfolio-wide' ? (
         <>
           <div className="flex items-center justify-between mb-1 shrink-0">

--- a/src/components/widgets/PortfolioWidget.jsx
+++ b/src/components/widgets/PortfolioWidget.jsx
@@ -88,15 +88,15 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
       {variant === 'portfolio-wide' ? (
         <>
           <div className="flex items-center justify-between mb-1 shrink-0">
-            <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 비중</span>
-            <span className={`text-[10px] font-semibold ${returnRateColor}`}>{returnRateStr}</span>
+            <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 비중</span>
+            <span className={`text-widget-10 font-semibold ${returnRateColor}`}>{returnRateStr}</span>
           </div>
           <div className="flex flex-col gap-2 flex-1 min-h-0">
             {portfolio.items.slice(0, 3).map((item) => (
               <div key={item.name}>
                 <div className="flex justify-between mb-0.5">
-                  <span className="text-[10px] text-foreground-secondary">{item.name}</span>
-                  <span className="text-[10px] font-semibold text-foreground">{item.ratio}%</span>
+                  <span className="text-widget-10 text-foreground-secondary">{item.name}</span>
+                  <span className="text-widget-10 font-semibold text-foreground">{item.ratio}%</span>
                 </div>
                 <div className="h-[3px] bg-surface-muted rounded-full overflow-hidden">
                   <div className="h-full rounded-full" style={{ width: `${item.ratio}%`, background: item.color }} />
@@ -108,7 +108,7 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
       ) : variant === 'portfolio-2x2' ? (
         <>
           <div className="flex items-center justify-between mb-1 shrink-0">
-            <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">섹터별 비중</span>
+            <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">섹터별 비중</span>
           </div>
           <div className="flex flex-col flex-1 gap-3">
             <div className="flex items-center gap-3 shrink-0">
@@ -117,17 +117,17 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
                 style={{ background: `conic-gradient(${conicStops})` }}
               />
               <div>
-                <div className="text-[9px] text-foreground-disabled">총 수익률</div>
-                <div className={`text-[22px] font-bold leading-tight ${returnRateColor}`}>{returnRateStr}</div>
-                <div className="text-[9px] text-foreground-disabled mt-0.5">+4,280,000원</div>
+                <div className="text-widget-9 text-foreground-disabled">총 수익률</div>
+                <div className={`text-widget-22 font-bold leading-tight ${returnRateColor}`}>{returnRateStr}</div>
+                <div className="text-widget-9 text-foreground-disabled mt-0.5">+4,280,000원</div>
               </div>
             </div>
             <div className="flex flex-col gap-2.5 flex-1">
               {portfolio.items.map((item) => (
                 <div key={item.name}>
                   <div className="flex justify-between mb-0.5">
-                    <span className="text-[10px] text-foreground-tertiary">{item.name}</span>
-                    <span className="text-[10px] font-semibold text-foreground">{item.ratio}%</span>
+                    <span className="text-widget-10 text-foreground-tertiary">{item.name}</span>
+                    <span className="text-widget-10 font-semibold text-foreground">{item.ratio}%</span>
                   </div>
                   <div className="h-[4px] bg-surface-muted rounded-full overflow-hidden">
                     <div className="h-full rounded-full" style={{ width: `${item.ratio}%`, background: item.color }} />
@@ -141,8 +141,8 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
         /* portfolio-sm (default) */
         <>
           <div className="flex items-center justify-between mb-1 shrink-0">
-            <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 비중</span>
-            <span className={`text-[10px] font-semibold ${returnRateColor}`}>{returnRateStr}</span>
+            <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 비중</span>
+            <span className={`text-widget-10 font-semibold ${returnRateColor}`}>{returnRateStr}</span>
           </div>
           <div className="flex items-center gap-2.5 flex-1 min-h-0">
             <div
@@ -153,7 +153,7 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
               {portfolio.items.map((item) => (
                 <div key={item.name} className="flex items-center gap-1">
                   <div className="w-1.5 h-1.5 rounded-full shrink-0" style={{ background: item.color }} />
-                  <span className="text-[10px] text-foreground-secondary">{item.name}</span>
+                  <span className="text-widget-10 text-foreground-secondary">{item.name}</span>
                 </div>
               ))}
             </div>

--- a/src/components/widgets/RankingWidget.jsx
+++ b/src/components/widgets/RankingWidget.jsx
@@ -1,8 +1,10 @@
 import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import PriceChange from '@/components/ui/PriceChange'
 import TabChip from '@/components/ui/TabChip'
 import WidgetCard from './WidgetCard'
 import useMarketRanking from '@/features/market/useMarketRanking'
+import useWidgetDetailStore from '@/store/useWidgetDetailStore'
 
 const TABS = ['거래대금', '급상승', '거래량']
 
@@ -16,6 +18,14 @@ export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, r
   const [activeTab, setActiveTab] = useState(
     () => localStorage.getItem('rankingWidget.activeTab') ?? '거래대금'
   )
+  const open     = useWidgetDetailStore((s) => s.open)
+  const navigate = useNavigate()
+
+  const handleCardClick  = () => open({ widgetTypeId: 'ranking', config: { initialSortFilter: TAB_TO_SORT[activeTab] } })
+  const handleStockClick = (e, stock) => {
+    e.stopPropagation()
+    navigate(`/invest/${stock.stockCode}`, { state: { stockName: stock.name, marketType: stock.marketType ?? stock.market } })
+  }
 
   function handleTabChange(tab) {
     setActiveTab(tab)
@@ -25,7 +35,7 @@ export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, r
 
   if (variant === 'ranking-lg') {
     return (
-      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleCardClick}>
         <div className="flex items-center justify-between mb-1.5 shrink-0">
           <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">실시간 순위</span>
           <div className="flex gap-0.5">
@@ -44,7 +54,8 @@ export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, r
           {stocks.map((stock) => (
             <div
               key={stock.id ?? stock.rank}
-              className="flex items-center justify-between px-1 py-1 hover:bg-surface-subtle rounded-lg transition-colors cursor-pointer"
+              className="flex items-center justify-between px-1 py-1 rounded-r-lg border-l-2 border-transparent hover:border-primary hover:bg-surface-subtle transition-colors cursor-pointer"
+              onClick={(e) => handleStockClick(e, stock)}
             >
               <div className="flex items-center gap-1.5">
                 <span className={`text-[9px] font-bold w-4 text-center shrink-0 ${stock.rank === 1 ? 'text-primary' : 'text-foreground-disabled'}`}>
@@ -62,7 +73,7 @@ export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, r
 
   /* ranking-wide (default) */
   return (
-    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleCardClick}>
       <div className="flex items-center justify-between mb-1.5 shrink-0">
         <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">실시간 순위</span>
         <div className="flex gap-0.5">
@@ -81,7 +92,8 @@ export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, r
         {stocks.map((stock) => (
           <div
             key={stock.id ?? stock.rank}
-            className="flex items-center justify-between px-1.5 py-1.5 rounded-xl hover:bg-surface-subtle transition-colors cursor-pointer"
+            className="flex items-center justify-between px-1.5 py-1.5 rounded-r-xl border-l-2 border-transparent hover:border-primary hover:bg-surface-subtle transition-colors cursor-pointer"
+            onClick={(e) => handleStockClick(e, stock)}
           >
             <div className="flex items-center gap-1.5">
               <span className={`text-[9px] font-bold w-3 text-center shrink-0 ${stock.rank === 1 ? 'text-primary' : 'text-foreground-disabled'}`}>

--- a/src/components/widgets/RankingWidget.jsx
+++ b/src/components/widgets/RankingWidget.jsx
@@ -37,7 +37,7 @@ export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, r
     return (
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleCardClick}>
         <div className="flex items-center justify-between mb-1.5 shrink-0">
-          <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">실시간 순위</span>
+          <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">실시간 순위</span>
           <div className="flex gap-0.5">
             {TABS.map((tab) => (
               <TabChip
@@ -58,12 +58,12 @@ export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, r
               onClick={(e) => handleStockClick(e, stock)}
             >
               <div className="flex items-center gap-1.5">
-                <span className={`text-[9px] font-bold w-4 text-center shrink-0 ${stock.rank === 1 ? 'text-primary' : 'text-foreground-disabled'}`}>
+                <span className={`text-widget-9 font-bold w-4 text-center shrink-0 ${stock.rank === 1 ? 'text-primary' : 'text-foreground-disabled'}`}>
                   {stock.rank}
                 </span>
-                <span className="text-[10px] font-semibold text-foreground">{stock.name}</span>
+                <span className="text-widget-10 font-semibold text-foreground">{stock.name}</span>
               </div>
-              <PriceChange value={stock.change} className="text-[10px]" />
+              <PriceChange value={stock.change} className="text-widget-10" />
             </div>
           ))}
         </div>
@@ -75,7 +75,7 @@ export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, r
   return (
     <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleCardClick}>
       <div className="flex items-center justify-between mb-1.5 shrink-0">
-        <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">실시간 순위</span>
+        <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">실시간 순위</span>
         <div className="flex gap-0.5">
           {TABS.map((tab) => (
             <TabChip
@@ -96,12 +96,12 @@ export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, r
             onClick={(e) => handleStockClick(e, stock)}
           >
             <div className="flex items-center gap-1.5">
-              <span className={`text-[9px] font-bold w-3 text-center shrink-0 ${stock.rank === 1 ? 'text-primary' : 'text-foreground-disabled'}`}>
+              <span className={`text-widget-9 font-bold w-3 text-center shrink-0 ${stock.rank === 1 ? 'text-primary' : 'text-foreground-disabled'}`}>
                 {stock.rank}
               </span>
-              <span className="text-[10px] font-semibold text-foreground">{stock.name}</span>
+              <span className="text-widget-10 font-semibold text-foreground">{stock.name}</span>
             </div>
-            <PriceChange value={stock.change} className="text-[10px]" />
+            <PriceChange value={stock.change} className="text-widget-10" />
           </div>
         ))}
       </div>

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -133,7 +133,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
         <button
           key={p}
           onClick={(e) => { e.stopPropagation(); handlePeriodChange(p) }}
-          className={`text-[9px] px-1.5 py-0.5 rounded font-medium transition-colors duration-[150ms] ${activePeriod === p ? 'bg-primary-light text-primary' : 'text-foreground-disabled hover:text-foreground'}`}
+          className={`text-widget-9 px-1.5 py-0.5 rounded font-medium transition-colors duration-[150ms] ${activePeriod === p ? 'bg-primary-light text-primary' : 'text-foreground-disabled hover:text-foreground'}`}
         >
           {p}
         </button>
@@ -354,21 +354,21 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
                   <StockAvatar name={stock.name} stockCode={stock.code} marketType={stock.marketType} color={stock.color} size="sm" />
                   <div>
                     <div className="flex items-center gap-1">
-                      <div className="text-[11px] font-bold text-foreground leading-none">{stock.name}</div>
+                      <div className="text-widget-11 font-bold text-foreground leading-none">{stock.name}</div>
                       {settingsBtn}
                     </div>
-                    <div className="text-[9px] text-foreground-disabled mt-0.5">{stock.code}{stock.marketType ? ` · ${stock.marketType}` : ''}</div>
+                    <div className="text-widget-9 text-foreground-disabled mt-0.5">{stock.code}{stock.marketType ? ` · ${stock.marketType}` : ''}</div>
                   </div>
                 </div>
                 {periodTabs}
               </div>
               <div>
-                <div className="text-[18px] font-bold leading-tight text-foreground">{stock.price}</div>
+                <div className="text-widget-18 font-bold leading-tight text-foreground">{stock.price}</div>
                 {hasPrice
-                  ? <div className={`text-[10px] ${isUp ? 'text-up' : 'text-down'}`}>
+                  ? <div className={`text-widget-10 ${isUp ? 'text-up' : 'text-down'}`}>
                       {isUp ? '▲' : '▼'} {stock.changeAmt}원 ({isUp ? '+' : ''}{stock.change}%)
                     </div>
-                  : <div className="text-[10px] text-foreground-disabled">-</div>
+                  : <div className="text-widget-10 text-foreground-disabled">-</div>
                 }
               </div>
             </div>
@@ -389,15 +389,15 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
               <StockAvatar name={stock.name} stockCode={stock.code} marketType={stock.marketType} color={stock.color} size="sm" />
               <div>
                 <div className="flex items-center gap-1">
-                  <div className="text-[13px] font-bold text-foreground">{stock.name}</div>
+                  <div className="text-widget-13 font-bold text-foreground">{stock.name}</div>
                   {settingsBtn}
                 </div>
-                <div className="text-[9px] text-foreground-disabled">{stock.code}{stock.marketType ? ` · ${stock.marketType}` : ''}</div>
+                <div className="text-widget-9 text-foreground-disabled">{stock.code}{stock.marketType ? ` · ${stock.marketType}` : ''}</div>
               </div>
             </div>
             <div className="text-right">
-              <div className="text-[20px] font-bold leading-tight text-foreground">{stock.price}</div>
-              <PriceChange value={stock.change} className="text-[10px]" />
+              <div className="text-widget-20 font-bold leading-tight text-foreground">{stock.price}</div>
+              <PriceChange value={stock.change} className="text-widget-10" />
             </div>
           </div>
           <div className="flex items-center shrink-0 mb-1.5">
@@ -412,8 +412,8 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
               { label: '거래량', val: stock.volume },
             ].map(({ label, val }) => (
               <div key={label} className="text-center">
-                <div className="text-[8px] text-foreground-disabled">{label}</div>
-                <div className="text-[10px] font-semibold text-foreground">{val}</div>
+                <div className="text-widget-8 text-foreground-disabled">{label}</div>
+                <div className="text-widget-10 font-semibold text-foreground">{val}</div>
               </div>
             ))}
           </div>
@@ -432,15 +432,15 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
               <StockAvatar name={stock.name} stockCode={stock.code} marketType={stock.marketType} color={stock.color} size="sm" />
               <div>
                 <div className="flex items-center gap-1">
-                  <div className="text-[13px] font-bold text-foreground">{stock.name}</div>
+                  <div className="text-widget-13 font-bold text-foreground">{stock.name}</div>
                   {settingsBtn}
                 </div>
-                <div className="text-[9px] text-foreground-disabled">{stock.code}</div>
+                <div className="text-widget-9 text-foreground-disabled">{stock.code}</div>
               </div>
             </div>
             <div className="text-right">
-              <div className="text-[18px] font-bold leading-tight text-foreground">{stock.price}</div>
-              <PriceChange value={stock.change} className="text-[10px]" />
+              <div className="text-widget-18 font-bold leading-tight text-foreground">{stock.price}</div>
+              <PriceChange value={stock.change} className="text-widget-10" />
             </div>
           </div>
           <div className="flex shrink-0 mb-1">
@@ -454,8 +454,8 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
               { label: '저가', val: stock.low },
             ].map(({ label, val }) => (
               <div key={label} className="text-center">
-                <div className="text-[9px] text-foreground-disabled">{label}</div>
-                <div className="text-[11px] font-semibold text-foreground">{val}</div>
+                <div className="text-widget-9 text-foreground-disabled">{label}</div>
+                <div className="text-widget-11 font-semibold text-foreground">{val}</div>
               </div>
             ))}
           </div>
@@ -472,22 +472,22 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
         <div className="flex items-center justify-between shrink-0">
           <div className="flex items-center gap-1.5">
             <StockAvatar name={stock.name} stockCode={stock.code} marketType={stock.marketType} color={stock.color} size="sm" />
-            <span className="text-[12px] font-bold text-foreground leading-none">{stock.name}</span>
+            <span className="text-widget-12 font-bold text-foreground leading-none">{stock.name}</span>
           </div>
           <div className="flex items-center gap-1">
-            <span className="text-[9px] text-foreground-disabled">{stock.code}</span>
+            <span className="text-widget-9 text-foreground-disabled">{stock.code}</span>
             {settingsBtn}
           </div>
         </div>
         <div className="flex-1 flex flex-col justify-end min-h-0">
-          <div className="text-[18px] font-bold leading-tight tracking-tight text-foreground">
+          <div className="text-widget-18 font-bold leading-tight tracking-tight text-foreground">
             {stock.price}
           </div>
           {hasPrice
-            ? <div className={`text-[10px] mt-0.5 ${isUp ? 'text-up' : 'text-down'}`}>
+            ? <div className={`text-widget-10 mt-0.5 ${isUp ? 'text-up' : 'text-down'}`}>
                 {isUp ? '▲' : '▼'} {stock.changeAmt}원 ({isUp ? '+' : ''}{stock.change}%)
               </div>
-            : <div className="text-[10px] mt-0.5 text-foreground-disabled">-</div>
+            : <div className="text-widget-10 mt-0.5 text-foreground-disabled">-</div>
           }
         </div>
       </WidgetCard>

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -82,8 +82,9 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
       widgetTypeId: 'stock-chart',
       config: {
         stockCode,
-        stockName: stockName ?? stockMeta.name,
-        marketType: config.marketType ?? stockMeta.market ?? null,
+        stockName:    stockName ?? stockMeta.name,
+        marketType:   config.marketType ?? stockMeta.market ?? null,
+        widgetPeriod: activePeriod,
       },
     })
   }

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -9,6 +9,7 @@ import StockSelectModal from './StockSelectModal'
 import { HOME_STOCKS } from '@/mocks/home'
 import { marketApi, foreignMarketApi } from '@/api/market'
 import useWidgetStore from '@/store/useWidgetStore'
+import useWidgetDetailStore from '@/store/useWidgetDetailStore'
 import { useDashboardSave } from '@/hooks/useDashboardSync'
 import useStompSubscription from '@/hooks/useStompSubscription'
 import { normalizeDailySeries, normalizeMinuteSeries } from '@/features/invest/domestic/normalize'
@@ -74,6 +75,18 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
   const [liveCandle, setLiveCandle] = useState(null)
   const updateWidgetConfig = useWidgetStore((s) => s.updateWidgetConfig)
   const { mutate: saveDashboard } = useDashboardSave()
+  const openDetail = useWidgetDetailStore((s) => s.open)
+
+  const handleCardClick = () => {
+    openDetail({
+      widgetTypeId: 'stock-chart',
+      config: {
+        stockCode,
+        stockName: stockName ?? stockMeta.name,
+        marketType: config.marketType ?? stockMeta.market ?? null,
+      },
+    })
+  }
 
   const stockId    = config.stockId ?? 'samsung'
   const stockCode  = config.stockCode ?? STOCK_CODE_MAP[stockId]
@@ -331,7 +344,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
   if (variant === 'stock-wide') {
     return (
       <>
-        <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+        <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleCardClick}>
           <div className="flex h-full gap-2.5 min-h-0">
             <div className="flex flex-col shrink-0 justify-between">
               <div>
@@ -368,7 +381,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
   if (variant === 'stock-3x2') {
     return (
       <>
-        <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+        <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleCardClick}>
           <div className="flex items-start justify-between mb-1.5 shrink-0">
             <div className="flex items-center gap-2">
               <StockAvatar name={stock.name} stockCode={stock.code} marketType={stock.marketType} color={stock.color} size="sm" />
@@ -411,7 +424,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
   if (variant === 'stock-2x2') {
     return (
       <>
-        <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+        <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleCardClick}>
           <div className="flex items-start justify-between mb-1.5 shrink-0">
             <div className="flex items-center gap-2">
               <StockAvatar name={stock.name} stockCode={stock.code} marketType={stock.marketType} color={stock.color} size="sm" />
@@ -453,7 +466,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
   /* stock-sm (default) */
   return (
     <>
-      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleCardClick}>
         <div className="flex items-center justify-between shrink-0">
           <div className="flex items-center gap-1.5">
             <StockAvatar name={stock.name} stockCode={stock.code} marketType={stock.marketType} color={stock.color} size="sm" />

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -84,6 +84,7 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
         stockCode,
         stockName:    stockName ?? stockMeta.name,
         marketType:   config.marketType ?? stockMeta.market ?? null,
+        exchangeCode: config.exchangeCode ?? null,
         widgetPeriod: activePeriod,
       },
     })

--- a/src/components/widgets/StockNewsWidget.jsx
+++ b/src/components/widgets/StockNewsWidget.jsx
@@ -1,93 +1,155 @@
+import { useState } from 'react'
+import { ChevronDown } from 'lucide-react'
 import WidgetCard from './WidgetCard'
+import StockSelectModal from './StockSelectModal'
+import useStockNews from '@/features/market/useStockNews'
+import useWidgetStore from '@/store/useWidgetStore'
+import useWidgetDetailStore from '@/store/useWidgetDetailStore'
 
-const MOCK_STOCK = { name: '삼성전자', code: '005930' }
-
-const MOCK_NEWS = [
-  { title: 'HBM 공급 본격화 — 엔비디아향 납품 재개', desc: '3분기 HBM3E 공급 계약 확인. AI 서버 수요 확대로 수혜 기대.' },
-  { title: '외국인 6거래일 연속 순매수', desc: '누적 순매수 1.2조원. 반도체 업황 개선 기대에 외국인 수급 집중.' },
-  { title: '파운드리 2나노 시범 생산 개시', desc: '하반기 양산 목표로 TSMC와 경쟁 본격화.' },
-]
-
-function StockChip({ showCode = false }) {
+function StockChip({ name, onClick }) {
   return (
-    <span className="text-[9px] font-semibold text-primary bg-primary-light px-1.5 py-px rounded shrink-0">
-      {MOCK_STOCK.name}{showCode && ` ${MOCK_STOCK.code}`}
-    </span>
+    <button
+      onClick={onClick}
+      className="flex items-center gap-0.5 text-[9px] font-semibold text-primary shrink-0 hover:opacity-70"
+    >
+      {name ?? '종목 선택'}
+      <ChevronDown size={10} />
+    </button>
   )
 }
 
-export default function StockNewsWidget({ variant = 'stock-news-sm', colSpan = 1, rowSpan = 1, onDelete }) {
+function NewsCard({ item, onClickNews }) {
+  return (
+    <div
+      className="flex gap-2 py-2 border-b border-stroke last:border-b-0 cursor-pointer pl-2 border-l-2 border-l-transparent hover:border-l-primary transition-colors"
+      onClick={(e) => { e.stopPropagation(); onClickNews(item.newsId) }}
+    >
+      <div className="flex-1 flex flex-col gap-0.5 min-w-0">
+        <p className="text-[11px] font-semibold text-foreground leading-snug line-clamp-2">
+          {item.title}
+        </p>
+        <div className="flex items-center gap-1.5 mt-0.5">
+          {item.source && <span className="text-[9px] text-foreground-disabled">{item.source}</span>}
+          {item.source && item.publishedAt && <span className="text-[9px] text-stroke">·</span>}
+          {item.publishedAt && <span className="text-[9px] text-foreground-disabled">{item.publishedAt}</span>}
+        </div>
+      </div>
+      {item.thumbnailUrl && (
+        <img
+          src={item.thumbnailUrl}
+          alt=""
+          className="w-10 h-10 object-cover rounded-lg shrink-0"
+          onError={(e) => { e.currentTarget.style.display = 'none' }}
+        />
+      )}
+    </div>
+  )
+}
+
+function NewsListCompact({ items, onClickNews }) {
+  return items.map((item, i) => (
+    <div
+      key={item.newsId ?? i}
+      className="flex items-start gap-1.5 py-1 border-b border-stroke last:border-b-0 cursor-pointer pl-2 border-l-2 border-l-transparent hover:border-l-primary transition-colors"
+      onClick={(e) => { e.stopPropagation(); onClickNews(item.newsId) }}
+    >
+      <span className="text-[9px] font-bold text-primary mt-[1px] shrink-0">{i + 1}</span>
+      <p className="text-[10px] text-foreground leading-snug line-clamp-2">{item.title}</p>
+    </div>
+  ))
+}
+
+export default function StockNewsWidget({ instanceId, variant = 'stock-news-sm', colSpan = 1, rowSpan = 1, config = {}, onDelete }) {
+  const [showModal, setShowModal] = useState(false)
+  const updateWidgetConfig = useWidgetStore((s) => s.updateWidgetConfig)
+  const openDetail = useWidgetDetailStore((s) => s.open)
+
+  const stockCode = config.stockCode ?? null
+  const stockName = config.stockName ?? null
+
+  const size = variant === 'stock-news-2x2' ? 5 : 3
+  const { news, isLoading } = useStockNews(stockCode, size)
+
+  function handleStockSave({ stockCode: newCode, stockName: newName }) {
+    updateWidgetConfig(instanceId, { stockCode: newCode, stockName: newName })
+    setShowModal(false)
+  }
+
+  function handleWidgetClick() {
+    if (!stockCode) return
+    openDetail({ widgetTypeId: 'stock-news', config: { stockCode, stockName } })
+  }
+
+  function handleNewsClick(newsId) {
+    openDetail({ widgetTypeId: 'stock-news', config: { stockCode, stockName, newsId } })
+  }
+
+  const chip = (
+    <StockChip
+      name={stockName}
+      onClick={(e) => { e.stopPropagation(); setShowModal(true) }}
+    />
+  )
+  const empty   = <p className="text-[10px] text-foreground-disabled py-2">뉴스가 없습니다</p>
+  const loading = <p className="text-[10px] text-foreground-disabled py-2">로딩 중...</p>
+  const noStock = <p className="text-[10px] text-foreground-disabled py-2">종목을 선택하세요</p>
+
+  const modal = showModal && (
+    <StockSelectModal
+      currentCode={stockCode}
+      currentName={stockName}
+      onSave={handleStockSave}
+      onClose={() => setShowModal(false)}
+    />
+  )
+
   if (variant === 'stock-news-2x2') {
     return (
-      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-        <div className="flex items-center justify-between mb-2 shrink-0">
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
+        <div className="flex items-center justify-between mb-1 shrink-0">
           <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 뉴스</span>
-          <StockChip showCode />
+          {chip}
         </div>
-        <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-2">
-          {MOCK_NEWS.map((item, i) => (
-            <div
-              key={i}
-              className={`px-2.5 py-2 rounded-xl border-l-[3px] ${
-                i === 0
-                  ? 'bg-primary-light border-primary'
-                  : 'bg-surface-subtle border-stroke'
-              }`}
-            >
-              <p className="text-[11px] font-bold text-foreground leading-snug">{item.title}</p>
-              <p className="text-[9px] text-foreground-disabled leading-relaxed mt-0.5">{item.desc}</p>
-            </div>
-          ))}
+        <div className="flex-1 min-h-0 overflow-y-auto">
+          {isLoading ? loading : !stockCode ? noStock : !news.length ? empty :
+            news.map((item, i) => <NewsCard key={item.newsId ?? i} item={item} onClickNews={handleNewsClick} />)
+          }
         </div>
+        {modal}
       </WidgetCard>
     )
   }
 
   if (variant === 'stock-news-wide') {
     return (
-      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-        <div className="flex items-center justify-between mb-2 shrink-0">
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
+        <div className="flex items-center justify-between mb-1 shrink-0">
           <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 뉴스</span>
-          <StockChip showCode />
+          {chip}
         </div>
-        <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-2">
-          {MOCK_NEWS.slice(0, 2).map((item, i) => (
-            <div
-              key={i}
-              className={`px-2 py-1.5 rounded-lg border-l-[3px] ${
-                i === 0
-                  ? 'bg-primary-light border-primary'
-                  : 'bg-surface-subtle border-stroke'
-              }`}
-            >
-              <p className="text-[10px] font-bold text-foreground leading-snug">{item.title}</p>
-              <p className="text-[9px] text-foreground-disabled leading-relaxed mt-0.5">{item.desc}</p>
-            </div>
-          ))}
+        <div className="flex-1 min-h-0 overflow-y-auto">
+          {isLoading ? loading : !stockCode ? noStock : !news.length ? empty :
+            news.slice(0, 2).map((item, i) => <NewsCard key={item.newsId ?? i} item={item} onClickNews={handleNewsClick} />)
+          }
         </div>
+        {modal}
       </WidgetCard>
     )
   }
 
-  /* stock-news-sm (default) — 헤드라인 3줄 */
+  /* stock-news-sm */
   return (
-    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-      <div className="flex items-center justify-between mb-2">
+    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
+      <div className="flex items-center justify-between mb-1 shrink-0">
         <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 뉴스</span>
-        <StockChip />
+        {chip}
       </div>
-      <div className="flex-1 flex flex-col gap-1.5 overflow-hidden">
-        {MOCK_NEWS.map((item, i) => (
-          <p
-            key={i}
-            className={`text-[10px] leading-snug truncate ${
-              i === 0 ? 'font-bold text-foreground' : 'text-foreground-disabled'
-            }`}
-          >
-            {item.title}
-          </p>
-        ))}
+      <div className="flex-1 flex flex-col overflow-hidden">
+        {isLoading ? loading : !stockCode ? noStock : !news.length ? empty :
+          <NewsListCompact items={news} onClickNews={handleNewsClick} />
+        }
       </div>
+      {modal}
     </WidgetCard>
   )
 }

--- a/src/components/widgets/StockNewsWidget.jsx
+++ b/src/components/widgets/StockNewsWidget.jsx
@@ -10,7 +10,7 @@ function StockChip({ name, onClick }) {
   return (
     <button
       onClick={onClick}
-      className="flex items-center gap-0.5 text-[9px] font-semibold text-primary shrink-0 hover:opacity-70"
+      className="flex items-center gap-0.5 text-widget-9 font-semibold text-primary shrink-0 hover:opacity-70"
     >
       {name ?? '종목 선택'}
       <ChevronDown size={10} />
@@ -25,13 +25,13 @@ function NewsCard({ item, onClickNews }) {
       onClick={(e) => { e.stopPropagation(); onClickNews(item.newsId) }}
     >
       <div className="flex-1 flex flex-col gap-0.5 min-w-0">
-        <p className="text-[11px] font-semibold text-foreground leading-snug line-clamp-2">
+        <p className="text-widget-11 font-semibold text-foreground leading-snug line-clamp-2">
           {item.title}
         </p>
         <div className="flex items-center gap-1.5 mt-0.5">
-          {item.source && <span className="text-[9px] text-foreground-disabled">{item.source}</span>}
-          {item.source && item.publishedAt && <span className="text-[9px] text-stroke">·</span>}
-          {item.publishedAt && <span className="text-[9px] text-foreground-disabled">{item.publishedAt}</span>}
+          {item.source && <span className="text-widget-9 text-foreground-disabled">{item.source}</span>}
+          {item.source && item.publishedAt && <span className="text-widget-9 text-stroke">·</span>}
+          {item.publishedAt && <span className="text-widget-9 text-foreground-disabled">{item.publishedAt}</span>}
         </div>
       </div>
       {item.thumbnailUrl && (
@@ -53,8 +53,8 @@ function NewsListCompact({ items, onClickNews }) {
       className="flex items-start gap-1.5 py-1 border-b border-stroke last:border-b-0 cursor-pointer pl-2 border-l-2 border-l-transparent hover:border-l-primary transition-colors"
       onClick={(e) => { e.stopPropagation(); onClickNews(item.newsId) }}
     >
-      <span className="text-[9px] font-bold text-primary mt-[1px] shrink-0">{i + 1}</span>
-      <p className="text-[10px] text-foreground leading-snug line-clamp-2">{item.title}</p>
+      <span className="text-widget-9 font-bold text-primary mt-[1px] shrink-0">{i + 1}</span>
+      <p className="text-widget-10 text-foreground leading-snug line-clamp-2">{item.title}</p>
     </div>
   ))
 }
@@ -90,9 +90,9 @@ export default function StockNewsWidget({ instanceId, variant = 'stock-news-sm',
       onClick={(e) => { e.stopPropagation(); setShowModal(true) }}
     />
   )
-  const empty   = <p className="text-[10px] text-foreground-disabled py-2">뉴스가 없습니다</p>
-  const loading = <p className="text-[10px] text-foreground-disabled py-2">로딩 중...</p>
-  const noStock = <p className="text-[10px] text-foreground-disabled py-2">종목을 선택하세요</p>
+  const empty   = <p className="text-widget-10 text-foreground-disabled py-2">뉴스가 없습니다</p>
+  const loading = <p className="text-widget-10 text-foreground-disabled py-2">로딩 중...</p>
+  const noStock = <p className="text-widget-10 text-foreground-disabled py-2">종목을 선택하세요</p>
 
   const modal = showModal && (
     <StockSelectModal
@@ -107,7 +107,7 @@ export default function StockNewsWidget({ instanceId, variant = 'stock-news-sm',
     return (
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
         <div className="flex items-center justify-between mb-1 shrink-0">
-          <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 뉴스</span>
+          <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 뉴스</span>
           {chip}
         </div>
         <div className="flex-1 min-h-0 overflow-y-auto">
@@ -124,7 +124,7 @@ export default function StockNewsWidget({ instanceId, variant = 'stock-news-sm',
     return (
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
         <div className="flex items-center justify-between mb-1 shrink-0">
-          <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 뉴스</span>
+          <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 뉴스</span>
           {chip}
         </div>
         <div className="flex-1 min-h-0 overflow-y-auto">
@@ -141,7 +141,7 @@ export default function StockNewsWidget({ instanceId, variant = 'stock-news-sm',
   return (
     <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
       <div className="flex items-center justify-between mb-1 shrink-0">
-        <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 뉴스</span>
+        <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 뉴스</span>
         {chip}
       </div>
       <div className="flex-1 flex flex-col overflow-hidden">

--- a/src/components/widgets/TradeHistoryWidget.jsx
+++ b/src/components/widgets/TradeHistoryWidget.jsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import LockedOverlay from '@/components/ui/LockedOverlay'
 import useAuthStore from '@/store/useAuthStore'
+import useWidgetDetailStore from '@/store/useWidgetDetailStore'
 import WidgetCard from './WidgetCard'
 import { cn } from '@/lib/cn'
 import { orderApi } from '@/api/order'
@@ -30,7 +31,9 @@ function buildTradeMap(orders) {
     const d = new Date(raw.length === 10 ? raw + 'T00:00:00' : raw)
     const k = dateKey(d)
     if (!map[k]) map[k] = []
-    map[k].push({ s: o.stockName, buy: o.orderSide === 'BUY' })
+    const buy = o.orderSide === 'BUY'
+    const isDup = map[k].some((t) => t.s === o.stockName && t.buy === buy)
+    if (!isDup) map[k].push({ s: o.stockName, buy })
   })
   return map
 }
@@ -65,6 +68,8 @@ function useFilledOrders(enabled) {
 
 export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1, rowSpan = 1, onDelete }) {
   const { isAuthenticated, isRestoring } = useAuthStore()
+  const open = useWidgetDetailStore((s) => s.open)
+  const handleCardClick = () => open({ widgetTypeId: 'trade-history', config: {} })
   const { data: orders, isLoading } = useFilledOrders(isAuthenticated && !isRestoring)
 
   const now = new Date()
@@ -90,7 +95,7 @@ export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1
   /* ── trade-3x2: 캘린더 + 목록 3×2 ── */
   if (variant === 'trade-3x2') {
     return (
-      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleCardClick}>
         <div className="flex items-center justify-between mb-2 shrink-0">
           <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">거래내역</span>
           <span className="text-[9px] text-foreground-disabled">{monthLabel}</span>
@@ -159,7 +164,7 @@ export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1
   /* ── trade-wide: 주간 캘린더 2×1 ── */
   if (variant === 'trade-wide') {
     return (
-      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleCardClick}>
         <div className="flex items-center justify-between mb-2 shrink-0">
           <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">거래내역</span>
           <span className="text-[9px] text-foreground-disabled">{monthLabel}</span>
@@ -193,7 +198,7 @@ export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1
   /* ── trade-cal: 월간 캘린더 2×2 ── */
   if (variant === 'trade-cal') {
     return (
-      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleCardClick}>
         <div className="flex items-center justify-between mb-2 shrink-0">
           <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">거래내역</span>
           <span className="text-[9px] text-foreground-disabled">{monthLabel}</span>
@@ -229,7 +234,7 @@ export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1
 
   /* ── trade-list: 목록형 1×1 (default) ── */
   return (
-    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+    <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleCardClick}>
       <div className="flex items-center justify-between mb-2 shrink-0">
         <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">거래내역</span>
       </div>

--- a/src/components/widgets/WatchlistWidget.jsx
+++ b/src/components/widgets/WatchlistWidget.jsx
@@ -78,7 +78,7 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
   const addBtn = (
     <button
       onClick={(e) => { e.stopPropagation(); setIsAddOpen(true) }}
-      className="text-[10px] text-primary font-semibold hover:underline"
+      className="text-widget-10 text-primary font-semibold hover:underline"
     >
       + 추가
     </button>
@@ -89,26 +89,26 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
       <>
         <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
           <div className="flex items-center justify-between mb-2 shrink-0">
-            <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">관심 종목</span>
+            <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">관심 종목</span>
             {addBtn}
           </div>
           <div className="flex-1 flex flex-col gap-1.5 min-h-0">
             {isError
-              ? <span className="text-[10px] text-foreground-disabled">불러오기에 실패했습니다</span>
+              ? <span className="text-widget-10 text-foreground-disabled">불러오기에 실패했습니다</span>
               : list.length > 0 ? list.map((item) => (
               <div
                 key={item.stockCode}
                 onClick={(e) => handleStockClick(e, item)}
                 className="flex items-center justify-between gap-2 group cursor-pointer pl-1.5 border-l-2 border-l-transparent hover:border-l-primary transition-colors"
               >
-                <span className="text-[10px] font-medium text-foreground truncate">{item.stockName}</span>
+                <span className="text-widget-10 font-medium text-foreground truncate">{item.stockName}</span>
                 <div className="flex items-center gap-1.5 shrink-0">
                   {fmtPrice(item.currentPrice, item.marketType) && (
-                    <span className="text-[10px] font-semibold text-foreground tabular-nums">
+                    <span className="text-widget-10 font-semibold text-foreground tabular-nums">
                       {fmtPrice(item.currentPrice, item.marketType)}
                     </span>
                   )}
-                  <PriceChange value={item.changeRate} className="text-[9px] font-medium" />
+                  <PriceChange value={item.changeRate} className="text-widget-9 font-medium" />
                   <button
                     onClick={(e) => handleRemove(e, item.stockCode)}
                     className="opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded text-foreground-disabled hover:text-down"
@@ -118,7 +118,7 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
                 </div>
               </div>
             )) : (
-              <div className="flex-1 flex items-center justify-center text-[9px] text-foreground-disabled">관심 종목 없음</div>
+              <div className="flex-1 flex items-center justify-center text-widget-9 text-foreground-disabled">관심 종목 없음</div>
             )}
           </div>
           {!isRestoring && !isAuthenticated && <LockedOverlay message="관심 종목을 보려면" />}
@@ -133,21 +133,21 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
     <>
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
         <div className="flex items-center justify-between mb-2 shrink-0">
-          <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">관심 종목</span>
+          <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">관심 종목</span>
           {addBtn}
         </div>
         <div className="flex-1 flex flex-col gap-1.5 min-h-0">
           {isError
-            ? <span className="text-[10px] text-foreground-disabled">불러오기에 실패했습니다</span>
+            ? <span className="text-widget-10 text-foreground-disabled">불러오기에 실패했습니다</span>
             : list.length > 0 ? list.map((item) => (
             <div
               key={item.stockCode}
               onClick={(e) => handleStockClick(e, item)}
               className="flex items-center justify-between group cursor-pointer pl-1.5 border-l-2 border-l-transparent hover:border-l-primary transition-colors"
             >
-              <span className="text-[10px] font-medium text-foreground truncate">{item.stockName}</span>
+              <span className="text-widget-10 font-medium text-foreground truncate">{item.stockName}</span>
               <div className="flex items-center gap-1 shrink-0">
-                <PriceChange value={item.changeRate} className="text-[9px] font-semibold" />
+                <PriceChange value={item.changeRate} className="text-widget-9 font-semibold" />
                 <button
                   onClick={(e) => handleRemove(e, item.stockCode)}
                   className="opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded text-foreground-disabled hover:text-down"
@@ -157,7 +157,7 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
               </div>
             </div>
           )) : (
-            <div className="flex-1 flex items-center justify-center text-[9px] text-foreground-disabled">관심 종목 없음</div>
+            <div className="flex-1 flex items-center justify-center text-widget-9 text-foreground-disabled">관심 종목 없음</div>
           )}
         </div>
         {!isRestoring && !isAuthenticated && <LockedOverlay message="관심 종목을 보려면" />}

--- a/src/components/widgets/WatchlistWidget.jsx
+++ b/src/components/widgets/WatchlistWidget.jsx
@@ -119,7 +119,7 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
   /* watchlist-sm (default) */
   return (
     <>
-      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+      <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
         <div className="flex items-center justify-between mb-2 shrink-0">
           <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">관심 종목</span>
           {addBtn}

--- a/src/components/widgets/WatchlistWidget.jsx
+++ b/src/components/widgets/WatchlistWidget.jsx
@@ -8,11 +8,15 @@ import WidgetCard from './WidgetCard'
 import StockSelectModal from './StockSelectModal'
 import { useWatchlist, watchlistApi } from '@/api/watchlist'
 import useWidgetDetailStore from '@/store/useWidgetDetailStore'
+import { isForeignMarketType } from '@/features/invest/formatters'
 
 const EXCHANGE_CODE_BY_MARKET_TYPE = { NASDAQ: 'NAS', NYSE: 'NYS', AMEX: 'AMS' }
 
-function fmtPrice(n) {
-  return `₩${Number(n ?? 0).toLocaleString('ko-KR')}`
+function fmtPrice(n, marketType) {
+  if (n == null) return null
+  return isForeignMarketType(marketType)
+    ? `$${Number(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+    : `₩${Number(n).toLocaleString('ko-KR')}`
 }
 
 function useWatchlistMutations() {
@@ -99,7 +103,11 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
               >
                 <span className="text-[10px] font-medium text-foreground truncate">{item.stockName}</span>
                 <div className="flex items-center gap-1.5 shrink-0">
-                  <span className="text-[10px] font-semibold text-foreground">{fmtPrice(item.currentPrice)}</span>
+                  {fmtPrice(item.currentPrice, item.marketType) && (
+                    <span className="text-[10px] font-semibold text-foreground tabular-nums">
+                      {fmtPrice(item.currentPrice, item.marketType)}
+                    </span>
+                  )}
                   <PriceChange value={item.changeRate} className="text-[9px] font-medium" />
                   <button
                     onClick={(e) => handleRemove(e, item.stockCode)}

--- a/src/components/widgets/WatchlistWidget.jsx
+++ b/src/components/widgets/WatchlistWidget.jsx
@@ -9,6 +9,8 @@ import StockSelectModal from './StockSelectModal'
 import { useWatchlist, watchlistApi } from '@/api/watchlist'
 import useWidgetDetailStore from '@/store/useWidgetDetailStore'
 
+const EXCHANGE_CODE_BY_MARKET_TYPE = { NASDAQ: 'NAS', NYSE: 'NYS', AMEX: 'AMS' }
+
 function fmtPrice(n) {
   return `₩${Number(n ?? 0).toLocaleString('ko-KR')}`
 }
@@ -43,9 +45,11 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
 
   function handleStockClick(e, item) {
     e.stopPropagation()
+    const marketType   = item.marketType ?? null
+    const exchangeCode = item.exchangeCode ?? EXCHANGE_CODE_BY_MARKET_TYPE[marketType] ?? null
     openDetail({
       widgetTypeId: 'stock-chart',
-      config: { stockCode: item.stockCode, stockName: item.stockName, marketType: item.marketType ?? null },
+      config: { stockCode: item.stockCode, stockName: item.stockName, marketType, exchangeCode },
     })
   }
 

--- a/src/components/widgets/WatchlistWidget.jsx
+++ b/src/components/widgets/WatchlistWidget.jsx
@@ -7,6 +7,7 @@ import useAuthStore from '@/store/useAuthStore'
 import WidgetCard from './WidgetCard'
 import StockSelectModal from './StockSelectModal'
 import { useWatchlist, watchlistApi } from '@/api/watchlist'
+import useWidgetDetailStore from '@/store/useWidgetDetailStore'
 
 function fmtPrice(n) {
   return `₩${Number(n ?? 0).toLocaleString('ko-KR')}`
@@ -34,6 +35,19 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
   const { data: items = [], isError } = useWatchlist({ enabled: isAuthenticated && !isRestoring })
   const { add, remove } = useWatchlistMutations()
   const [isAddOpen, setIsAddOpen] = useState(false)
+  const openDetail = useWidgetDetailStore((s) => s.open)
+
+  function handleWidgetClick() {
+    openDetail({ widgetTypeId: 'watchlist', config: {} })
+  }
+
+  function handleStockClick(e, item) {
+    e.stopPropagation()
+    openDetail({
+      widgetTypeId: 'stock-chart',
+      config: { stockCode: item.stockCode, stockName: item.stockName, marketType: item.marketType ?? null },
+    })
+  }
 
   const list = items.slice(0, 5)
 
@@ -65,7 +79,7 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
   if (variant === 'watchlist-wide') {
     return (
       <>
-        <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
+        <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
           <div className="flex items-center justify-between mb-2 shrink-0">
             <span className="text-[10px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">관심 종목</span>
             {addBtn}
@@ -73,14 +87,18 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
           <div className="flex-1 flex flex-col gap-1.5 min-h-0">
             {isError
               ? <span className="text-[10px] text-foreground-disabled">불러오기에 실패했습니다</span>
-              : list.length > 0 ? list.map(({ stockCode, stockName, currentPrice, changeRate }) => (
-              <div key={stockCode} className="flex items-center justify-between gap-2 group">
-                <span className="text-[10px] font-medium text-foreground truncate">{stockName}</span>
+              : list.length > 0 ? list.map((item) => (
+              <div
+                key={item.stockCode}
+                onClick={(e) => handleStockClick(e, item)}
+                className="flex items-center justify-between gap-2 group cursor-pointer pl-1.5 border-l-2 border-l-transparent hover:border-l-primary transition-colors"
+              >
+                <span className="text-[10px] font-medium text-foreground truncate">{item.stockName}</span>
                 <div className="flex items-center gap-1.5 shrink-0">
-                  <span className="text-[10px] font-semibold text-foreground">{fmtPrice(currentPrice)}</span>
-                  <PriceChange value={changeRate} className="text-[9px] font-medium" />
+                  <span className="text-[10px] font-semibold text-foreground">{fmtPrice(item.currentPrice)}</span>
+                  <PriceChange value={item.changeRate} className="text-[9px] font-medium" />
                   <button
-                    onClick={(e) => handleRemove(e, stockCode)}
+                    onClick={(e) => handleRemove(e, item.stockCode)}
                     className="opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded text-foreground-disabled hover:text-down"
                   >
                     <X className="w-3 h-3" />
@@ -109,13 +127,17 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
         <div className="flex-1 flex flex-col gap-1.5 min-h-0">
           {isError
             ? <span className="text-[10px] text-foreground-disabled">불러오기에 실패했습니다</span>
-            : list.length > 0 ? list.map(({ stockCode, stockName, changeRate }) => (
-            <div key={stockCode} className="flex items-center justify-between group">
-              <span className="text-[10px] font-medium text-foreground truncate">{stockName}</span>
+            : list.length > 0 ? list.map((item) => (
+            <div
+              key={item.stockCode}
+              onClick={(e) => handleStockClick(e, item)}
+              className="flex items-center justify-between group cursor-pointer pl-1.5 border-l-2 border-l-transparent hover:border-l-primary transition-colors"
+            >
+              <span className="text-[10px] font-medium text-foreground truncate">{item.stockName}</span>
               <div className="flex items-center gap-1 shrink-0">
-                <PriceChange value={changeRate} className="text-[9px] font-semibold" />
+                <PriceChange value={item.changeRate} className="text-[9px] font-semibold" />
                 <button
-                  onClick={(e) => handleRemove(e, stockCode)}
+                  onClick={(e) => handleRemove(e, item.stockCode)}
                   className="opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded text-foreground-disabled hover:text-down"
                 >
                   <X className="w-3 h-3" />

--- a/src/components/widgets/WidgetCard.jsx
+++ b/src/components/widgets/WidgetCard.jsx
@@ -23,7 +23,7 @@ export default function WidgetCard({ children, className = '', onDelete, onClick
       >
         <div
           className={cn(
-            'h-full bg-surface border rounded-2xl p-[14px_16px]',
+            'h-full bg-surface border rounded-2xl p-[14px_16px] overflow-hidden',
             'flex flex-col',
             isEditMode
               ? 'border-stroke-input shadow-widget-edit'

--- a/src/components/widgets/WidgetCard.jsx
+++ b/src/components/widgets/WidgetCard.jsx
@@ -2,7 +2,7 @@ import useEditModeStore from '@/store/useEditModeStore'
 import EditHandle from './EditHandle'
 import { cn } from '@/lib/cn'
 
-export default function WidgetCard({ children, className = '', onDelete }) {
+export default function WidgetCard({ children, className = '', onDelete, onClick }) {
   const { isEditMode, wiggleDelay, wiggleSyncKey } = useEditModeStore()
 
   return (
@@ -19,6 +19,7 @@ export default function WidgetCard({ children, className = '', onDelete }) {
             : 'cursor-pointer',
         )}
         style={isEditMode ? { animationDelay: `${wiggleDelay}ms` } : undefined}
+        onClick={!isEditMode ? onClick : undefined}
       >
         <div
           className={cn(

--- a/src/components/widgets/WidgetDetailModal.jsx
+++ b/src/components/widgets/WidgetDetailModal.jsx
@@ -1,0 +1,126 @@
+import { useState, useRef, useEffect } from 'react'
+import { X } from 'lucide-react'
+import useWidgetDetailStore from '@/store/useWidgetDetailStore'
+import StockChartDetail from './detail/StockChartDetail'
+import BalanceDetail from './detail/BalanceDetail'
+import { cn } from '@/lib/cn'
+
+const DETAIL_MAP = {
+  'stock-chart': StockChartDetail,
+  'balance':     BalanceDetail,
+}
+
+const DRAG_CLOSE_THRESHOLD = 80
+
+export default function WidgetDetailModal() {
+  const { openWidget, close } = useWidgetDetailStore()
+  const [isClosing, setIsClosing] = useState(false)
+  const localWidget  = useRef(null)
+  const closeTimer   = useRef(null)
+  const sheetRef     = useRef(null)
+  const dragStartY   = useRef(null)
+  const dragCurrentY = useRef(0)
+
+  if (openWidget) localWidget.current = openWidget
+
+  useEffect(() => {
+    if (openWidget) {
+      if (closeTimer.current) {
+        clearTimeout(closeTimer.current)
+        closeTimer.current = null
+      }
+      setIsClosing(false)
+    }
+  }, [openWidget])
+
+  const handleClose = () => {
+    setIsClosing(true)
+    closeTimer.current = setTimeout(() => {
+      close()
+      setIsClosing(false)
+    }, 240)
+  }
+
+  // ── 드래그 (DOM 직접 조작 — 리렌더 없음) ─────────────────
+  const handlePointerDown = (e) => {
+    dragStartY.current   = e.clientY
+    dragCurrentY.current = 0
+    e.currentTarget.setPointerCapture(e.pointerId)
+    if (sheetRef.current) sheetRef.current.style.transition = 'none'
+  }
+
+  const handlePointerMove = (e) => {
+    if (dragStartY.current === null) return
+    const delta = Math.max(0, e.clientY - dragStartY.current)
+    dragCurrentY.current = delta
+    if (sheetRef.current) sheetRef.current.style.transform = `translateY(${delta}px)`
+  }
+
+  const handlePointerUp = () => {
+    if (dragStartY.current === null) return
+    dragStartY.current = null
+
+    if (dragCurrentY.current >= DRAG_CLOSE_THRESHOLD) {
+      handleClose()
+    } else {
+      // 스냅백
+      if (sheetRef.current) {
+        sheetRef.current.style.transition = 'transform 200ms ease'
+        sheetRef.current.style.transform  = ''
+      }
+      dragCurrentY.current = 0
+    }
+  }
+
+  if (!openWidget && !isClosing) return null
+
+  const DetailComp = localWidget.current ? DETAIL_MAP[localWidget.current.widgetTypeId] : null
+  if (!DetailComp) return null
+
+  return (
+    <div className="absolute inset-0 z-40 flex flex-col justify-end pointer-events-none">
+      {/* 배경 딤 */}
+      <div
+        className={cn(
+          'absolute inset-0 pointer-events-auto transition-opacity duration-[240ms]',
+          isClosing ? 'opacity-0' : 'opacity-100 bg-black/10',
+        )}
+        onClick={handleClose}
+      />
+
+      {/* 시트 */}
+      <div
+        ref={sheetRef}
+        className={cn(
+          'relative bg-surface rounded-t-[20px] shadow-modal flex flex-col pointer-events-auto',
+          isClosing ? 'animate-slide-down' : 'animate-slide-up',
+        )}
+        style={{ height: '99%' }}
+      >
+        {/* 드래그 핸들 + 닫기 버튼 */}
+        <div
+          className="flex items-center justify-between pt-2.5 pb-1.5 px-4 shrink-0 cursor-grab active:cursor-grabbing"
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          style={{ touchAction: 'none' }}
+        >
+          <div className="w-6" />
+          <div className="w-9 h-1 rounded-full bg-stroke" />
+          <button
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={handleClose}
+            className="p-1 rounded-lg hover:bg-surface-muted transition-colors"
+          >
+            <X className="w-4 h-4 text-foreground-tertiary" />
+          </button>
+        </div>
+
+        <DetailComp
+          config={localWidget.current.config}
+          onClose={handleClose}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/widgets/WidgetDetailModal.jsx
+++ b/src/components/widgets/WidgetDetailModal.jsx
@@ -92,22 +92,21 @@ export default function WidgetDetailModal() {
       <div
         ref={sheetRef}
         className={cn(
-          'relative bg-surface rounded-t-[20px] shadow-modal flex flex-col pointer-events-auto',
+          'relative bg-surface rounded-t-[20px] shadow-modal flex flex-col pointer-events-auto h-[99%]',
           isClosing ? 'animate-slide-down' : 'animate-slide-up',
         )}
-        style={{ height: '99%' }}
       >
         {/* 드래그 핸들 + 닫기 버튼 */}
         <div
-          className="flex items-center justify-between pt-2.5 pb-1.5 px-4 shrink-0 cursor-grab active:cursor-grabbing"
+          className="flex items-center justify-between pt-2.5 pb-1.5 px-4 shrink-0 cursor-grab active:cursor-grabbing touch-none"
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}
-          style={{ touchAction: 'none' }}
         >
           <div className="w-6" />
           <div className="w-9 h-1 rounded-full bg-stroke" />
           <button
+            aria-label="닫기"
             onPointerDown={(e) => e.stopPropagation()}
             onClick={handleClose}
             className="p-1 rounded-lg hover:bg-surface-muted transition-colors"

--- a/src/components/widgets/WidgetDetailModal.jsx
+++ b/src/components/widgets/WidgetDetailModal.jsx
@@ -103,7 +103,7 @@ export default function WidgetDetailModal() {
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}
         >
-          <div className="absolute left-1/2 -translate-x-1/2 w-9 h-1 rounded-full bg-primary" />
+          <div className="absolute left-1/2 -translate-x-1/2 w-9 h-1 rounded-full bg-stroke" />
           <button
             aria-label="닫기"
             onPointerDown={(e) => e.stopPropagation()}

--- a/src/components/widgets/WidgetDetailModal.jsx
+++ b/src/components/widgets/WidgetDetailModal.jsx
@@ -103,7 +103,7 @@ export default function WidgetDetailModal() {
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}
         >
-          <div className="absolute left-1/2 -translate-x-1/2 w-9 h-1 rounded-full bg-stroke" />
+          <div className="absolute left-1/2 -translate-x-1/2 w-9 h-1 rounded-full bg-primary" />
           <button
             aria-label="닫기"
             onPointerDown={(e) => e.stopPropagation()}

--- a/src/components/widgets/WidgetDetailModal.jsx
+++ b/src/components/widgets/WidgetDetailModal.jsx
@@ -8,6 +8,7 @@ import IndexDetail from './detail/IndexDetail'
 import MarketNewsDetail from './detail/MarketNewsDetail'
 import StockNewsDetail from './detail/StockNewsDetail'
 import WatchlistDetail from './detail/WatchlistDetail'
+import ExchangeDetail from './detail/ExchangeDetail'
 import { cn } from '@/lib/cn'
 
 const DETAIL_MAP = {
@@ -18,6 +19,7 @@ const DETAIL_MAP = {
   'market-overview': MarketNewsDetail,
   'stock-news':      StockNewsDetail,
   'watchlist':       WatchlistDetail,
+  'exchange':        ExchangeDetail,
 }
 
 const DRAG_CLOSE_THRESHOLD = 80
@@ -25,6 +27,7 @@ const DRAG_CLOSE_THRESHOLD = 80
 export default function WidgetDetailModal() {
   const { openWidget, close } = useWidgetDetailStore()
   const [isClosing, setIsClosing] = useState(false)
+  const [slideUpDone, setSlideUpDone] = useState(false)
   const localWidget  = useRef(null)
   const closeTimer   = useRef(null)
   const sheetRef     = useRef(null)
@@ -40,6 +43,7 @@ export default function WidgetDetailModal() {
         closeTimer.current = null
       }
       setIsClosing(false)
+      setSlideUpDone(false)
     }
   }, [openWidget])
 
@@ -103,8 +107,9 @@ export default function WidgetDetailModal() {
         ref={sheetRef}
         className={cn(
           'relative bg-surface rounded-t-[20px] shadow-modal flex flex-col pointer-events-auto h-[99%]',
-          isClosing ? 'animate-slide-down' : 'animate-slide-up',
+          isClosing ? 'animate-slide-down' : slideUpDone ? '' : 'animate-slide-up',
         )}
+        onAnimationEnd={(e) => { if (e.animationName === 'slide-up') setSlideUpDone(true) }}
       >
         {/* 드래그 핸들 + 닫기 버튼 */}
         <div

--- a/src/components/widgets/WidgetDetailModal.jsx
+++ b/src/components/widgets/WidgetDetailModal.jsx
@@ -98,13 +98,13 @@ export default function WidgetDetailModal() {
       >
         {/* 드래그 핸들 + 닫기 버튼 */}
         <div
-          className="flex items-center justify-between pt-2.5 pb-1.5 px-4 shrink-0 cursor-grab active:cursor-grabbing touch-none"
+          className="relative flex items-center justify-end pt-2.5 pb-1.5 px-4 shrink-0 cursor-grab active:cursor-grabbing touch-none"
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}
         >
-          <div className="w-6" />
-          <div className="w-9 h-1 rounded-full bg-stroke" />
+          {/* pill을 화면 시각적 중앙(main + 채팅패널 절반)에 정렬 */}
+          <div className="absolute left-[calc(50%+calc(var(--spacing-chat-panel)/2))] -translate-x-1/2 w-9 h-1 rounded-full bg-stroke" />
           <button
             aria-label="닫기"
             onPointerDown={(e) => e.stopPropagation()}

--- a/src/components/widgets/WidgetDetailModal.jsx
+++ b/src/components/widgets/WidgetDetailModal.jsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import { X } from 'lucide-react'
+import { X, ChevronLeft } from 'lucide-react'
 import useWidgetDetailStore from '@/store/useWidgetDetailStore'
 import StockChartDetail from './detail/StockChartDetail'
 import BalanceDetail from './detail/BalanceDetail'
@@ -9,6 +9,7 @@ import MarketNewsDetail from './detail/MarketNewsDetail'
 import StockNewsDetail from './detail/StockNewsDetail'
 import WatchlistDetail from './detail/WatchlistDetail'
 import ExchangeDetail from './detail/ExchangeDetail'
+import TradeHistoryDetail from './detail/TradeHistoryDetail'
 import { cn } from '@/lib/cn'
 
 const DETAIL_MAP = {
@@ -20,12 +21,17 @@ const DETAIL_MAP = {
   'stock-news':      StockNewsDetail,
   'watchlist':       WatchlistDetail,
   'exchange':        ExchangeDetail,
+  'trade-history':   TradeHistoryDetail,
 }
 
 const DRAG_CLOSE_THRESHOLD = 80
 
 export default function WidgetDetailModal() {
-  const { openWidget, close } = useWidgetDetailStore()
+  const { openWidget, close, back, history, isBack } = useWidgetDetailStore()
+  const canGoBack  = history.length > 0
+  const isBackRef  = useRef(isBack)
+  isBackRef.current = isBack
+
   const [isClosing, setIsClosing] = useState(false)
   const [slideUpDone, setSlideUpDone] = useState(false)
   const localWidget  = useRef(null)
@@ -42,8 +48,15 @@ export default function WidgetDetailModal() {
         clearTimeout(closeTimer.current)
         closeTimer.current = null
       }
+      // 드래그 잔여 transform 초기화
+      if (sheetRef.current) {
+        sheetRef.current.style.transition = ''
+        sheetRef.current.style.transform  = ''
+      }
+      dragStartY.current   = null
+      dragCurrentY.current = 0
       setIsClosing(false)
-      setSlideUpDone(false)
+      if (!isBackRef.current) setSlideUpDone(false)
     }
   }, [openWidget])
 
@@ -75,7 +88,15 @@ export default function WidgetDetailModal() {
     dragStartY.current = null
 
     if (dragCurrentY.current >= DRAG_CLOSE_THRESHOLD) {
-      handleClose()
+      // 현재 위치에서 계속 아래로 슬라이드
+      if (sheetRef.current) {
+        sheetRef.current.style.transition = 'transform 220ms ease-in'
+        sheetRef.current.style.transform  = 'translateY(100%)'
+      }
+      dragCurrentY.current = 0
+      closeTimer.current = setTimeout(() => {
+        close()
+      }, 220)
     } else {
       // 스냅백
       if (sheetRef.current) {
@@ -111,14 +132,26 @@ export default function WidgetDetailModal() {
         )}
         onAnimationEnd={(e) => { if (e.animationName === 'slide-up') setSlideUpDone(true) }}
       >
-        {/* 드래그 핸들 + 닫기 버튼 */}
+        {/* 드래그 핸들 + 뒤로가기 + 닫기 버튼 */}
         <div
-          className="relative flex items-center justify-end pt-2.5 pb-1.5 px-4 shrink-0 cursor-grab active:cursor-grabbing touch-none"
+          className="relative flex items-center justify-between pt-2.5 pb-1.5 px-4 shrink-0 cursor-grab active:cursor-grabbing touch-none"
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}
         >
           <div className="absolute left-1/2 -translate-x-1/2 w-9 h-1 rounded-full bg-stroke" />
+          {canGoBack ? (
+            <button
+              aria-label="뒤로가기"
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={back}
+              className="p-1 rounded-lg hover:bg-surface-muted transition-colors"
+            >
+              <ChevronLeft className="w-4 h-4 text-foreground-tertiary" />
+            </button>
+          ) : (
+            <div className="w-6" />
+          )}
           <button
             aria-label="닫기"
             onPointerDown={(e) => e.stopPropagation()}

--- a/src/components/widgets/WidgetDetailModal.jsx
+++ b/src/components/widgets/WidgetDetailModal.jsx
@@ -1,4 +1,5 @@
-import { useState, useRef, useEffect } from 'react'
+import { useRef } from 'react'
+import { Drawer } from 'vaul'
 import { X, ChevronLeft } from 'lucide-react'
 import useWidgetDetailStore from '@/store/useWidgetDetailStore'
 import StockChartDetail from './detail/StockChartDetail'
@@ -10,7 +11,6 @@ import StockNewsDetail from './detail/StockNewsDetail'
 import WatchlistDetail from './detail/WatchlistDetail'
 import ExchangeDetail from './detail/ExchangeDetail'
 import TradeHistoryDetail from './detail/TradeHistoryDetail'
-import { cn } from '@/lib/cn'
 
 const DETAIL_MAP = {
   'stock-chart':     StockChartDetail,
@@ -24,126 +24,32 @@ const DETAIL_MAP = {
   'trade-history':   TradeHistoryDetail,
 }
 
-const DRAG_CLOSE_THRESHOLD = 80
-
 export default function WidgetDetailModal() {
-  const { openWidget, close, back, history, isBack } = useWidgetDetailStore()
-  const canGoBack  = history.length > 0
-  const isBackRef  = useRef(isBack)
-  isBackRef.current = isBack
+  const { openWidget, close, back, history } = useWidgetDetailStore()
+  const canGoBack = history.length > 0
 
-  const [isClosing, setIsClosing] = useState(false)
-  const [slideUpDone, setSlideUpDone] = useState(false)
-  const localWidget  = useRef(null)
-  const closeTimer   = useRef(null)
-  const sheetRef     = useRef(null)
-  const dragStartY   = useRef(null)
-  const dragCurrentY = useRef(0)
-
+  // 닫힘 애니메이션 중에도 마지막 위젯 유지
+  const localWidget = useRef(null)
   if (openWidget) localWidget.current = openWidget
 
-  useEffect(() => {
-    if (openWidget) {
-      if (closeTimer.current) {
-        clearTimeout(closeTimer.current)
-        closeTimer.current = null
-      }
-      // 드래그 잔여 transform 초기화
-      if (sheetRef.current) {
-        sheetRef.current.style.transition = ''
-        sheetRef.current.style.transform  = ''
-      }
-      dragStartY.current   = null
-      dragCurrentY.current = 0
-      setIsClosing(false)
-      if (!isBackRef.current) setSlideUpDone(false)
-    }
-  }, [openWidget])
-
-  const handleClose = () => {
-    setIsClosing(true)
-    closeTimer.current = setTimeout(() => {
-      close()
-      setIsClosing(false)
-    }, 240)
-  }
-
-  // ── 드래그 (DOM 직접 조작 — 리렌더 없음) ─────────────────
-  const handlePointerDown = (e) => {
-    dragStartY.current   = e.clientY
-    dragCurrentY.current = 0
-    e.currentTarget.setPointerCapture(e.pointerId)
-    if (sheetRef.current) sheetRef.current.style.transition = 'none'
-  }
-
-  const handlePointerMove = (e) => {
-    if (dragStartY.current === null) return
-    const delta = Math.max(0, e.clientY - dragStartY.current)
-    dragCurrentY.current = delta
-    if (sheetRef.current) sheetRef.current.style.transform = `translateY(${delta}px)`
-  }
-
-  const handlePointerUp = () => {
-    if (dragStartY.current === null) return
-    dragStartY.current = null
-
-    if (dragCurrentY.current >= DRAG_CLOSE_THRESHOLD) {
-      // 현재 위치에서 계속 아래로 슬라이드
-      if (sheetRef.current) {
-        sheetRef.current.style.transition = 'transform 220ms ease-in'
-        sheetRef.current.style.transform  = 'translateY(100%)'
-      }
-      dragCurrentY.current = 0
-      closeTimer.current = setTimeout(() => {
-        close()
-      }, 220)
-    } else {
-      // 스냅백
-      if (sheetRef.current) {
-        sheetRef.current.style.transition = 'transform 200ms ease'
-        sheetRef.current.style.transform  = ''
-      }
-      dragCurrentY.current = 0
-    }
-  }
-
-  if (!openWidget && !isClosing) return null
-
   const DetailComp = localWidget.current ? DETAIL_MAP[localWidget.current.widgetTypeId] : null
-  if (!DetailComp) return null
 
   return (
-    <div className="absolute inset-0 z-40 flex flex-col justify-end pointer-events-none">
-      {/* 배경 딤 */}
-      <div
-        className={cn(
-          'absolute inset-0 pointer-events-auto transition-opacity duration-[240ms]',
-          isClosing ? 'opacity-0' : 'opacity-100 bg-black/10',
-        )}
-        onClick={handleClose}
-      />
+    <Drawer.Root
+      open={!!openWidget}
+      onOpenChange={(open) => { if (!open) close() }}
+      noBodyStyles
+    >
+      {/* 오버레이 — main 영역에만 국한 */}
+      <Drawer.Overlay className="absolute inset-0 z-40 bg-black/10" />
 
-      {/* 시트 */}
-      <div
-        ref={sheetRef}
-        className={cn(
-          'relative bg-surface rounded-t-[20px] shadow-modal flex flex-col pointer-events-auto h-[99%]',
-          isClosing ? 'animate-slide-down' : slideUpDone ? '' : 'animate-slide-up',
-        )}
-        onAnimationEnd={(e) => { if (e.animationName === 'slide-up') setSlideUpDone(true) }}
-      >
-        {/* 드래그 핸들 + 뒤로가기 + 닫기 버튼 */}
-        <div
-          className="relative flex items-center justify-between pt-2.5 pb-1.5 px-4 shrink-0 cursor-grab active:cursor-grabbing touch-none"
-          onPointerDown={handlePointerDown}
-          onPointerMove={handlePointerMove}
-          onPointerUp={handlePointerUp}
-        >
-          <div className="absolute left-1/2 -translate-x-1/2 w-9 h-1 rounded-full bg-stroke" />
+      {/* 시트 — Portal 없이 main 안에서 absolute */}
+      <Drawer.Content className="absolute inset-x-0 bottom-0 z-40 h-[99%] bg-surface rounded-t-[20px] shadow-modal flex flex-col outline-none">
+        {/* 헤더 (드래그 핸들 영역) */}
+        <div className="relative flex items-center justify-between pt-2.5 pb-1.5 px-4 shrink-0">
+          <Drawer.Handle className="!absolute !left-1/2 !top-3 !-translate-x-1/2 !w-9 !h-1 !rounded-full !bg-stroke !opacity-100" />
           {canGoBack ? (
             <button
-              aria-label="뒤로가기"
-              onPointerDown={(e) => e.stopPropagation()}
               onClick={back}
               className="p-1 rounded-lg hover:bg-surface-muted transition-colors"
             >
@@ -153,20 +59,20 @@ export default function WidgetDetailModal() {
             <div className="w-6" />
           )}
           <button
-            aria-label="닫기"
-            onPointerDown={(e) => e.stopPropagation()}
-            onClick={handleClose}
+            onClick={() => close()}
             className="p-1 rounded-lg hover:bg-surface-muted transition-colors"
           >
             <X className="w-4 h-4 text-foreground-tertiary" />
           </button>
         </div>
 
-        <DetailComp
-          config={localWidget.current.config}
-          onClose={handleClose}
-        />
-      </div>
-    </div>
+        {DetailComp && localWidget.current && (
+          <DetailComp
+            config={localWidget.current.config}
+            onClose={() => close()}
+          />
+        )}
+      </Drawer.Content>
+    </Drawer.Root>
   )
 }

--- a/src/components/widgets/WidgetDetailModal.jsx
+++ b/src/components/widgets/WidgetDetailModal.jsx
@@ -103,8 +103,7 @@ export default function WidgetDetailModal() {
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}
         >
-          {/* pill을 화면 시각적 중앙(main + 채팅패널 절반)에 정렬 */}
-          <div className="absolute left-[calc(50%+calc(var(--spacing-chat-panel)/2))] -translate-x-1/2 w-9 h-1 rounded-full bg-stroke" />
+          <div className="absolute left-1/2 -translate-x-1/2 w-9 h-1 rounded-full bg-stroke" />
           <button
             aria-label="닫기"
             onPointerDown={(e) => e.stopPropagation()}

--- a/src/components/widgets/WidgetDetailModal.jsx
+++ b/src/components/widgets/WidgetDetailModal.jsx
@@ -3,11 +3,21 @@ import { X } from 'lucide-react'
 import useWidgetDetailStore from '@/store/useWidgetDetailStore'
 import StockChartDetail from './detail/StockChartDetail'
 import BalanceDetail from './detail/BalanceDetail'
+import RankingDetail from './detail/RankingDetail'
+import IndexDetail from './detail/IndexDetail'
+import MarketNewsDetail from './detail/MarketNewsDetail'
+import StockNewsDetail from './detail/StockNewsDetail'
+import WatchlistDetail from './detail/WatchlistDetail'
 import { cn } from '@/lib/cn'
 
 const DETAIL_MAP = {
-  'stock-chart': StockChartDetail,
-  'balance':     BalanceDetail,
+  'stock-chart':     StockChartDetail,
+  'balance':         BalanceDetail,
+  'ranking':         RankingDetail,
+  'index':           IndexDetail,
+  'market-overview': MarketNewsDetail,
+  'stock-news':      StockNewsDetail,
+  'watchlist':       WatchlistDetail,
 }
 
 const DRAG_CLOSE_THRESHOLD = 80

--- a/src/components/widgets/detail/BalanceDetail.jsx
+++ b/src/components/widgets/detail/BalanceDetail.jsx
@@ -1,5 +1,5 @@
-import AssetPage from '@/pages/AssetPage'
+import { AssetContent } from '@/pages/AssetPage'
 
 export default function BalanceDetail() {
-  return <AssetPage />
+  return <AssetContent />
 }

--- a/src/components/widgets/detail/BalanceDetail.jsx
+++ b/src/components/widgets/detail/BalanceDetail.jsx
@@ -1,0 +1,5 @@
+import AssetPage from '@/pages/AssetPage'
+
+export default function BalanceDetail() {
+  return <AssetPage />
+}

--- a/src/components/widgets/detail/DetailChart.jsx
+++ b/src/components/widgets/detail/DetailChart.jsx
@@ -11,6 +11,48 @@ function getColors() {
   }
 }
 
+function formatTz(epochSec, timezone, isMinute) {
+  const d = new Date(epochSec * 1000)
+  if (timezone) {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', hour12: false,
+    }).formatToParts(d)
+    const get = (type) => parts.find((p) => p.type === type)?.value ?? '00'
+    if (isMinute) return `${get('year')}/${get('month')}/${get('day')} ${get('hour')}:${get('minute')}`
+    return `${get('year')}/${get('month')}/${get('day')}`
+  }
+  const m  = String(d.getMonth() + 1).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+  if (isMinute) {
+    const hh = String(d.getHours()).padStart(2, '0')
+    const mi = String(d.getMinutes()).padStart(2, '0')
+    return `${d.getFullYear()}/${m}/${dd} ${hh}:${mi}`
+  }
+  return `${d.getFullYear()}/${m}/${dd}`
+}
+
+function getTickLabel(epochSec, tickMarkType, timezone, isMinute) {
+  const d = new Date(epochSec * 1000)
+  if (timezone) {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', hour12: false,
+    }).formatToParts(d)
+    const get = (type) => parts.find((p) => p.type === type)?.value ?? '00'
+    if (isMinute) return `${get('hour')}:${get('minute')}`
+    if (tickMarkType <= 1) return `${Number(get('month'))}월`
+    return `${Number(get('month'))}/${Number(get('day'))}`
+  }
+  if (isMinute) {
+    return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+  }
+  if (tickMarkType <= 1) return `${d.getMonth() + 1}월`
+  return `${d.getMonth() + 1}/${d.getDate()}`
+}
+
 /**
  * 상세 차트 — 선형 / 캔들 전환 지원
  * @param {{ time: number, value: number }[]}                       lineData
@@ -18,9 +60,10 @@ function getColors() {
  * @param {'line'|'candle'} chartType
  * @param {boolean} isMinute
  * @param {boolean} isUp
+ * @param {string}  [timezone]  - IANA timezone (e.g. 'America/New_York'). 없으면 로컬 시간.
  * @param {string}  className
  */
-export default function DetailChart({ lineData, candleData, chartType = 'line', isMinute, isUp, className = '' }) {
+export default function DetailChart({ lineData, candleData, chartType = 'line', isMinute, isUp, timezone, className = '' }) {
   const ref = useRef(null)
 
   useEffect(() => {
@@ -48,6 +91,9 @@ export default function DetailChart({ lineData, candleData, chartType = 'line', 
         borderVisible: false,
         textColor: textMuted,
       },
+      localization: {
+        timeFormatter: (time) => formatTz(time, timezone, isMinute),
+      },
       timeScale: {
         visible:        true,
         timeVisible:    isMinute,
@@ -56,14 +102,7 @@ export default function DetailChart({ lineData, candleData, chartType = 'line', 
         ticksVisible:   false,
         fixLeftEdge:    true,
         fixRightEdge:   true,
-        tickMarkFormatter: (time, tickMarkType) => {
-          const d = new Date(time * 1000)
-          if (isMinute) {
-            return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
-          }
-          if (tickMarkType <= 1) return `${d.getMonth() + 1}월`
-          return `${d.getMonth() + 1}/${d.getDate()}`
-        },
+        tickMarkFormatter: (time, tickMarkType) => getTickLabel(time, tickMarkType, timezone, isMinute),
       },
       crosshair: {
         vertLine: { color: primary, width: 1, style: 1, labelBackgroundColor: primary },
@@ -116,7 +155,7 @@ export default function DetailChart({ lineData, candleData, chartType = 'line', 
       ro.disconnect()
       chart.remove()
     }
-  }, [lineData, candleData, chartType, isMinute, isUp]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [lineData, candleData, chartType, isMinute, isUp, timezone]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return <div ref={ref} className={`overflow-hidden ${className}`} />
 }

--- a/src/components/widgets/detail/DetailChart.jsx
+++ b/src/components/widgets/detail/DetailChart.jsx
@@ -7,7 +7,7 @@ function getColors() {
     up:        style.getPropertyValue('--color-up').trim()                  || '#E8393E',
     down:      style.getPropertyValue('--color-down').trim()                || '#0075E8',
     textMuted: style.getPropertyValue('--color-foreground-disabled').trim() || '#9CA3AF',
-    stroke:    style.getPropertyValue('--color-stroke').trim()              || '#EAECF0',
+    primary:   style.getPropertyValue('--color-primary').trim()             || '#0046FF',
   }
 }
 
@@ -26,7 +26,8 @@ export default function DetailChart({ lineData, candleData, chartType = 'line', 
   useEffect(() => {
     const el = ref.current
     if (!el) return
-    const { up, down, textMuted, stroke } = getColors()
+    const { up, down, textMuted, primary } = getColors()
+    const lineColor = isUp ? up : down
 
     const chart = createChart(el, {
       width:  el.clientWidth,
@@ -38,11 +39,15 @@ export default function DetailChart({ lineData, candleData, chartType = 'line', 
         fontSize:   10,
       },
       grid: {
-        vertLines: { visible: false },
-        horzLines: { color: stroke },
+        vertLines: { color: '#F3F4F6' },
+        horzLines: { color: '#F3F4F6' },
       },
       leftPriceScale:  { visible: false },
-      rightPriceScale: { visible: true, borderVisible: false, textColor: textMuted },
+      rightPriceScale: {
+        visible: true,
+        borderVisible: false,
+        textColor: textMuted,
+      },
       timeScale: {
         visible:        true,
         timeVisible:    isMinute,
@@ -61,8 +66,8 @@ export default function DetailChart({ lineData, candleData, chartType = 'line', 
         },
       },
       crosshair: {
-        vertLine: { color: stroke },
-        horzLine: { color: stroke },
+        vertLine: { color: primary, width: 1, style: 1, labelBackgroundColor: primary },
+        horzLine: { color: primary, width: 1, style: 1, labelBackgroundColor: primary },
       },
       handleScroll: false,
       handleScale:  false,
@@ -70,19 +75,20 @@ export default function DetailChart({ lineData, candleData, chartType = 'line', 
 
     if (chartType === 'candle') {
       const series = chart.addSeries(CandlestickSeries, {
-        upColor:        up,
-        downColor:      down,
-        borderUpColor:  up,
+        upColor:         up,
+        downColor:       down,
+        borderUpColor:   up,
         borderDownColor: down,
-        wickUpColor:    up,
-        wickDownColor:  down,
+        wickUpColor:     up,
+        wickDownColor:   down,
+        priceLineVisible: false,
+        lastValueVisible: false,
       })
       if (candleData?.length) {
         series.setData(candleData)
         chart.timeScale().fitContent()
       }
     } else {
-      const lineColor = isUp ? up : down
       const series = chart.addSeries(LineSeries, {
         lineColor,
         lineWidth:              2,

--- a/src/components/widgets/detail/DetailChart.jsx
+++ b/src/components/widgets/detail/DetailChart.jsx
@@ -1,0 +1,116 @@
+import { useEffect, useRef } from 'react'
+import { LineSeries, CandlestickSeries, createChart } from 'lightweight-charts'
+
+function getColors() {
+  const style = getComputedStyle(document.documentElement)
+  return {
+    up:        style.getPropertyValue('--color-up').trim()                  || '#E8393E',
+    down:      style.getPropertyValue('--color-down').trim()                || '#0075E8',
+    textMuted: style.getPropertyValue('--color-foreground-disabled').trim() || '#9CA3AF',
+    stroke:    style.getPropertyValue('--color-stroke').trim()              || '#EAECF0',
+  }
+}
+
+/**
+ * 상세 차트 — 선형 / 캔들 전환 지원
+ * @param {{ time: number, value: number }[]}                       lineData
+ * @param {{ time: number, open, high, low, close: number }[]}      candleData
+ * @param {'line'|'candle'} chartType
+ * @param {boolean} isMinute
+ * @param {boolean} isUp
+ * @param {string}  className
+ */
+export default function DetailChart({ lineData, candleData, chartType = 'line', isMinute, isUp, className = '' }) {
+  const ref = useRef(null)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const { up, down, textMuted, stroke } = getColors()
+
+    const chart = createChart(el, {
+      width:  el.clientWidth,
+      height: el.clientHeight,
+      layout: {
+        background: { color: 'transparent' },
+        textColor:  textMuted,
+        fontFamily: 'Pretendard, -apple-system, BlinkMacSystemFont, Apple SD Gothic Neo, sans-serif',
+        fontSize:   10,
+      },
+      grid: {
+        vertLines: { visible: false },
+        horzLines: { color: stroke },
+      },
+      leftPriceScale:  { visible: false },
+      rightPriceScale: { visible: true, borderVisible: false, textColor: textMuted },
+      timeScale: {
+        visible:        true,
+        timeVisible:    isMinute,
+        secondsVisible: false,
+        borderVisible:  false,
+        ticksVisible:   false,
+        fixLeftEdge:    true,
+        fixRightEdge:   true,
+        tickMarkFormatter: (time, tickMarkType) => {
+          const d = new Date(time * 1000)
+          if (isMinute) {
+            return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+          }
+          if (tickMarkType <= 1) return `${d.getMonth() + 1}월`
+          return `${d.getMonth() + 1}/${d.getDate()}`
+        },
+      },
+      crosshair: {
+        vertLine: { color: stroke },
+        horzLine: { color: stroke },
+      },
+      handleScroll: false,
+      handleScale:  false,
+    })
+
+    if (chartType === 'candle') {
+      const series = chart.addSeries(CandlestickSeries, {
+        upColor:        up,
+        downColor:      down,
+        borderUpColor:  up,
+        borderDownColor: down,
+        wickUpColor:    up,
+        wickDownColor:  down,
+      })
+      if (candleData?.length) {
+        series.setData(candleData)
+        chart.timeScale().fitContent()
+      }
+    } else {
+      const lineColor = isUp ? up : down
+      const series = chart.addSeries(LineSeries, {
+        lineColor,
+        lineWidth:              2,
+        priceLineVisible:       false,
+        lastValueVisible:       false,
+        crosshairMarkerVisible: true,
+        crosshairMarkerRadius:  4,
+      })
+      if (lineData?.length) {
+        series.setData(lineData)
+        chart.timeScale().fitContent()
+      }
+    }
+
+    const ro = new ResizeObserver(([entry]) => {
+      if (!entry) return
+      chart.applyOptions({
+        width:  entry.contentRect.width,
+        height: entry.contentRect.height,
+      })
+    })
+    ro.observe(el)
+
+    return () => {
+      ro.disconnect()
+      chart.remove()
+    }
+  }, [lineData, candleData, chartType, isMinute, isUp]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return <div ref={ref} className={`overflow-hidden ${className}`} />
+}

--- a/src/components/widgets/detail/ExchangeDetail.jsx
+++ b/src/components/widgets/detail/ExchangeDetail.jsx
@@ -1,0 +1,5 @@
+import IndexDetail from './IndexDetail'
+
+export default function ExchangeDetail({ config = {}, onClose }) {
+  return <IndexDetail config={{ currency: 'USD', ...config }} onClose={onClose} />
+}

--- a/src/components/widgets/detail/IndexDetail.jsx
+++ b/src/components/widgets/detail/IndexDetail.jsx
@@ -1,0 +1,162 @@
+import { useState, useEffect } from 'react'
+import PriceChange from '@/components/ui/PriceChange'
+import TabChip from '@/components/ui/TabChip'
+import DetailChart from './DetailChart'
+import useMarketIndices from '@/features/market/useMarketIndices'
+import useIndexChart from '@/features/market/useIndexChart'
+import { cn } from '@/lib/cn'
+
+const INDEX_LIST = [
+  { code: '001',      label: 'KOSPI'   },
+  { code: '301',      label: 'KOSDAQ'  },
+  { code: 'NAS@IXIC', label: 'NASDAQ'  },
+  { code: 'SPI@SPX',  label: 'S&P 500' },
+]
+
+const PERIODS = ['1D', '1M', '3M', '1Y']
+
+export default function IndexDetail({ config = {} }) {
+  const [code, setCode]               = useState(config.code ?? '001')
+  const [period, setPeriod]           = useState('3M')
+  const [fetchPeriod, setFetchPeriod] = useState(null)
+  const [chartType, setChartType]     = useState(
+    () => localStorage.getItem('index.chartType') ?? 'candle',
+  )
+
+  useEffect(() => {
+    localStorage.setItem('index.chartType', chartType)
+  }, [chartType])
+
+  // t3518 rate limit(1 req/sec) 대응
+  useEffect(() => {
+    const timer = setTimeout(() => setFetchPeriod(period), 1200)
+    return () => clearTimeout(timer)
+  }, [period])
+
+  // 지수 전환 시 fetchPeriod 리셋 후 재요청
+  useEffect(() => {
+    setFetchPeriod(null)
+    const timer = setTimeout(() => setFetchPeriod(period), 1200)
+    return () => clearTimeout(timer)
+  }, [code]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const { indices } = useMarketIndices()
+  const currentMeta = INDEX_LIST.find((m) => m.code === code)
+  const idx         = indices.find((i) => i.code === code)
+
+  const price      = idx ? Number(idx.price).toLocaleString('ko-KR', { maximumFractionDigits: 2 }) : '—'
+  const changeRate = idx?.changeRate ?? null
+  const isUp       = changeRate != null ? changeRate >= 0 : true
+
+  const { lineData, candleData, isLoading, isIntraday, error } = useIndexChart(code, fetchPeriod)
+  const hasData = chartType === 'candle' ? candleData.length > 0 : lineData.length > 0
+
+  return (
+    <div className="flex flex-1 min-h-0 overflow-hidden">
+
+      {/* ── 좌측: 차트 영역 ── */}
+      <div className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden">
+        {/* 헤더 */}
+        <div className="flex items-center justify-between px-5 py-3 border-b border-stroke shrink-0">
+          <div className="flex items-baseline gap-3">
+            <span className="text-[15px] font-bold text-foreground">{currentMeta?.label ?? code}</span>
+            <span className="text-[20px] font-extrabold text-foreground">{price}</span>
+            {changeRate != null && <PriceChange value={changeRate} className="text-[13px]" />}
+          </div>
+          <div className="flex items-center gap-2">
+            {/* 캔들/라인 토글 */}
+            <div className="flex items-center rounded-lg bg-surface-muted p-0.5">
+              {[{ key: 'candle', label: '캔들' }, { key: 'line', label: '라인' }].map((type) => (
+                <button
+                  key={type.key}
+                  type="button"
+                  onClick={() => setChartType(type.key)}
+                  className={cn(
+                    'rounded-md px-2.5 py-0.5 text-[10px] font-semibold transition-all',
+                    chartType === type.key
+                      ? 'bg-primary text-white shadow-control'
+                      : 'text-foreground-disabled hover:text-foreground-secondary',
+                  )}
+                >
+                  {type.label}
+                </button>
+              ))}
+            </div>
+
+            {/* 기간 탭 */}
+            <div className="flex gap-1">
+              {PERIODS.map((p) => (
+                <TabChip key={p} isActive={period === p} onClick={() => setPeriod(p)}>
+                  {p}
+                </TabChip>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* 차트 */}
+        <div className="flex-1 min-h-0 p-4">
+          {isLoading ? (
+            <div className="h-full flex items-center justify-center text-[12px] text-foreground-disabled">불러오는 중...</div>
+          ) : error ? (
+            <div className="h-full flex items-center justify-center text-[12px] text-status-negative">{error.message ?? 'API 오류'}</div>
+          ) : hasData ? (
+            <DetailChart
+              lineData={lineData}
+              candleData={candleData}
+              chartType={chartType}
+              isMinute={isIntraday}
+              isUp={isUp}
+              className="w-full h-full"
+            />
+          ) : (
+            <div className="h-full flex items-center justify-center text-[12px] text-foreground-disabled">데이터 없음</div>
+          )}
+        </div>
+      </div>
+
+      {/* ── 우측: 지수 목록 ── */}
+      <div className="w-[200px] shrink-0 border-l border-stroke flex flex-col py-2 overflow-y-auto">
+        <p className="px-4 pt-2 pb-3 text-[11px] font-semibold text-foreground-disabled">주가지수</p>
+        {INDEX_LIST.map((item) => {
+          const itemIdx   = indices.find((i) => i.code === item.code)
+          const itemPrice = itemIdx ? Number(itemIdx.price).toLocaleString('ko-KR', { maximumFractionDigits: 2 }) : '—'
+          const itemRate  = itemIdx?.changeRate ?? null
+          const itemIsUp  = itemRate != null ? itemRate >= 0 : true
+          const isActive  = item.code === code
+
+          return (
+            <button
+              key={item.code}
+              type="button"
+              onClick={() => setCode(item.code)}
+              className={cn(
+                'flex items-center gap-2 px-4 py-2.5 text-left transition-colors',
+                isActive ? 'bg-surface-subtle' : 'hover:bg-surface-muted',
+              )}
+            >
+              <span className={cn(
+                'text-[12px] font-semibold w-[52px] shrink-0',
+                isActive ? 'text-foreground' : 'text-foreground-secondary',
+              )}>
+                {item.label}
+              </span>
+              <span className="text-[12px] font-bold text-foreground tabular-nums flex-1 text-right">{itemPrice}</span>
+              {itemRate != null ? (
+                <span className={cn(
+                  'text-[11px] font-semibold tabular-nums w-[46px] text-right shrink-0',
+                  itemIsUp ? 'text-up' : 'text-down',
+                )}>
+                  {itemIsUp ? '+' : ''}{itemRate.toFixed(2)}%
+                </span>
+              ) : (
+                <span className="w-[46px] shrink-0" />
+              )}
+            </button>
+          )
+        })}
+      </div>
+
+    </div>
+  )
+}

--- a/src/components/widgets/detail/IndexDetail.jsx
+++ b/src/components/widgets/detail/IndexDetail.jsx
@@ -4,67 +4,89 @@ import TabChip from '@/components/ui/TabChip'
 import DetailChart from './DetailChart'
 import useMarketIndices from '@/features/market/useMarketIndices'
 import useIndexChart from '@/features/market/useIndexChart'
+import useForexChart from '@/features/market/useForexChart'
 import { cn } from '@/lib/cn'
 
-const INDEX_LIST = [
-  { code: '001',      label: 'KOSPI'   },
-  { code: '301',      label: 'KOSDAQ'  },
-  { code: 'NAS@IXIC', label: 'NASDAQ'  },
-  { code: 'SPI@SPX',  label: 'S&P 500' },
+const SIDEBAR_ITEMS = [
+  { type: 'index', code: '001',        label: 'KOSPI'   },
+  { type: 'index', code: '301',        label: 'KOSDAQ'  },
+  { type: 'index', code: 'NAS@IXIC',  label: 'NASDAQ'  },
+  { type: 'index', code: 'SPI@SPX',   label: 'S&P 500' },
+  { type: 'forex', code: 'USD',        symbol: 'USDKRW=X', label: 'USD/KRW' },
 ]
 
 const PERIODS = ['1D', '1M', '3M', '1Y']
 
 export default function IndexDetail({ config = {} }) {
-  const [code, setCode]               = useState(config.code ?? '001')
+  const initialCode = config.code ?? (config.currency === 'USD' ? 'USD' : '001')
+  const [selected, setSelected]       = useState(() => SIDEBAR_ITEMS.find((i) => i.code === initialCode) ?? SIDEBAR_ITEMS[0])
   const [period, setPeriod]           = useState('3M')
   const [fetchPeriod, setFetchPeriod] = useState(null)
   const [chartType, setChartType]     = useState(
-    () => localStorage.getItem('index.chartType') ?? 'candle',
+    () => localStorage.getItem('market.chartType') ?? 'candle',
   )
 
   useEffect(() => {
-    localStorage.setItem('index.chartType', chartType)
+    localStorage.setItem('market.chartType', chartType)
   }, [chartType])
 
-  // t3518 rate limit(1 req/sec) 대응
-  useEffect(() => {
-    const timer = setTimeout(() => setFetchPeriod(period), 1200)
-    return () => clearTimeout(timer)
-  }, [period])
-
-  // 지수 전환 시 fetchPeriod 리셋 후 재요청
+  // 인덱스 전환 시 fetchPeriod 리셋 (t3518 rate limit 대응)
   useEffect(() => {
     setFetchPeriod(null)
     const timer = setTimeout(() => setFetchPeriod(period), 1200)
     return () => clearTimeout(timer)
-  }, [code]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [selected.code]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // 기간 변경 시 debounce
+  useEffect(() => {
+    if (selected.type === 'index') {
+      const timer = setTimeout(() => setFetchPeriod(period), 1200)
+      return () => clearTimeout(timer)
+    } else {
+      setFetchPeriod(period)
+    }
+  }, [period, selected.type])
 
   const { indices } = useMarketIndices()
-  const currentMeta = INDEX_LIST.find((m) => m.code === code)
-  const idx         = indices.find((i) => i.code === code)
 
-  const price      = idx ? Number(idx.price).toLocaleString('ko-KR', { maximumFractionDigits: 2 }) : '—'
-  const changeRate = idx?.changeRate ?? null
-  const isUp       = changeRate != null ? changeRate >= 0 : true
+  // 두 훅 모두 호출 — enabled 조건으로 실제 요청 제어
+  const { lineData: idxLine, candleData: idxCandle, isLoading: idxLoading, isIntraday: idxIsIntraday, error: idxError } =
+    useIndexChart(selected.type === 'index' ? selected.code : null, selected.type === 'index' ? fetchPeriod : null)
 
-  const { lineData, candleData, isLoading, isIntraday, error } = useIndexChart(code, fetchPeriod)
-  const hasData = chartType === 'candle' ? candleData.length > 0 : lineData.length > 0
+  const { lineData: fxLine, candleData: fxCandle, isLoading: fxLoading, isIntraday: fxIsIntraday, error: fxError } =
+    useForexChart(selected.type === 'forex' ? selected.symbol : null, selected.type === 'forex' ? fetchPeriod : null)
+
+  const isForex    = selected.type === 'forex'
+  const lineData   = isForex ? fxLine   : idxLine
+  const candleData = isForex ? fxCandle : idxCandle
+  const isLoading  = isForex ? fxLoading  : idxLoading
+  const isIntraday = isForex ? fxIsIntraday : idxIsIntraday
+  const error      = isForex ? fxError   : idxError
+  const hasData    = chartType === 'candle' ? candleData.length > 0 : lineData.length > 0
+
+  // 헤더용 현재가/등락률 — USD 포함 모두 indices에서 조회
+  const selectedIdx = indices.find((i) => i.code === selected.code)
+  const headerPrice = selectedIdx ? Number(selectedIdx.price).toLocaleString('ko-KR', { maximumFractionDigits: 2 }) : '—'
+  const headerRate  = selectedIdx?.changeRate ?? null
+  const headerIsUp  = headerRate != null ? headerRate >= 0 : true
+
+  function handleSelect(item) {
+    setSelected(item)
+    setPeriod('3M')
+  }
 
   return (
     <div className="flex flex-1 min-h-0 overflow-hidden">
 
       {/* ── 좌측: 차트 영역 ── */}
       <div className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden">
-        {/* 헤더 */}
         <div className="flex items-center justify-between px-5 py-3 border-b border-stroke shrink-0">
           <div className="flex items-baseline gap-3">
-            <span className="text-[15px] font-bold text-foreground">{currentMeta?.label ?? code}</span>
-            <span className="text-[20px] font-extrabold text-foreground">{price}</span>
-            {changeRate != null && <PriceChange value={changeRate} className="text-[13px]" />}
+            <span className="text-[15px] font-bold text-foreground">{selected.label}</span>
+            <span className="text-[20px] font-extrabold text-foreground">{headerPrice}</span>
+            {headerRate != null && <PriceChange value={headerRate} className="text-[13px]" />}
           </div>
           <div className="flex items-center gap-2">
-            {/* 캔들/라인 토글 */}
             <div className="flex items-center rounded-lg bg-surface-muted p-0.5">
               {[{ key: 'candle', label: '캔들' }, { key: 'line', label: '라인' }].map((type) => (
                 <button
@@ -82,8 +104,6 @@ export default function IndexDetail({ config = {} }) {
                 </button>
               ))}
             </div>
-
-            {/* 기간 탭 */}
             <div className="flex gap-1">
               {PERIODS.map((p) => (
                 <TabChip key={p} isActive={period === p} onClick={() => setPeriod(p)}>
@@ -94,7 +114,6 @@ export default function IndexDetail({ config = {} }) {
           </div>
         </div>
 
-        {/* 차트 */}
         <div className="flex-1 min-h-0 p-4">
           {isLoading ? (
             <div className="h-full flex items-center justify-center text-[12px] text-foreground-disabled">불러오는 중...</div>
@@ -106,7 +125,7 @@ export default function IndexDetail({ config = {} }) {
               candleData={candleData}
               chartType={chartType}
               isMinute={isIntraday}
-              isUp={isUp}
+              isUp={headerIsUp}
               className="w-full h-full"
             />
           ) : (
@@ -115,21 +134,21 @@ export default function IndexDetail({ config = {} }) {
         </div>
       </div>
 
-      {/* ── 우측: 지수 목록 ── */}
+      {/* ── 우측: 목록 ── */}
       <div className="w-[200px] shrink-0 border-l border-stroke flex flex-col py-2 overflow-y-auto">
-        <p className="px-4 pt-2 pb-3 text-[11px] font-semibold text-foreground-disabled">주가지수</p>
-        {INDEX_LIST.map((item) => {
-          const itemIdx   = indices.find((i) => i.code === item.code)
-          const itemPrice = itemIdx ? Number(itemIdx.price).toLocaleString('ko-KR', { maximumFractionDigits: 2 }) : '—'
-          const itemRate  = itemIdx?.changeRate ?? null
+        <p className="px-4 pt-2 pb-3 text-[11px] font-semibold text-foreground-disabled">시장</p>
+        {SIDEBAR_ITEMS.map((item) => {
+          const idx      = indices.find((i) => i.code === item.code)
+          const itemPrice = idx ? Number(idx.price).toLocaleString('ko-KR', { maximumFractionDigits: 2 }) : '—'
+          const itemRate  = idx?.changeRate ?? null
           const itemIsUp  = itemRate != null ? itemRate >= 0 : true
-          const isActive  = item.code === code
+          const isActive = item.code === selected.code
 
           return (
             <button
               key={item.code}
               type="button"
-              onClick={() => setCode(item.code)}
+              onClick={() => handleSelect(item)}
               className={cn(
                 'flex items-center gap-2 px-4 py-2.5 text-left transition-colors',
                 isActive ? 'bg-surface-subtle' : 'hover:bg-surface-muted',

--- a/src/components/widgets/detail/IndexDetail.jsx
+++ b/src/components/widgets/detail/IndexDetail.jsx
@@ -126,6 +126,7 @@ export default function IndexDetail({ config = {} }) {
               chartType={chartType}
               isMinute={isIntraday}
               isUp={headerIsUp}
+
               className="w-full h-full"
             />
           ) : (

--- a/src/components/widgets/detail/MarketNewsDetail.jsx
+++ b/src/components/widgets/detail/MarketNewsDetail.jsx
@@ -1,0 +1,223 @@
+import { useState } from 'react'
+import { ArrowLeft } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
+import useLatestNews from '@/features/market/useLatestNews'
+import { newsApi } from '@/api/news'
+import { cn } from '@/lib/cn'
+
+const TABS = [
+  { key: 'kr', label: '한국' },
+  { key: 'us', label: '미국' },
+]
+
+function HighlightedText({ text }) {
+  const parts = text.split(/(상승|하락)/g)
+  return (
+    <>
+      {parts.map((part, i) => {
+        if (part === '상승') return <span key={i} className="text-up font-bold">{part}</span>
+        if (part === '하락') return <span key={i} className="text-down font-bold">{part}</span>
+        return part
+      })}
+    </>
+  )
+}
+
+/* ── 기사 본문 뷰 ──────────────────────────────────────────── */
+function ArticleView({ newsId, onBack }) {
+  const { data, isLoading } = useQuery({
+    queryKey: ['news', 'detail', newsId],
+    queryFn: () => newsApi.getNewsDetail(newsId),
+    staleTime: 10 * 60 * 1000,
+  })
+
+  if (isLoading) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <span className="text-sm text-foreground-disabled">불러오는 중...</span>
+      </div>
+    )
+  }
+
+  if (!data) return null
+
+  const paragraphs = data.content
+    ? data.content.split(/\n{1,}/).map((p) => p.trim()).filter(Boolean)
+    : []
+
+  return (
+    <div className="flex-1 min-h-0 flex flex-col">
+      {/* 헤더 */}
+      <div className="shrink-0 px-10 py-3">
+        <div className="max-w-2xl mx-auto flex items-center gap-2 pb-3 border-b border-stroke">
+          <button
+            onClick={onBack}
+            className="p-1 -ml-1 rounded-lg hover:bg-surface-muted transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4 text-foreground-secondary" />
+          </button>
+          <span className="text-xs font-semibold text-foreground-disabled">오늘의 시황</span>
+        </div>
+      </div>
+
+      {/* 본문 스크롤 */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-10 py-7">
+      <div className="max-w-2xl mx-auto flex flex-col gap-6">
+
+        {/* 제목 */}
+        <h2 className="text-[22px] font-bold text-foreground leading-tight tracking-tight">
+          {data.title}
+        </h2>
+
+        {/* 출처 · 날짜 */}
+        <div className="flex items-center gap-2 pb-5 border-b border-stroke">
+          {data.source && (
+            <span className="text-sm font-semibold text-primary">{data.source}</span>
+          )}
+          {data.source && data.publishedAt && (
+            <span className="text-sm text-stroke">·</span>
+          )}
+          {data.publishedAt && (
+            <span className="text-sm text-foreground-disabled">{data.publishedAt}</span>
+          )}
+        </div>
+
+        {/* 한줄 요약 — 강조 */}
+        {data.oneLineSummary && (
+          <div className="flex flex-col gap-2">
+            <span className="text-xs font-bold text-foreground-disabled uppercase tracking-widest">한 줄 요약</span>
+            <div className="rounded-2xl px-5 py-4" style={{ background: 'linear-gradient(135deg, #EEF2FF 0%, #E0E7FF 100%)' }}>
+              <p className="text-[17px] font-semibold text-foreground leading-relaxed">
+                <HighlightedText text={data.oneLineSummary} />
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* 주요 이벤트 */}
+        {data.marketEvents?.length > 0 && (
+          <div className="bg-surface-subtle rounded-2xl px-5 py-4 flex flex-col gap-3">
+            <span className="text-xs font-bold text-foreground-disabled uppercase tracking-widest">
+              주요 이벤트
+            </span>
+            <ul className="flex flex-col gap-2.5">
+              {data.marketEvents.map((ev, i) => (
+                <li key={i} className="flex items-start gap-3 text-[14px] text-foreground leading-relaxed">
+                  <span className="text-primary font-bold mt-[2px] shrink-0">•</span>
+                  {ev}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* 본문 카드 */}
+        {paragraphs.length > 0 && (
+          <div className="bg-surface-subtle rounded-2xl px-5 py-5 mb-6">
+            {paragraphs.map((p, i) => (
+              <p
+                key={i}
+                className="text-[15px] text-foreground leading-[1.85]"
+                style={{ marginBottom: i < paragraphs.length - 1 ? '1.25rem' : 0 }}
+              >
+                {p}
+              </p>
+            ))}
+          </div>
+        )}
+      </div>
+      </div>
+    </div>
+  )
+}
+
+/* ── 목록 뷰 (분리하여 useLatestNews가 기사 뷰에서 호출되지 않게 함) ── */
+function ListView({ initialTab, onSelectNews }) {
+  const [tab, setTab] = useState(initialTab)
+  const { krNews, usNews, isLoading } = useLatestNews(20)
+  const items = tab === 'kr' ? krNews : usNews
+
+  return (
+    <div className="flex-1 min-h-0 flex flex-col">
+      <div className="shrink-0 px-10 py-3">
+        <div className="max-w-2xl mx-auto flex items-center justify-between pb-3 border-b border-stroke">
+          <h2 className="text-[15px] font-bold text-foreground">오늘의 시황</h2>
+          <div className="flex gap-1">
+            {TABS.map((t) => (
+              <button
+                key={t.key}
+                onClick={() => setTab(t.key)}
+                className={cn(
+                  'px-2.5 py-0.5 text-[11px] font-semibold rounded-lg transition-colors',
+                  tab === t.key
+                    ? 'bg-primary text-white'
+                    : 'text-foreground-disabled hover:text-foreground-secondary',
+                )}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto px-10 py-2">
+      <div className="max-w-2xl mx-auto">
+        {isLoading ? (
+          <div className="flex items-center justify-center h-20">
+            <span className="text-xs text-foreground-disabled">불러오는 중...</span>
+          </div>
+        ) : !items.length ? (
+          <div className="flex items-center justify-center h-20">
+            <span className="text-xs text-foreground-disabled">뉴스가 없습니다.</span>
+          </div>
+        ) : (
+          items.map((item) => (
+            <button
+              key={item.newsId}
+              onClick={() => onSelectNews(item.newsId)}
+              className="w-full text-left flex flex-col gap-2 py-5 border-b border-stroke last:border-b-0 hover:opacity-75 transition-opacity"
+            >
+              {/* 출처 · 날짜 */}
+              <div className="flex items-center gap-1.5">
+                {item.source && (
+                  <span className="text-[12px] font-semibold text-foreground-tertiary">{item.source}</span>
+                )}
+                {item.source && item.publishedAt && (
+                  <span className="text-[12px] text-stroke">·</span>
+                )}
+                {item.publishedAt && (
+                  <span className="text-[12px] text-foreground-disabled">{item.publishedAt}</span>
+                )}
+              </div>
+
+              {/* 제목 */}
+              <p className="text-[15px] font-bold text-foreground leading-snug line-clamp-2">
+                {item.title}
+              </p>
+
+              {/* 본문 미리보기 */}
+              {item.contentPreview && (
+                <p className="text-[13px] text-foreground-secondary leading-relaxed line-clamp-3">
+                  {item.contentPreview}
+                </p>
+              )}
+            </button>
+          ))
+        )}
+      </div>
+      </div>
+    </div>
+  )
+}
+
+/* ── 메인 ──────────────────────────────────────────────────── */
+export default function MarketNewsDetail({ config = {} }) {
+  const [selectedNewsId, setSelectedNewsId] = useState(config.newsId ?? null)
+
+  if (selectedNewsId) {
+    return <ArticleView newsId={selectedNewsId} onBack={() => setSelectedNewsId(null)} />
+  }
+
+  return <ListView initialTab={config.tab ?? 'kr'} onSelectNews={setSelectedNewsId} />
+}

--- a/src/components/widgets/detail/MarketNewsDetail.jsx
+++ b/src/components/widgets/detail/MarketNewsDetail.jsx
@@ -86,7 +86,7 @@ function ArticleView({ newsId, onBack }) {
         {data.oneLineSummary && (
           <div className="flex flex-col gap-2">
             <span className="text-xs font-bold text-foreground-disabled uppercase tracking-widest">한 줄 요약</span>
-            <div className="rounded-2xl px-5 py-4" style={{ background: 'linear-gradient(135deg, #EEF2FF 0%, #E0E7FF 100%)' }}>
+            <div className="rounded-2xl px-5 py-4 [background:var(--background-summary-card)]">
               <p className="text-[17px] font-semibold text-foreground leading-relaxed">
                 <HighlightedText text={data.oneLineSummary} />
               </p>
@@ -117,8 +117,7 @@ function ArticleView({ newsId, onBack }) {
             {paragraphs.map((p, i) => (
               <p
                 key={i}
-                className="text-[15px] text-foreground leading-[1.85]"
-                style={{ marginBottom: i < paragraphs.length - 1 ? '1.25rem' : 0 }}
+                className={`text-[15px] text-foreground leading-[1.85]${i < paragraphs.length - 1 ? ' mb-5' : ''}`}
               >
                 {p}
               </p>

--- a/src/components/widgets/detail/RankingDetail.jsx
+++ b/src/components/widgets/detail/RankingDetail.jsx
@@ -1,5 +1,5 @@
-import MarketPage from '@/pages/MarketPage'
+import { MarketContent } from '@/pages/MarketPage'
 
 export default function RankingDetail({ config = {} }) {
-  return <MarketPage initialSortFilter={config.initialSortFilter} />
+  return <MarketContent initialSortFilter={config.initialSortFilter} />
 }

--- a/src/components/widgets/detail/RankingDetail.jsx
+++ b/src/components/widgets/detail/RankingDetail.jsx
@@ -1,0 +1,5 @@
+import MarketPage from '@/pages/MarketPage'
+
+export default function RankingDetail({ config = {} }) {
+  return <MarketPage initialSortFilter={config.initialSortFilter} />
+}

--- a/src/components/widgets/detail/StockChartDetail.jsx
+++ b/src/components/widgets/detail/StockChartDetail.jsx
@@ -11,6 +11,13 @@ import {
 import useCurrencyStore from '@/store/useCurrencyStore'
 import { INVEST_STOCK } from '@/mocks/invest'
 
+const WIDGET_PERIOD_MAP = {
+  '1일': { initialPeriod: 'MINUTE', initialMinuteInterval: 5  },
+  '1주': { initialPeriod: 'MINUTE', initialMinuteInterval: 30 },
+  '1달': { initialPeriod: 'MINUTE', initialMinuteInterval: 60 },
+  '3달': { initialPeriod: 'DAILY',  initialMinuteInterval: undefined },
+}
+
 export default function StockChartDetail({ config = {}, onClose }) {
   const stockCode     = config.stockCode ?? INVEST_STOCK.code
   const locationState = {
@@ -19,6 +26,8 @@ export default function StockChartDetail({ config = {}, onClose }) {
     marketType:   config.marketType ?? null,
     exchangeCode: null,
   }
+
+  const periodInit = WIDGET_PERIOD_MAP[config.widgetPeriod] ?? {}
 
   const {
     stockMeta,
@@ -39,7 +48,7 @@ export default function StockChartDetail({ config = {}, onClose }) {
     onChartPeriodChange,
     onLoadMoreChartHistory,
     onMinuteIntervalChange,
-  } = useInvestMarketData(stockCode, locationState, { activeLeftTab: 'daily' })
+  } = useInvestMarketData(stockCode, locationState, { activeLeftTab: 'daily', ...periodInit })
 
   const marketType      = stockMeta.marketType ?? stockMeta.market
   const isForeignMarket = isForeignMarketType(marketType)

--- a/src/components/widgets/detail/StockChartDetail.jsx
+++ b/src/components/widgets/detail/StockChartDetail.jsx
@@ -21,10 +21,10 @@ const WIDGET_PERIOD_MAP = {
 export default function StockChartDetail({ config = {}, onClose }) {
   const stockCode     = config.stockCode ?? INVEST_STOCK.code
   const locationState = {
-    stockName:    config.stockName  ?? null,
+    stockName:    config.stockName   ?? null,
     stockNameEn:  null,
-    marketType:   config.marketType ?? null,
-    exchangeCode: null,
+    marketType:   config.marketType  ?? null,
+    exchangeCode: config.exchangeCode ?? null,
   }
 
   const periodInit = WIDGET_PERIOD_MAP[config.widgetPeriod] ?? {}

--- a/src/components/widgets/detail/StockChartDetail.jsx
+++ b/src/components/widgets/detail/StockChartDetail.jsx
@@ -1,0 +1,116 @@
+import { useState } from 'react'
+import InvestStockOverview from '@/components/invest/InvestStockOverview'
+import InvestOrderSection from '@/components/invest/InvestOrderSection'
+import StockHoldingCard from './StockHoldingCard'
+import useInvestMarketData from '@/features/invest/useInvestMarketData'
+import {
+  DISPLAY_CURRENCY,
+  FALLBACK_USD_RATE,
+  isForeignMarketType,
+} from '@/features/invest/formatters'
+import useCurrencyStore from '@/store/useCurrencyStore'
+import { INVEST_STOCK } from '@/mocks/invest'
+
+export default function StockChartDetail({ config = {}, onClose }) {
+  const stockCode     = config.stockCode ?? INVEST_STOCK.code
+  const locationState = {
+    stockName:    config.stockName  ?? null,
+    stockNameEn:  null,
+    marketType:   config.marketType ?? null,
+    exchangeCode: null,
+  }
+
+  const {
+    stockMeta,
+    currentPrice,
+    changeAmount,
+    changeRate,
+    overview,
+    chartSeries,
+    chartPeriod,
+    minuteInterval,
+    chartLoading,
+    chartErrorMessage,
+    chartHistoryLoading,
+    hasMoreChartHistory,
+    marketLoading,
+    marketErrorMessage,
+    orderBook,
+    onChartPeriodChange,
+    onLoadMoreChartHistory,
+    onMinuteIntervalChange,
+  } = useInvestMarketData(stockCode, locationState, { activeLeftTab: 'daily' })
+
+  const marketType      = stockMeta.marketType ?? stockMeta.market
+  const isForeignMarket = isForeignMarketType(marketType)
+  const usdRate         = useCurrencyStore((s) => s.rates.USD?.rate ?? FALLBACK_USD_RATE)
+
+  const [displayCurrencyOverrides, setDisplayCurrencyOverrides] = useState({})
+  const displayCurrency = isForeignMarket
+    ? (displayCurrencyOverrides[stockCode] ?? DISPLAY_CURRENCY.USD)
+    : DISPLAY_CURRENCY.KRW
+
+  function handleDisplayCurrencyChange(nextCurrency) {
+    setDisplayCurrencyOverrides((prev) => ({ ...prev, [stockCode]: nextCurrency }))
+  }
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
+
+      {/* 차트 + 호가창/주문 */}
+      <div className="flex flex-1 min-h-0 overflow-hidden">
+
+        {/* 왼쪽: 차트 + 보유 현황 */}
+        <div className="flex flex-col min-w-0 basis-0 flex-1 border-r border-stroke overflow-hidden">
+          <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
+            <InvestStockOverview
+              hideSearch
+              className="border-r-0"
+              stockMeta={stockMeta}
+              currentPrice={currentPrice}
+              changeAmount={changeAmount}
+              changeRate={changeRate}
+              overview={overview}
+              chartSeries={chartSeries}
+              chartPeriod={chartPeriod}
+              minuteInterval={minuteInterval}
+              chartLoading={chartLoading}
+              chartErrorMessage={chartErrorMessage}
+              chartHistoryLoading={chartHistoryLoading}
+              hasMoreChartHistory={hasMoreChartHistory}
+              onChartPeriodChange={onChartPeriodChange}
+              onLoadMoreChartHistory={onLoadMoreChartHistory}
+              onMinuteIntervalChange={onMinuteIntervalChange}
+              isLoading={marketLoading}
+              errorMessage={marketErrorMessage}
+              displayCurrency={displayCurrency}
+              usdRate={usdRate}
+              onDisplayCurrencyChange={handleDisplayCurrencyChange}
+            />
+          </div>
+          <StockHoldingCard
+            stockCode={stockCode}
+            displayCurrency={displayCurrency}
+            usdRate={usdRate}
+          />
+        </div>
+
+        {/* 오른쪽: 호가창 + 주문 */}
+        <InvestOrderSection
+          key={stockCode}
+          stockCode={stockCode}
+          marketType={marketType}
+          stockName={stockMeta.name}
+          currentPrice={currentPrice}
+          changeRate={changeRate}
+          defaultPrice={currentPrice ?? stockMeta.price}
+          orderBook={orderBook}
+          displayCurrency={displayCurrency}
+          usdRate={usdRate}
+        />
+
+      </div>
+
+    </div>
+  )
+}

--- a/src/components/widgets/detail/StockHoldingCard.jsx
+++ b/src/components/widgets/detail/StockHoldingCard.jsx
@@ -16,15 +16,6 @@ export default function StockHoldingCard({ stockCode, displayCurrency, usdRate }
 
   const holding = [...domestic, ...overseas].find((h) => h.stockCode === stockCode)
 
-  const avgPrice  = holding.avgPrice ?? holding.avgBuyPrice ?? 0
-  const quantity  = holding.holdingQuantity ?? holding.availableQuantity ?? 0
-  const evalPrice = holding.currentPrice ?? null
-  const profitLoss = evalPrice != null ? (evalPrice - avgPrice) * quantity : null
-  const profitRate = evalPrice != null && avgPrice > 0
-    ? ((evalPrice - avgPrice) / avgPrice) * 100
-    : null
-  const isProfit = profitLoss != null ? profitLoss >= 0 : false
-
   if (!holding) {
     return (
       <div className="shrink-0 border-t border-stroke px-[14px] py-3 bg-surface">
@@ -36,6 +27,15 @@ export default function StockHoldingCard({ stockCode, displayCurrency, usdRate }
       </div>
     )
   }
+
+  const avgPrice   = holding.avgPrice ?? holding.avgBuyPrice ?? 0
+  const quantity   = holding.holdingQuantity ?? holding.availableQuantity ?? 0
+  const evalPrice  = holding.currentPrice ?? null
+  const profitLoss = evalPrice != null ? (evalPrice - avgPrice) * quantity : null
+  const profitRate = evalPrice != null && avgPrice > 0
+    ? ((evalPrice - avgPrice) / avgPrice) * 100
+    : null
+  const isProfit   = profitLoss != null ? profitLoss >= 0 : false
 
   return (
     <div className="shrink-0 border-t border-stroke px-[14px] py-3 bg-surface">

--- a/src/components/widgets/detail/StockHoldingCard.jsx
+++ b/src/components/widgets/detail/StockHoldingCard.jsx
@@ -1,0 +1,77 @@
+import { useDomesticHoldings, useOverseasHoldings } from '@/api/balance'
+import StockAvatar from '@/components/ui/StockAvatar'
+import useAuthStore from '@/store/useAuthStore'
+import { formatCurrency, formatNumber } from '@/features/invest/formatters'
+import { cn } from '@/lib/cn'
+
+export default function StockHoldingCard({ stockCode, displayCurrency, usdRate }) {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
+  const isRestoring     = useAuthStore((s) => s.isRestoring)
+
+  const enabled = isAuthenticated && !isRestoring
+  const { data: domestic = [], isLoading: dLoading } = useDomesticHoldings({ enabled })
+  const { data: overseas = [], isLoading: oLoading } = useOverseasHoldings({ enabled })
+
+  if (!isAuthenticated || isRestoring || dLoading || oLoading) return null
+
+  const holding = [...domestic, ...overseas].find((h) => h.stockCode === stockCode)
+
+  const avgPrice  = holding.avgPrice ?? holding.avgBuyPrice ?? 0
+  const quantity  = holding.holdingQuantity ?? holding.availableQuantity ?? 0
+  const evalPrice = holding.currentPrice ?? null
+  const profitLoss = evalPrice != null ? (evalPrice - avgPrice) * quantity : null
+  const profitRate = evalPrice != null && avgPrice > 0
+    ? ((evalPrice - avgPrice) / avgPrice) * 100
+    : null
+  const isProfit = profitLoss != null ? profitLoss >= 0 : false
+
+  if (!holding) {
+    return (
+      <div className="shrink-0 border-t border-stroke px-[14px] py-3 bg-surface">
+        <div className="text-[9px] font-semibold text-foreground-disabled mb-2">보유 현황</div>
+        <div className="-mx-[14px] border-b border-stroke mb-3" />
+        <div className="flex items-center justify-center py-1">
+          <span className="text-[11px] text-foreground-disabled">해당 종목을 보유하고 있지 않음</span>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="shrink-0 border-t border-stroke px-[14px] py-3 bg-surface">
+      <div className="text-[9px] font-semibold text-foreground-disabled mb-2">보유 현황</div>
+      <div className="-mx-[14px] border-b border-stroke mb-3" />
+      <div className="flex items-center gap-2.5">
+        <StockAvatar
+          name={holding.stockName ?? stockCode}
+          stockCode={stockCode}
+          marketType={holding.marketType}
+          size="sm"
+        />
+        <div className="flex-1 min-w-0">
+          <div className="text-[11px] font-semibold text-foreground truncate">
+            {holding.stockName ?? stockCode}
+          </div>
+          <div className="text-[9px] text-foreground-disabled mt-0.5">
+            평균 {formatCurrency(avgPrice, { marketType: holding.marketType, displayCurrency, usdRate })}
+          </div>
+        </div>
+        <div className="text-right shrink-0">
+          <div className="text-[11px] font-bold text-foreground">
+            {formatNumber(quantity)}주
+          </div>
+          <div className={cn(
+            'text-[10px] font-semibold mt-0.5',
+            profitLoss == null ? 'text-foreground-disabled'
+              : isProfit ? 'text-up' : 'text-down',
+          )}>
+            {profitLoss == null
+              ? '-'
+              : `${isProfit ? '+' : ''}${formatCurrency(profitLoss, { marketType: holding.marketType, displayCurrency, usdRate })} (${isProfit ? '+' : ''}${profitRate?.toFixed(2)}%)`
+            }
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/widgets/detail/StockNewsDetail.jsx
+++ b/src/components/widgets/detail/StockNewsDetail.jsx
@@ -85,10 +85,7 @@ function ArticleView({ newsId, stockName, onBack }) {
           {data.summary && (
             <div className="flex flex-col gap-1.5">
               <span className="text-[10px] font-bold text-foreground-disabled uppercase tracking-widest">한 줄 요약</span>
-              <div
-                className="rounded-xl px-4 py-3"
-                style={{ background: 'linear-gradient(135deg, #EEF2FF 0%, #E0E7FF 100%)' }}
-              >
+              <div className="rounded-xl px-4 py-3 [background:var(--background-summary-card)]">
                 <p className="text-[14px] font-semibold text-foreground leading-relaxed">
                   <HighlightedText text={data.summary} />
                 </p>
@@ -127,8 +124,7 @@ function ArticleView({ newsId, stockName, onBack }) {
               {paragraphs.map((p, i) => (
                 <p
                   key={i}
-                  className="text-[13px] text-foreground leading-[1.8]"
-                  style={{ marginBottom: i < paragraphs.length - 1 ? '1rem' : 0 }}
+                  className={`text-[13px] text-foreground leading-[1.8]${i < paragraphs.length - 1 ? ' mb-4' : ''}`}
                 >
                   {p}
                 </p>

--- a/src/components/widgets/detail/StockNewsDetail.jsx
+++ b/src/components/widgets/detail/StockNewsDetail.jsx
@@ -1,0 +1,240 @@
+import { useState } from 'react'
+import { ArrowLeft } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
+import useStockNews from '@/features/market/useStockNews'
+import { newsApi } from '@/api/news'
+
+function HighlightedText({ text }) {
+  const parts = text.split(/(상승|하락)/g)
+  return (
+    <>
+      {parts.map((part, i) => {
+        if (part === '상승') return <span key={i} className="text-up font-bold">{part}</span>
+        if (part === '하락') return <span key={i} className="text-down font-bold">{part}</span>
+        return part
+      })}
+    </>
+  )
+}
+
+/* ── 기사 본문 뷰 ──────────────────────────────────────────── */
+function ArticleView({ newsId, stockName, onBack }) {
+  const { data, isLoading } = useQuery({
+    queryKey: ['stock-news', 'detail', newsId],
+    queryFn: () => newsApi.getStockNewsDetail(newsId),
+    staleTime: 10 * 60 * 1000,
+  })
+
+  if (isLoading) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <span className="text-sm text-foreground-disabled">불러오는 중...</span>
+      </div>
+    )
+  }
+
+  if (!data) return null
+
+  const paragraphs = data.content
+    ? data.content.split(/\n{1,}/).map((p) => p.trim()).filter(Boolean)
+    : []
+
+  return (
+    <div className="flex-1 min-h-0 flex flex-col">
+      {/* 헤더 */}
+      <div className="shrink-0 px-10 py-3">
+        <div className="max-w-2xl mx-auto flex items-center gap-2 pb-3 border-b border-stroke">
+          <button
+            onClick={onBack}
+            className="p-1 -ml-1 rounded-lg hover:bg-surface-muted transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4 text-foreground-secondary" />
+          </button>
+          <span className="text-xs font-semibold text-foreground-disabled">
+            {stockName ?? '종목별 뉴스'}
+          </span>
+        </div>
+      </div>
+
+      {/* 본문 스크롤 */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-10 py-5">
+        <div className="max-w-2xl mx-auto flex flex-col gap-4">
+
+          {/* 제목 */}
+          <h2 className="text-[18px] font-bold text-foreground leading-tight tracking-tight">
+            {data.title}
+          </h2>
+
+          {/* 출처 · 날짜 */}
+          <div className="flex items-center gap-2 pb-4 border-b border-stroke">
+            {data.source && (
+              <span className="text-xs font-semibold text-primary">{data.source}</span>
+            )}
+            {data.source && data.publishedAt && <span className="text-xs text-stroke">·</span>}
+            {data.publishedAt && (
+              <span className="text-xs text-foreground-disabled">{data.publishedAt}</span>
+            )}
+            {data.market && (
+              <span className="ml-auto text-[10px] font-semibold text-foreground-disabled bg-surface-muted px-2 py-0.5 rounded-md">
+                {data.market}
+              </span>
+            )}
+          </div>
+
+          {/* 한줄 요약 */}
+          {data.summary && (
+            <div className="flex flex-col gap-1.5">
+              <span className="text-[10px] font-bold text-foreground-disabled uppercase tracking-widest">한 줄 요약</span>
+              <div
+                className="rounded-xl px-4 py-3"
+                style={{ background: 'linear-gradient(135deg, #EEF2FF 0%, #E0E7FF 100%)' }}
+              >
+                <p className="text-[14px] font-semibold text-foreground leading-relaxed">
+                  <HighlightedText text={data.summary} />
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* 소제목 목록 */}
+          {data.subtitles?.length > 0 && (
+            <div className="bg-surface-subtle rounded-xl px-4 py-3 flex flex-col gap-2">
+              <span className="text-[10px] font-bold text-foreground-disabled uppercase tracking-widest">주요 내용</span>
+              <ul className="flex flex-col gap-1.5">
+                {data.subtitles.map((s, i) => (
+                  <li key={i} className="flex items-start gap-2.5 text-[13px] text-foreground leading-relaxed">
+                    <span className="text-primary font-bold mt-[2px] shrink-0">•</span>
+                    {s}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* 썸네일 */}
+          {data.thumbnailUrl && (
+            <img
+              src={data.thumbnailUrl}
+              alt=""
+              className="w-full h-80 object-cover"
+              onError={(e) => { e.currentTarget.style.display = 'none' }}
+            />
+          )}
+
+          {/* 본문 카드 */}
+          {paragraphs.length > 0 && (
+            <div className="bg-surface-subtle rounded-xl px-4 py-4 mb-4">
+              {paragraphs.map((p, i) => (
+                <p
+                  key={i}
+                  className="text-[13px] text-foreground leading-[1.8]"
+                  style={{ marginBottom: i < paragraphs.length - 1 ? '1rem' : 0 }}
+                >
+                  {p}
+                </p>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/* ── 목록 뷰 ──────────────────────────────────────────────── */
+function ListView({ stockCode, stockName, onSelectNews }) {
+  const { news, isLoading } = useStockNews(stockCode, 20)
+
+  return (
+    <div className="flex-1 min-h-0 flex flex-col">
+      <div className="shrink-0 px-10 py-3">
+        <div className="max-w-2xl mx-auto flex items-center justify-between pb-3 border-b border-stroke">
+          <div className="flex flex-col gap-0.5">
+            <h2 className="text-[15px] font-bold text-foreground">{stockName ?? '종목별 뉴스'}</h2>
+            {stockCode && (
+              <span className="text-[11px] text-foreground-disabled">{stockCode}</span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto px-10 py-2">
+        <div className="max-w-2xl mx-auto">
+          {isLoading ? (
+            <div className="flex items-center justify-center h-20">
+              <span className="text-xs text-foreground-disabled">불러오는 중...</span>
+            </div>
+          ) : !news.length ? (
+            <div className="flex items-center justify-center h-20">
+              <span className="text-xs text-foreground-disabled">뉴스가 없습니다.</span>
+            </div>
+          ) : (
+            news.map((item) => (
+              <button
+                key={item.newsId}
+                onClick={() => onSelectNews(item.newsId)}
+                className="w-full text-left flex gap-4 py-5 border-b border-stroke last:border-b-0 hover:opacity-75 transition-opacity"
+              >
+                {/* 텍스트 */}
+                <div className="flex-1 flex flex-col gap-2">
+                  <div className="flex items-center gap-1.5">
+                    {item.source && (
+                      <span className="text-[12px] font-semibold text-foreground-tertiary">{item.source}</span>
+                    )}
+                    {item.source && item.publishedAt && (
+                      <span className="text-[12px] text-stroke">·</span>
+                    )}
+                    {item.publishedAt && (
+                      <span className="text-[12px] text-foreground-disabled">{item.publishedAt}</span>
+                    )}
+                  </div>
+                  <p className="text-[15px] font-bold text-foreground leading-snug line-clamp-2">
+                    {item.title}
+                  </p>
+                  {item.contentPreview && (
+                    <p className="text-[13px] text-foreground-secondary leading-relaxed line-clamp-3">
+                      {item.contentPreview}
+                    </p>
+                  )}
+                </div>
+
+                {/* 썸네일 */}
+                {item.thumbnailUrl && (
+                  <img
+                    src={item.thumbnailUrl}
+                    alt=""
+                    className="w-20 h-20 object-cover rounded-xl shrink-0 self-start"
+                    onError={(e) => { e.currentTarget.style.display = 'none' }}
+                  />
+                )}
+              </button>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/* ── 메인 ──────────────────────────────────────────────────── */
+export default function StockNewsDetail({ config = {} }) {
+  const [selectedNewsId, setSelectedNewsId] = useState(config.newsId ?? null)
+
+  if (selectedNewsId) {
+    return (
+      <ArticleView
+        newsId={selectedNewsId}
+        stockName={config.stockName}
+        onBack={() => setSelectedNewsId(null)}
+      />
+    )
+  }
+
+  return (
+    <ListView
+      stockCode={config.stockCode}
+      stockName={config.stockName}
+      onSelectNews={setSelectedNewsId}
+    />
+  )
+}

--- a/src/components/widgets/detail/TradeHistoryDetail.jsx
+++ b/src/components/widgets/detail/TradeHistoryDetail.jsx
@@ -1,0 +1,317 @@
+import { useState, useMemo, useCallback } from 'react'
+import useWidgetDetailStore from '@/store/useWidgetDetailStore'
+import StockAvatar from '@/components/ui/StockAvatar'
+import { DayPicker } from 'react-day-picker'
+import { ko } from 'react-day-picker/locale'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
+import { orderApi } from '@/api/order'
+import useAuthStore from '@/store/useAuthStore'
+import { cn } from '@/lib/cn'
+
+function dateKey(d) {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+const FOREIGN_MARKETS = new Set(['NASDAQ', 'NYSE', 'AMEX'])
+
+function fmtPrice(n, marketType) {
+  if (n == null) return '-'
+  return FOREIGN_MARKETS.has(marketType)
+    ? `$${Number(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+    : `₩${Number(n).toLocaleString('ko-KR')}`
+}
+
+function fmtDate(dateStr) {
+  if (!dateStr) return ''
+  const d = new Date(dateStr.length === 10 ? dateStr + 'T00:00:00' : dateStr)
+  return `${d.getMonth() + 1}/${d.getDate()}`
+}
+
+function buildTradeMap(orders) {
+  // 날짜별 원본 목록 (리스트 패널용)
+  const raw = {}
+  orders.forEach((o) => {
+    const dt = o.executedAt ?? o.requestedAt
+    if (!dt) return
+    const d = new Date(dt.length === 10 ? dt + 'T00:00:00' : dt)
+    const k = dateKey(d)
+    if (!raw[k]) raw[k] = []
+    raw[k].push({
+      stockCode:    o.stockCode,
+      marketType:   o.marketType ?? null,
+      exchangeCode: o.exchangeCode ?? null,
+      name:  o.stockName,
+      buy:   o.orderSide === 'BUY',
+      qty:   o.filledQuantity ?? o.orderQuantity,
+      price: o.orderPrice,
+      date:  fmtDate(dt),
+    })
+  })
+
+  // 캘린더 셀용: 종목 dedup 후 매수 최대 3건, 매도 최대 2건, 초과 시 '...' 하나
+  const map = {}
+  Object.entries(raw).forEach(([k, trades]) => {
+    const seen = new Set()
+    const buys = [], sells = []
+    trades.forEach((t) => {
+      const id = `${t.buy ? 'B' : 'S'}:${t.name}`
+      if (seen.has(id)) return
+      seen.add(id)
+      ;(t.buy ? buys : sells).push(t.name)
+    })
+    const hasMore = buys.length > 3 || sells.length > 2
+    map[k] = [
+      ...buys.slice(0, 3).map((name) => ({ buy: true,  name })),
+      ...sells.slice(0, 2).map((name) => ({ buy: false, name })),
+      ...(hasMore ? [{ buy: null, name: '...' }] : []),
+    ]
+  })
+
+  return { calMap: map, rawMap: raw }
+}
+
+export default function TradeHistoryDetail() {
+  const { isAuthenticated, isRestoring } = useAuthStore()
+  const open = useWidgetDetailStore((s) => s.open)
+
+  const handleTradeClick = useCallback((trade) => {
+    open({
+      widgetTypeId: 'stock-chart',
+      config: {
+        stockCode:    trade.stockCode,
+        stockName:    trade.name,
+        marketType:   trade.marketType,
+        exchangeCode: trade.exchangeCode,
+      },
+    })
+  }, [open])
+  const [selected, setSelected] = useState(null)
+  const [month, setMonth] = useState(new Date())
+
+  const { data: orders = [], isLoading } = useQuery({
+    queryKey: ['orders', 'FILLED'],
+    queryFn:  () => orderApi.getOrders('FILLED'),
+    enabled:  isAuthenticated && !isRestoring,
+    staleTime: 30_000,
+  })
+
+  const { calMap, rawMap } = useMemo(() => buildTradeMap(orders), [orders])
+
+  // 날짜 셀 커스텀 버튼
+  const CustomDayButton = useCallback(({ day, modifiers, ...btnProps }) => {
+    const key    = dateKey(day.date)
+    const dow    = day.date.getDay()
+    const trades = calMap[key] ?? []
+
+    return (
+      <button
+        {...btnProps}
+        className={cn(
+          'w-full h-full flex flex-col items-start justify-start gap-1 rounded-xl transition-colors pb-1 overflow-hidden',
+          modifiers.selected && '',
+          !modifiers.selected && modifiers.today && '',
+          !modifiers.selected && !modifiers.today && 'hover:bg-surface-muted',
+          modifiers.outside && 'opacity-25 pointer-events-none',
+        )}
+      >
+        {/* 상단 바 (날짜 포함) */}
+        <div className={cn(
+          'w-full shrink-0 flex items-center justify-center py-1',
+          modifiers.today ? 'bg-primary' : 'bg-transparent',
+        )}>
+          <div className="flex flex-col items-center gap-0.5">
+            <span className={cn(
+              'text-[13px] leading-none font-medium',
+              modifiers.today
+                ? 'text-white font-bold'
+                : dow === 6 ? 'text-up'
+                : dow === 0 ? 'text-down'
+                : 'text-foreground',
+            )}>
+              {day.date.getDate()}
+            </span>
+            {modifiers.selected && !modifiers.today && (
+              <div className="w-4.5 h-[2px] rounded-full bg-primary" />
+            )}
+          </div>
+        </div>
+        <div className="flex flex-col gap-px w-full px-1">
+          {trades.map((tr, i) => (
+            <div key={i} className="flex items-center gap-0.5 w-full min-w-0">
+              {tr.buy !== null && <div className={cn('w-0.5 self-stretch rounded-full shrink-0', tr.buy ? 'bg-up' : 'bg-down')} />}
+              <span className="text-[9px] leading-tight truncate text-foreground">
+                {tr.name}
+              </span>
+            </div>
+          ))}
+        </div>
+      </button>
+    )
+  }, [calMap])
+
+  const CustomMonthCaption = useCallback(({ calendarMonth }) => {
+    const d = calendarMonth.date
+    const label = `${d.getMonth() + 1}월`
+    const prevMonth = new Date(d.getFullYear(), d.getMonth() - 1, 1)
+    const nextMonth = new Date(d.getFullYear(), d.getMonth() + 1, 1)
+    return (
+      <div className="mb-5">
+        <div className="grid grid-cols-7 items-center">
+          <div className="col-span-6 flex items-center gap-1">
+            <button
+              onClick={() => setMonth(prevMonth)}
+              className="p-1.5 rounded-lg hover:bg-surface-muted transition-colors text-foreground-tertiary"
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </button>
+            <div className="flex flex-col items-center flex-1">
+              <span className="text-[12px] text-foreground-disabled font-medium leading-none">{d.getFullYear()}년</span>
+              <span className="text-[15px] font-bold text-foreground leading-tight">{label}</span>
+            </div>
+            <button
+              onClick={() => setMonth(nextMonth)}
+              className="p-1.5 rounded-lg hover:bg-surface-muted transition-colors text-foreground-tertiary"
+            >
+              <ChevronRight className="w-4 h-4" />
+            </button>
+          </div>
+          <div className="flex justify-center">
+            <button
+              onClick={() => { setMonth(new Date()); setSelected(new Date()) }}
+              className="text-[11px] font-medium text-primary hover:bg-primary-light px-2 py-1 rounded-lg transition-colors"
+            >
+              오늘
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }, [setMonth, setSelected])
+
+  const CustomWeekday = useCallback(({ children, ...props }) => {
+    const label = String(children)
+    const isSat = label === '토'
+    const isSun = label === '일'
+    return (
+      <th
+        {...props}
+        className={cn(
+          'text-center text-[11px] font-semibold pb-2 border-b border-stroke',
+          isSat ? 'text-up' : isSun ? 'text-down' : 'text-foreground-disabled',
+        )}
+      >
+        {children}
+      </th>
+    )
+  }, [])
+
+  // 오른쪽 패널에 표시할 거래 목록
+  const displayTrades = useMemo(() => {
+    if (selected) {
+      return rawMap[dateKey(selected)] ?? []
+    }
+    const y = month.getFullYear()
+    const m = month.getMonth()
+    return Object.entries(rawMap)
+      .filter(([k]) => {
+        const d = new Date(k)
+        return d.getFullYear() === y && d.getMonth() === m
+      })
+      .sort(([a], [b]) => b.localeCompare(a))
+      .flatMap(([, trades]) => trades)
+  }, [selected, rawMap, month])
+
+  const panelLabel = selected
+    ? `${selected.getMonth() + 1}월 ${selected.getDate()}일`
+    : `${month.getMonth() + 1}월 전체`
+
+  return (
+    <div className="flex-1 min-h-0 flex overflow-hidden">
+
+      {/* ── 왼쪽: 캘린더 ── */}
+      <div className="flex flex-col border-r border-stroke p-6 w-[65%]">
+        <DayPicker
+          mode="single"
+          locale={ko}
+          selected={selected}
+          onSelect={(date) => {
+            if (!date) return
+            setSelected((prev) =>
+              prev && dateKey(prev) === dateKey(date) ? null : date
+            )
+          }}
+          month={month}
+          onMonthChange={setMonth}
+          components={{ DayButton: CustomDayButton, Weekday: CustomWeekday, MonthCaption: CustomMonthCaption }}
+          classNames={{
+            root:            'w-full',
+            months:          'w-full',
+            month:           'w-full',
+            month_caption:   '',
+            nav:             'hidden',
+            month_grid:      'w-full border-collapse',
+            weekdays:        'grid grid-cols-7',
+            weekday:         '',
+            weeks:           'flex flex-col gap-1 mt-2',
+            week:            'grid grid-cols-7 gap-1',
+            day:             'aspect-square',
+            day_button:      'w-full h-full',
+          }}
+        />
+      </div>
+
+      {/* ── 오른쪽: 거래 목록 ── */}
+      <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+        <div className="shrink-0 px-6 pt-5 pb-3 border-b border-stroke flex items-center justify-between">
+          <h3 className="text-[14px] font-bold text-foreground">{panelLabel}</h3>
+          {selected && (
+            <button
+              onClick={() => setSelected(null)}
+              className="text-[11px] text-foreground-disabled hover:text-foreground-secondary transition-colors"
+            >
+              전체 보기
+            </button>
+          )}
+        </div>
+
+        <div className="flex-1 min-h-0 overflow-y-auto">
+          {isLoading ? (
+            <div className="flex items-center justify-center h-20">
+              <span className="text-xs text-foreground-disabled">불러오는 중...</span>
+            </div>
+          ) : displayTrades.length === 0 ? (
+            <div className="flex items-center justify-center h-20">
+              <span className="text-xs text-foreground-disabled">거래내역이 없습니다</span>
+            </div>
+          ) : (
+            <div className="divide-y divide-stroke">
+              {displayTrades.map((t, i) => (
+                <div key={i} onClick={() => handleTradeClick(t)} className="flex items-center justify-between px-6 py-3.5 cursor-pointer hover:bg-surface-muted transition-colors">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <StockAvatar name={t.name} stockCode={t.stockCode} marketType={t.marketType} size="sm" />
+                    <div className="flex flex-col min-w-0">
+                      <span className="text-[13px] font-medium text-foreground truncate">{t.name}</span>
+                      <span className={cn('text-[10px] font-semibold', t.buy ? 'text-up' : 'text-down')}>
+                        {t.buy ? '매수' : '매도'}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="flex flex-col items-end shrink-0 gap-0.5 ml-4">
+                    <span className="text-[13px] font-semibold text-foreground tabular-nums">
+                      {fmtPrice(t.price, t.marketType)}
+                    </span>
+                    <span className="text-[11px] text-foreground-disabled tabular-nums">
+                      {t.qty}주 · {t.date}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+    </div>
+  )
+}

--- a/src/components/widgets/detail/WatchlistDetail.jsx
+++ b/src/components/widgets/detail/WatchlistDetail.jsx
@@ -127,17 +127,15 @@ export default function WatchlistDetail() {
     <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
       {/* 헤더 */}
       <div className="shrink-0 px-8 pt-4 pb-3 border-b border-stroke">
-        <div className="flex items-center justify-between">
-          <h2 className="text-[15px] font-bold text-foreground">관심 종목</h2>
-          <span className="text-[11px] text-foreground-disabled">{items.length}개</span>
-        </div>
+        <h2 className="text-[15px] font-bold text-foreground">관심 종목</h2>
       </div>
 
       {/* 컬럼 헤더 */}
       {items.length > 0 && (
-        <div className="shrink-0 px-8 py-2 flex items-center text-[10px] font-semibold text-foreground-disabled border-b border-stroke">
+        <div className="shrink-0 px-8 py-2 flex items-center gap-3 text-[10px] font-semibold text-foreground-disabled border-b border-stroke">
+          <span className="w-8 shrink-0" />
           <span className="flex-1">종목</span>
-          <span className="w-[80px] text-center">차트</span>
+          <span className="w-[80px]" />
           <span className="w-[96px] text-right">현재가</span>
           <span className="w-[100px] text-right">등락</span>
           <span className="w-8" />

--- a/src/components/widgets/detail/WatchlistDetail.jsx
+++ b/src/components/widgets/detail/WatchlistDetail.jsx
@@ -1,16 +1,31 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { X } from 'lucide-react'
+import StockAvatar from '@/components/ui/StockAvatar'
 import PriceChange from '@/components/ui/PriceChange'
 import { useWatchlist, watchlistApi } from '@/api/watchlist'
 import useAuthStore from '@/store/useAuthStore'
 import useWidgetDetailStore from '@/store/useWidgetDetailStore'
+import { isForeignMarketType } from '@/features/invest/formatters'
 
-function fmtPrice(n, market) {
+const EXCHANGE_CODE_BY_MARKET_TYPE = { NASDAQ: 'NAS', NYSE: 'NYS', AMEX: 'AMS' }
+import { cn } from '@/lib/cn'
+
+function fmtPrice(n, marketType) {
   if (n == null) return '-'
-  const isOverseas = market && !['KSE', 'KOSDAQ', 'KONEX'].includes(market)
+  const isOverseas = isForeignMarketType(marketType)
   return isOverseas
     ? `$${Number(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
     : `₩${Number(n).toLocaleString('ko-KR')}`
+}
+
+function fmtChange(change, marketType) {
+  if (change == null) return null
+  const isOverseas = isForeignMarketType(marketType)
+  const abs = Math.abs(Number(change))
+  const sign = Number(change) >= 0 ? '+' : '-'
+  return isOverseas
+    ? `${sign}$${abs.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+    : `${sign}₩${abs.toLocaleString('ko-KR')}`
 }
 
 export default function WatchlistDetail() {
@@ -25,74 +40,114 @@ export default function WatchlistDetail() {
   })
 
   function handleStockClick(item) {
+    const marketType   = item.marketType ?? null
+    const exchangeCode = item.exchangeCode ?? EXCHANGE_CODE_BY_MARKET_TYPE[marketType] ?? null
     open({
       widgetTypeId: 'stock-chart',
-      config: {
-        stockCode:  item.stockCode,
-        stockName:  item.stockName,
-        marketType: item.marketType ?? null,
-      },
+      config: { stockCode: item.stockCode, stockName: item.stockName, marketType, exchangeCode },
     })
   }
 
   return (
-    <div className="flex-1 min-h-0 flex flex-col">
+    <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
       {/* 헤더 */}
-      <div className="shrink-0 px-10 py-3">
-        <div className="max-w-2xl mx-auto pb-3 border-b border-stroke">
+      <div className="shrink-0 px-8 pt-4 pb-3 border-b border-stroke">
+        <div className="flex items-center justify-between">
           <h2 className="text-[15px] font-bold text-foreground">관심 종목</h2>
+          <span className="text-[11px] text-foreground-disabled">{items.length}개</span>
         </div>
       </div>
 
+      {/* 컬럼 헤더 */}
+      {items.length > 0 && (
+        <div className="shrink-0 px-8 py-2 flex items-center text-[10px] font-semibold text-foreground-disabled border-b border-stroke">
+          <span className="flex-1">종목</span>
+          <span className="w-[100px] text-right">현재가</span>
+          <span className="w-[110px] text-right">등락</span>
+          <span className="w-8" />
+        </div>
+      )}
+
       {/* 목록 */}
-      <div className="flex-1 min-h-0 overflow-y-auto px-10 py-2">
-        <div className="max-w-2xl mx-auto">
-          {isLoading ? (
-            <div className="flex items-center justify-center h-20">
-              <span className="text-xs text-foreground-disabled">불러오는 중...</span>
-            </div>
-          ) : !isAuthenticated ? (
-            <div className="flex items-center justify-center h-20">
-              <span className="text-xs text-foreground-disabled">로그인이 필요합니다</span>
-            </div>
-          ) : !items.length ? (
-            <div className="flex items-center justify-center h-20">
-              <span className="text-xs text-foreground-disabled">관심 종목이 없습니다</span>
-            </div>
-          ) : (
-            items.map((item) => (
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        {isLoading ? (
+          <div className="flex items-center justify-center h-20">
+            <span className="text-xs text-foreground-disabled">불러오는 중...</span>
+          </div>
+        ) : !isAuthenticated ? (
+          <div className="flex items-center justify-center h-20">
+            <span className="text-xs text-foreground-disabled">로그인이 필요합니다</span>
+          </div>
+        ) : !items.length ? (
+          <div className="flex items-center justify-center h-20">
+            <span className="text-xs text-foreground-disabled">관심 종목이 없습니다</span>
+          </div>
+        ) : (
+          items.map((item) => {
+            const isOverseas = isForeignMarketType(item.marketType)
+            const changeAmt  = fmtChange(item.change ?? item.changeAmount, item.marketType)
+            const isUp       = (item.changeRate ?? 0) >= 0
+
+            return (
               <button
                 key={item.stockCode}
                 onClick={() => handleStockClick(item)}
-                className="w-full text-left flex items-center gap-4 py-4 border-b border-stroke last:border-b-0 hover:opacity-75 transition-opacity group"
+                className="w-full text-left flex items-center gap-3 px-8 py-3 border-b border-stroke last:border-b-0 hover:bg-surface-muted transition-colors group"
               >
+                {/* 로고 */}
+                <StockAvatar
+                  name={item.stockName}
+                  stockCode={item.stockCode}
+                  marketType={item.marketType}
+                  size="md"
+                />
+
                 {/* 종목명 + 코드 */}
                 <div className="flex-1 flex flex-col gap-0.5 min-w-0">
-                  <span className="text-[14px] font-semibold text-foreground truncate">
+                  <span className="text-[13px] font-semibold text-foreground truncate leading-tight">
                     {item.stockName}
                   </span>
-                  <span className="text-[11px] text-foreground-disabled">{item.stockCode}</span>
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-[10px] text-foreground-disabled">{item.stockCode}</span>
+                    {isOverseas && (
+                      <span className="text-[9px] font-medium text-foreground-disabled bg-surface-subtle rounded px-1 py-px">
+                        {item.marketType}
+                      </span>
+                    )}
+                  </div>
                 </div>
 
-                {/* 가격 + 등락률 */}
-                <div className="flex flex-col items-end gap-0.5 shrink-0">
-                  <span className="text-[14px] font-semibold text-foreground">
+                {/* 현재가 */}
+                <div className="w-[100px] text-right">
+                  <span className="text-[13px] font-bold text-foreground tabular-nums">
                     {fmtPrice(item.currentPrice, item.marketType)}
                   </span>
-                  <PriceChange value={item.changeRate} className="text-[12px] font-medium" />
+                </div>
+
+                {/* 등락 (금액 + 율) */}
+                <div className={cn(
+                  'w-[110px] flex flex-col items-end gap-0.5 tabular-nums',
+                  isUp ? 'text-up' : 'text-down',
+                )}>
+                  {changeAmt && (
+                    <span className="text-[12px] font-semibold">{changeAmt}</span>
+                  )}
+                  <PriceChange value={item.changeRate} className="text-[11px] font-medium" />
                 </div>
 
                 {/* 삭제 버튼 */}
-                <button
-                  onClick={(e) => { e.stopPropagation(); remove.mutate(item.stockCode) }}
-                  className="opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded-lg text-foreground-disabled hover:text-down hover:bg-surface-muted"
-                >
-                  <X className="w-4 h-4" />
-                </button>
+                <div className="w-8 flex justify-center">
+                  <button
+                    onClick={(e) => { e.stopPropagation(); remove.mutate(item.stockCode) }}
+                    className="opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded-lg text-foreground-disabled hover:text-down hover:bg-surface-subtle"
+                  >
+                    <X className="w-4 h-4" />
+                  </button>
+                </div>
               </button>
-            ))
-          )}
-        </div>
+            )
+          })
+        )}
       </div>
     </div>
   )

--- a/src/components/widgets/detail/WatchlistDetail.jsx
+++ b/src/components/widgets/detail/WatchlistDetail.jsx
@@ -2,13 +2,15 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { X } from 'lucide-react'
 import StockAvatar from '@/components/ui/StockAvatar'
 import PriceChange from '@/components/ui/PriceChange'
+import SparklineChart from '@/components/ui/SparklineChart'
 import { useWatchlist, watchlistApi } from '@/api/watchlist'
 import useAuthStore from '@/store/useAuthStore'
 import useWidgetDetailStore from '@/store/useWidgetDetailStore'
+import useSparkline from '@/features/market/useSparkline'
 import { isForeignMarketType } from '@/features/invest/formatters'
+import { cn } from '@/lib/cn'
 
 const EXCHANGE_CODE_BY_MARKET_TYPE = { NASDAQ: 'NAS', NYSE: 'NYS', AMEX: 'AMS' }
-import { cn } from '@/lib/cn'
 
 function fmtPrice(n, marketType) {
   if (n == null) return '-'
@@ -21,11 +23,84 @@ function fmtPrice(n, marketType) {
 function fmtChange(change, marketType) {
   if (change == null) return null
   const isOverseas = isForeignMarketType(marketType)
-  const abs = Math.abs(Number(change))
+  const abs  = Math.abs(Number(change))
   const sign = Number(change) >= 0 ? '+' : '-'
   return isOverseas
     ? `${sign}$${abs.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
     : `${sign}₩${abs.toLocaleString('ko-KR')}`
+}
+
+function WatchlistRow({ item, onStockClick, onRemove }) {
+  const isOverseas = isForeignMarketType(item.marketType)
+  const changeAmt  = fmtChange(item.change ?? item.changeAmount, item.marketType)
+  const isUp       = (item.changeRate ?? 0) >= 0
+
+  const { data: sparkData = [] } = useSparkline(item.stockCode, item.marketType)
+
+  return (
+    <button
+      onClick={() => onStockClick(item)}
+      className="w-full text-left flex items-center gap-3 px-8 py-3 border-b border-stroke last:border-b-0 hover:bg-surface-muted transition-colors group"
+    >
+      {/* 로고 */}
+      <StockAvatar
+        name={item.stockName}
+        stockCode={item.stockCode}
+        marketType={item.marketType}
+        size="md"
+      />
+
+      {/* 종목명 + 코드 */}
+      <div className="flex-1 flex flex-col gap-0.5 min-w-0">
+        <span className="text-[13px] font-semibold text-foreground truncate leading-tight">
+          {item.stockName}
+        </span>
+        <div className="flex items-center gap-1.5">
+          <span className="text-[10px] text-foreground-disabled">{item.stockCode}</span>
+          {isOverseas && (
+            <span className="text-[9px] font-medium text-foreground-disabled bg-surface-subtle rounded px-1 py-px">
+              {item.marketType}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* 스파크라인 */}
+      <SparklineChart
+        data={sparkData}
+        isUp={isUp}
+        className="w-[80px] h-8 shrink-0"
+      />
+
+      {/* 현재가 */}
+      <div className="w-[96px] text-right">
+        <span className="text-[13px] font-bold text-foreground tabular-nums">
+          {fmtPrice(item.currentPrice, item.marketType)}
+        </span>
+      </div>
+
+      {/* 등락 (금액 + 율) */}
+      <div className={cn(
+        'w-[100px] flex flex-col items-end gap-0.5 tabular-nums',
+        isUp ? 'text-up' : 'text-down',
+      )}>
+        {changeAmt && (
+          <span className="text-[12px] font-semibold">{changeAmt}</span>
+        )}
+        <PriceChange value={item.changeRate} className="text-[11px] font-medium" />
+      </div>
+
+      {/* 삭제 버튼 */}
+      <div className="w-8 flex justify-center">
+        <button
+          onClick={(e) => { e.stopPropagation(); onRemove(item.stockCode) }}
+          className="opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded-lg text-foreground-disabled hover:text-down hover:bg-surface-subtle"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+    </button>
+  )
 }
 
 export default function WatchlistDetail() {
@@ -62,8 +137,9 @@ export default function WatchlistDetail() {
       {items.length > 0 && (
         <div className="shrink-0 px-8 py-2 flex items-center text-[10px] font-semibold text-foreground-disabled border-b border-stroke">
           <span className="flex-1">종목</span>
-          <span className="w-[100px] text-right">현재가</span>
-          <span className="w-[110px] text-right">등락</span>
+          <span className="w-[80px] text-center">차트</span>
+          <span className="w-[96px] text-right">현재가</span>
+          <span className="w-[100px] text-right">등락</span>
           <span className="w-8" />
         </div>
       )}
@@ -83,70 +159,14 @@ export default function WatchlistDetail() {
             <span className="text-xs text-foreground-disabled">관심 종목이 없습니다</span>
           </div>
         ) : (
-          items.map((item) => {
-            const isOverseas = isForeignMarketType(item.marketType)
-            const changeAmt  = fmtChange(item.change ?? item.changeAmount, item.marketType)
-            const isUp       = (item.changeRate ?? 0) >= 0
-
-            return (
-              <button
-                key={item.stockCode}
-                onClick={() => handleStockClick(item)}
-                className="w-full text-left flex items-center gap-3 px-8 py-3 border-b border-stroke last:border-b-0 hover:bg-surface-muted transition-colors group"
-              >
-                {/* 로고 */}
-                <StockAvatar
-                  name={item.stockName}
-                  stockCode={item.stockCode}
-                  marketType={item.marketType}
-                  size="md"
-                />
-
-                {/* 종목명 + 코드 */}
-                <div className="flex-1 flex flex-col gap-0.5 min-w-0">
-                  <span className="text-[13px] font-semibold text-foreground truncate leading-tight">
-                    {item.stockName}
-                  </span>
-                  <div className="flex items-center gap-1.5">
-                    <span className="text-[10px] text-foreground-disabled">{item.stockCode}</span>
-                    {isOverseas && (
-                      <span className="text-[9px] font-medium text-foreground-disabled bg-surface-subtle rounded px-1 py-px">
-                        {item.marketType}
-                      </span>
-                    )}
-                  </div>
-                </div>
-
-                {/* 현재가 */}
-                <div className="w-[100px] text-right">
-                  <span className="text-[13px] font-bold text-foreground tabular-nums">
-                    {fmtPrice(item.currentPrice, item.marketType)}
-                  </span>
-                </div>
-
-                {/* 등락 (금액 + 율) */}
-                <div className={cn(
-                  'w-[110px] flex flex-col items-end gap-0.5 tabular-nums',
-                  isUp ? 'text-up' : 'text-down',
-                )}>
-                  {changeAmt && (
-                    <span className="text-[12px] font-semibold">{changeAmt}</span>
-                  )}
-                  <PriceChange value={item.changeRate} className="text-[11px] font-medium" />
-                </div>
-
-                {/* 삭제 버튼 */}
-                <div className="w-8 flex justify-center">
-                  <button
-                    onClick={(e) => { e.stopPropagation(); remove.mutate(item.stockCode) }}
-                    className="opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded-lg text-foreground-disabled hover:text-down hover:bg-surface-subtle"
-                  >
-                    <X className="w-4 h-4" />
-                  </button>
-                </div>
-              </button>
-            )
-          })
+          items.map((item) => (
+            <WatchlistRow
+              key={item.stockCode}
+              item={item}
+              onStockClick={handleStockClick}
+              onRemove={(code) => remove.mutate(code)}
+            />
+          ))
         )}
       </div>
     </div>

--- a/src/components/widgets/detail/WatchlistDetail.jsx
+++ b/src/components/widgets/detail/WatchlistDetail.jsx
@@ -35,7 +35,8 @@ function WatchlistRow({ item, onStockClick, onRemove }) {
   const changeAmt  = fmtChange(item.change ?? item.changeAmount, item.marketType)
   const isUp       = (item.changeRate ?? 0) >= 0
 
-  const { data: sparkData = [] } = useSparkline(item.stockCode, item.marketType)
+  const exchangeCode = item.exchangeCode ?? EXCHANGE_CODE_BY_MARKET_TYPE[item.marketType] ?? null
+  const { data: sparkData = [] } = useSparkline(item.stockCode, item.marketType, exchangeCode)
 
   return (
     <button

--- a/src/components/widgets/detail/WatchlistDetail.jsx
+++ b/src/components/widgets/detail/WatchlistDetail.jsx
@@ -1,0 +1,99 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { X } from 'lucide-react'
+import PriceChange from '@/components/ui/PriceChange'
+import { useWatchlist, watchlistApi } from '@/api/watchlist'
+import useAuthStore from '@/store/useAuthStore'
+import useWidgetDetailStore from '@/store/useWidgetDetailStore'
+
+function fmtPrice(n, market) {
+  if (n == null) return '-'
+  const isOverseas = market && !['KSE', 'KOSDAQ', 'KONEX'].includes(market)
+  return isOverseas
+    ? `$${Number(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+    : `₩${Number(n).toLocaleString('ko-KR')}`
+}
+
+export default function WatchlistDetail() {
+  const { isAuthenticated, isRestoring } = useAuthStore()
+  const { data: items = [], isLoading } = useWatchlist({ enabled: isAuthenticated && !isRestoring })
+  const open = useWidgetDetailStore((s) => s.open)
+
+  const queryClient = useQueryClient()
+  const remove = useMutation({
+    mutationFn: (stockCode) => watchlistApi.removeFromWatchlist(stockCode),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['watchlist'] }),
+  })
+
+  function handleStockClick(item) {
+    open({
+      widgetTypeId: 'stock-chart',
+      config: {
+        stockCode:  item.stockCode,
+        stockName:  item.stockName,
+        marketType: item.marketType ?? null,
+      },
+    })
+  }
+
+  return (
+    <div className="flex-1 min-h-0 flex flex-col">
+      {/* 헤더 */}
+      <div className="shrink-0 px-10 py-3">
+        <div className="max-w-2xl mx-auto pb-3 border-b border-stroke">
+          <h2 className="text-[15px] font-bold text-foreground">관심 종목</h2>
+        </div>
+      </div>
+
+      {/* 목록 */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-10 py-2">
+        <div className="max-w-2xl mx-auto">
+          {isLoading ? (
+            <div className="flex items-center justify-center h-20">
+              <span className="text-xs text-foreground-disabled">불러오는 중...</span>
+            </div>
+          ) : !isAuthenticated ? (
+            <div className="flex items-center justify-center h-20">
+              <span className="text-xs text-foreground-disabled">로그인이 필요합니다</span>
+            </div>
+          ) : !items.length ? (
+            <div className="flex items-center justify-center h-20">
+              <span className="text-xs text-foreground-disabled">관심 종목이 없습니다</span>
+            </div>
+          ) : (
+            items.map((item) => (
+              <button
+                key={item.stockCode}
+                onClick={() => handleStockClick(item)}
+                className="w-full text-left flex items-center gap-4 py-4 border-b border-stroke last:border-b-0 hover:opacity-75 transition-opacity group"
+              >
+                {/* 종목명 + 코드 */}
+                <div className="flex-1 flex flex-col gap-0.5 min-w-0">
+                  <span className="text-[14px] font-semibold text-foreground truncate">
+                    {item.stockName}
+                  </span>
+                  <span className="text-[11px] text-foreground-disabled">{item.stockCode}</span>
+                </div>
+
+                {/* 가격 + 등락률 */}
+                <div className="flex flex-col items-end gap-0.5 shrink-0">
+                  <span className="text-[14px] font-semibold text-foreground">
+                    {fmtPrice(item.currentPrice, item.marketType)}
+                  </span>
+                  <PriceChange value={item.changeRate} className="text-[12px] font-medium" />
+                </div>
+
+                {/* 삭제 버튼 */}
+                <button
+                  onClick={(e) => { e.stopPropagation(); remove.mutate(item.stockCode) }}
+                  className="opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded-lg text-foreground-disabled hover:text-down hover:bg-surface-muted"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              </button>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/data/dashboardPresets.js
+++ b/src/data/dashboardPresets.js
@@ -1,0 +1,107 @@
+/**
+ * 대시보드 프리셋 — DB (fin97901@gmail.com, user_id=204) 에서 읽은 좌표 그대로
+ *
+ * positionX → gridCol, positionY → gridRow, width → colSpan, height → rowSpan
+ * configJson.variantId → variantId
+ */
+
+export const DASHBOARD_PRESETS = [
+  // ── 프리셋 1: 종합형 (dashboard_id=324, order=1) ──────────────────
+  {
+    id:          'preset-standard',
+    name:        '종합형',
+    description: '잔고 · 차트 · 뉴스 · 거래내역',
+    widgets: [
+      { widgetTypeId: 'balance',         variantId: 'balance-sm',     gridCol: 1, gridRow: 1, colSpan: 1, rowSpan: 1 },
+      { widgetTypeId: 'index',           variantId: 'index-3x1',      gridCol: 2, gridRow: 1, colSpan: 3, rowSpan: 1 },
+      { widgetTypeId: 'exchange',        variantId: 'exchange-sm',    gridCol: 5, gridRow: 1, colSpan: 1, rowSpan: 1 },
+      { widgetTypeId: 'portfolio',       variantId: 'portfolio-sm',   gridCol: 6, gridRow: 1, colSpan: 1, rowSpan: 1 },
+      { widgetTypeId: 'stock-chart',     variantId: 'stock-wide',     gridCol: 1, gridRow: 2, colSpan: 2, rowSpan: 1 },
+      { widgetTypeId: 'market-overview', variantId: 'market-wide',    gridCol: 3, gridRow: 2, colSpan: 2, rowSpan: 1 },
+      { widgetTypeId: 'stock-chart',     variantId: 'stock-wide',     gridCol: 5, gridRow: 2, colSpan: 2, rowSpan: 1 },
+      { widgetTypeId: 'stock-chart',     variantId: 'stock-sm',       gridCol: 1, gridRow: 3, colSpan: 1, rowSpan: 1 },
+      { widgetTypeId: 'stock-chart',     variantId: 'stock-sm',       gridCol: 2, gridRow: 3, colSpan: 1, rowSpan: 1 },
+      { widgetTypeId: 'stock-chart',     variantId: 'stock-sm',       gridCol: 3, gridRow: 3, colSpan: 1, rowSpan: 1 },
+      { widgetTypeId: 'stock-chart',     variantId: 'stock-sm',       gridCol: 4, gridRow: 3, colSpan: 1, rowSpan: 1 },
+      { widgetTypeId: 'watchlist',       variantId: 'watchlist-sm',   gridCol: 5, gridRow: 3, colSpan: 1, rowSpan: 1 },
+      { widgetTypeId: 'stock-news',      variantId: 'stock-news-sm',  gridCol: 6, gridRow: 3, colSpan: 1, rowSpan: 1 },
+      { widgetTypeId: 'trade-history',   variantId: 'trade-wide',     gridCol: 1, gridRow: 4, colSpan: 2, rowSpan: 1 },
+      { widgetTypeId: 'stock-chart',     variantId: 'stock-wide',     gridCol: 3, gridRow: 4, colSpan: 2, rowSpan: 1 },
+      { widgetTypeId: 'ranking',         variantId: 'ranking-wide',   gridCol: 5, gridRow: 4, colSpan: 2, rowSpan: 1 },
+    ],
+  },
+
+  // ── 프리셋 2: 차트 중심형 (dashboard_id=325, order=2) ─────────────
+  {
+    id:          'preset-chart',
+    name:        '거래 분석형',
+    description: '여러 차트 · 포트폴리오 · 거래내역',
+    widgets: [
+      { widgetTypeId: 'balance',       variantId: 'balance-3x1',    gridCol: 1, gridRow: 1, colSpan: 3, rowSpan: 1 },
+      { widgetTypeId: 'stock-chart',   variantId: 'stock-sm',       gridCol: 4, gridRow: 1, colSpan: 1, rowSpan: 1 },
+      { widgetTypeId: 'portfolio',     variantId: 'portfolio-2x2',  gridCol: 5, gridRow: 1, colSpan: 2, rowSpan: 2 },
+      { widgetTypeId: 'watchlist',     variantId: 'watchlist-wide', gridCol: 1, gridRow: 2, colSpan: 2, rowSpan: 1 },
+      { widgetTypeId: 'stock-chart',   variantId: 'stock-wide',     gridCol: 3, gridRow: 2, colSpan: 2, rowSpan: 1 },
+      { widgetTypeId: 'stock-chart',   variantId: 'stock-sm',       gridCol: 1, gridRow: 3, colSpan: 1, rowSpan: 1 },
+      { widgetTypeId: 'stock-chart',   variantId: 'stock-wide',     gridCol: 2, gridRow: 3, colSpan: 2, rowSpan: 1 },
+      { widgetTypeId: 'trade-history', variantId: 'trade-3x2',      gridCol: 4, gridRow: 3, colSpan: 3, rowSpan: 2 },
+      { widgetTypeId: 'stock-chart',   variantId: 'stock-sm',       gridCol: 1, gridRow: 4, colSpan: 1, rowSpan: 1 },
+      { widgetTypeId: 'stock-chart',   variantId: 'stock-wide',     gridCol: 2, gridRow: 4, colSpan: 2, rowSpan: 1 },
+    ],
+  },
+
+  // ── 프리셋 3: 시황·뉴스형 (dashboard_id=326, order=3) ─────────────
+  {
+    id:          'preset-market',
+    name:        '시황·뉴스형',
+    description: '시황 · 순위 · 뉴스 · 환율 · 지수',
+    widgets: [
+      { widgetTypeId: 'stock-news',    variantId: 'stock-news-sm',  gridCol: 1, gridRow: 1, colSpan: 1, rowSpan: 1 },
+      { widgetTypeId: 'ranking',       variantId: 'ranking-lg',     gridCol: 2, gridRow: 1, colSpan: 2, rowSpan: 2 },
+      { widgetTypeId: 'stock-chart',   variantId: 'stock-3x2',      gridCol: 4, gridRow: 1, colSpan: 3, rowSpan: 2 },
+      { widgetTypeId: 'exchange',      variantId: 'exchange-sm',    gridCol: 1, gridRow: 2, colSpan: 1, rowSpan: 1 },
+      { widgetTypeId: 'market-overview', variantId: 'market-2x2',  gridCol: 1, gridRow: 3, colSpan: 2, rowSpan: 2 },
+      { widgetTypeId: 'stock-news',    variantId: 'stock-news-2x2', gridCol: 3, gridRow: 3, colSpan: 2, rowSpan: 2 },
+      { widgetTypeId: 'watchlist',     variantId: 'watchlist-wide', gridCol: 5, gridRow: 3, colSpan: 2, rowSpan: 1 },
+      { widgetTypeId: 'index',         variantId: 'index-wide',     gridCol: 5, gridRow: 4, colSpan: 2, rowSpan: 1 },
+    ],
+  },
+
+  // ── 프리셋 4: 자산 관리형 (dashboard_id=327, order=4) ─────────────
+  {
+    id:          'preset-asset',
+    name:        '자산 관리형',
+    description: '잔고 · 포트폴리오 · 지수 · 시황 · 순위',
+    widgets: [
+      { widgetTypeId: 'balance',         variantId: 'balance-lg',      gridCol: 1, gridRow: 1, colSpan: 2, rowSpan: 1 },
+      { widgetTypeId: 'stock-news',      variantId: 'stock-news-sm',   gridCol: 3, gridRow: 1, colSpan: 1, rowSpan: 1 },
+      { widgetTypeId: 'index',           variantId: 'index-wide',      gridCol: 4, gridRow: 1, colSpan: 2, rowSpan: 1 },
+      { widgetTypeId: 'exchange',        variantId: 'exchange-sm',     gridCol: 6, gridRow: 1, colSpan: 1, rowSpan: 1 },
+      { widgetTypeId: 'portfolio',       variantId: 'portfolio-wide',  gridCol: 1, gridRow: 2, colSpan: 2, rowSpan: 1 },
+      { widgetTypeId: 'watchlist',       variantId: 'watchlist-wide',  gridCol: 3, gridRow: 2, colSpan: 2, rowSpan: 1 },
+      { widgetTypeId: 'market-overview', variantId: 'market-wide',     gridCol: 5, gridRow: 2, colSpan: 2, rowSpan: 1 },
+      { widgetTypeId: 'stock-chart',     variantId: 'stock-2x2',       gridCol: 1, gridRow: 3, colSpan: 2, rowSpan: 2 },
+      { widgetTypeId: 'trade-history',   variantId: 'trade-wide',      gridCol: 3, gridRow: 3, colSpan: 2, rowSpan: 1 },
+      { widgetTypeId: 'ranking',         variantId: 'ranking-lg',      gridCol: 5, gridRow: 3, colSpan: 2, rowSpan: 2 },
+      { widgetTypeId: 'stock-chart',     variantId: 'stock-wide',      gridCol: 3, gridRow: 4, colSpan: 2, rowSpan: 1 },
+    ],
+  },
+
+  // ── 프리셋 5: 차트 집중형 (dashboard_id=328, order=5) ─────────────
+  {
+    id:          'preset-charts-only',
+    name:        '차트 집중형',
+    description: '다수 차트 · 포트폴리오 · 관심종목',
+    widgets: [
+      { widgetTypeId: 'portfolio',   variantId: 'portfolio-wide', gridCol: 1, gridRow: 1, colSpan: 2, rowSpan: 1 },
+      { widgetTypeId: 'stock-chart', variantId: 'stock-2x2',      gridCol: 3, gridRow: 1, colSpan: 2, rowSpan: 2 },
+      { widgetTypeId: 'watchlist',   variantId: 'watchlist-wide', gridCol: 5, gridRow: 1, colSpan: 2, rowSpan: 1 },
+      { widgetTypeId: 'stock-chart', variantId: 'stock-wide',     gridCol: 1, gridRow: 2, colSpan: 2, rowSpan: 1 },
+      { widgetTypeId: 'stock-chart', variantId: 'stock-wide',     gridCol: 5, gridRow: 2, colSpan: 2, rowSpan: 1 },
+      { widgetTypeId: 'stock-chart', variantId: 'stock-sm',       gridCol: 1, gridRow: 3, colSpan: 1, rowSpan: 1 },
+      { widgetTypeId: 'stock-chart', variantId: 'stock-3x2',      gridCol: 2, gridRow: 3, colSpan: 3, rowSpan: 2 },
+      { widgetTypeId: 'stock-chart', variantId: 'stock-2x2',      gridCol: 5, gridRow: 3, colSpan: 2, rowSpan: 2 },
+      { widgetTypeId: 'stock-chart', variantId: 'stock-sm',       gridCol: 1, gridRow: 4, colSpan: 1, rowSpan: 1 },
+    ],
+  },
+]

--- a/src/data/dashboardPresets.js
+++ b/src/data/dashboardPresets.js
@@ -1,5 +1,5 @@
 /**
- * 대시보드 프리셋 — DB (fin97901@gmail.com, user_id=204) 에서 읽은 좌표 그대로
+ * 대시보드 프리셋
  *
  * positionX → gridCol, positionY → gridRow, width → colSpan, height → rowSpan
  * configJson.variantId → variantId

--- a/src/features/invest/domestic/useMarketData.js
+++ b/src/features/invest/domestic/useMarketData.js
@@ -122,7 +122,7 @@ export default function useDomesticMarketData(stockCode, { enabled, activeDetail
     () => initialPeriod ?? localStorage.getItem('invest.chartPeriod') ?? 'MINUTE',
   )
   const [selectedMinuteInterval, setSelectedMinuteInterval] = useState(
-    () => initialMinuteInterval ?? Number(localStorage.getItem('invest.minuteInterval')) || DEFAULT_MINUTE_INTERVAL,
+    () => initialMinuteInterval ?? (Number(localStorage.getItem('invest.minuteInterval')) || DEFAULT_MINUTE_INTERVAL),
   )
   const [liveCandle, setLiveCandle] = useState(null)
   const [liveTrades, setLiveTrades] = useState([])

--- a/src/features/invest/domestic/useMarketData.js
+++ b/src/features/invest/domestic/useMarketData.js
@@ -117,12 +117,12 @@ function formatLocalDateTime(timestamp) {
   return `${yyyy}-${mm}-${dd}T${hh}:${mi}:${ss}`
 }
 
-export default function useDomesticMarketData(stockCode, { enabled, activeDetailTab = 'daily' }) {
+export default function useDomesticMarketData(stockCode, { enabled, activeDetailTab = 'daily', initialPeriod, initialMinuteInterval }) {
   const [selectedChartPeriod, setSelectedChartPeriod] = useState(
-    () => localStorage.getItem('invest.chartPeriod') ?? 'MINUTE',
+    () => initialPeriod ?? localStorage.getItem('invest.chartPeriod') ?? 'MINUTE',
   )
   const [selectedMinuteInterval, setSelectedMinuteInterval] = useState(
-    () => Number(localStorage.getItem('invest.minuteInterval')) || DEFAULT_MINUTE_INTERVAL,
+    () => initialMinuteInterval ?? Number(localStorage.getItem('invest.minuteInterval')) || DEFAULT_MINUTE_INTERVAL,
   )
   const [liveCandle, setLiveCandle] = useState(null)
   const [liveTrades, setLiveTrades] = useState([])

--- a/src/features/invest/foreign/useMarketData.js
+++ b/src/features/invest/foreign/useMarketData.js
@@ -19,12 +19,12 @@ const STALE = {
   orderBook: 1000 * 5,
 }
 
-export default function useForeignMarketData(stockCode, exchcd, { enabled }) {
+export default function useForeignMarketData(stockCode, exchcd, { enabled, initialPeriod, initialMinuteInterval }) {
   const [selectedChartPeriod, setSelectedChartPeriod] = useState(
-    () => localStorage.getItem('invest.chartPeriod') ?? 'MINUTE',
+    () => initialPeriod ?? localStorage.getItem('invest.chartPeriod') ?? 'MINUTE',
   )
   const [selectedMinuteInterval, setSelectedMinuteInterval] = useState(
-    () => Number(localStorage.getItem('invest.minuteInterval')) || DEFAULT_MINUTE_INTERVAL,
+    () => initialMinuteInterval ?? Number(localStorage.getItem('invest.minuteInterval')) || DEFAULT_MINUTE_INTERVAL,
   )
 
   const { endDate, startDate } = useMemo(() => {

--- a/src/features/invest/foreign/useMarketData.js
+++ b/src/features/invest/foreign/useMarketData.js
@@ -24,7 +24,7 @@ export default function useForeignMarketData(stockCode, exchcd, { enabled, initi
     () => initialPeriod ?? localStorage.getItem('invest.chartPeriod') ?? 'MINUTE',
   )
   const [selectedMinuteInterval, setSelectedMinuteInterval] = useState(
-    () => initialMinuteInterval ?? Number(localStorage.getItem('invest.minuteInterval')) || DEFAULT_MINUTE_INTERVAL,
+    () => initialMinuteInterval ?? (Number(localStorage.getItem('invest.minuteInterval')) || DEFAULT_MINUTE_INTERVAL),
   )
 
   const { endDate, startDate } = useMemo(() => {

--- a/src/features/invest/marketData.js
+++ b/src/features/invest/marketData.js
@@ -22,10 +22,15 @@ export function getChartPeriodLabel(periodKey, minuteInterval) {
   return getChartPeriodConfig(periodKey).periodLabel
 }
 
+const MARKET_TYPE_BY_EXCHANGE_CODE = { NAS: 'NASDAQ', NYS: 'NYSE', AMS: 'AMEX' }
+
 export function resolveStockMeta(stockCode, locationState) {
   const known = STOCK_META_BY_CODE[stockCode]
-  const marketType = locationState?.marketType ?? known?.market ?? null
   const exchangeCode = locationState?.exchangeCode ?? null
+  // exchangeCode가 있으면 역으로 marketType 파생 가능
+  const marketType = locationState?.marketType
+    ?? known?.market
+    ?? (exchangeCode ? MARKET_TYPE_BY_EXCHANGE_CODE[exchangeCode] : null)
   const isDomestic = exchangeCode == null
     ? (!marketType || ['KOSPI', 'KOSDAQ'].includes(marketType))
     : ['KOSPI', 'KOSDAQ'].includes(marketType)

--- a/src/features/invest/marketData.js
+++ b/src/features/invest/marketData.js
@@ -34,7 +34,7 @@ export function resolveStockMeta(stockCode, locationState) {
     name: known?.name ?? locationState?.stockName ?? stockCode,
     nameEn: locationState?.stockNameEn ?? null,
     code: stockCode,
-    market: known?.market ?? marketType ?? '-',
+    market: known?.market ?? marketType ?? null,
     exchangeCode,
     sector: known?.sector ?? '-',
     isDomestic,

--- a/src/features/invest/marketData.js
+++ b/src/features/invest/marketData.js
@@ -23,6 +23,8 @@ export function getChartPeriodLabel(periodKey, minuteInterval) {
 }
 
 const MARKET_TYPE_BY_EXCHANGE_CODE = { NAS: 'NASDAQ', NYS: 'NYSE', AMS: 'AMEX' }
+// 국내 종목코드는 항상 6자리 숫자 (005930), 해외는 알파벳 포함 (NVDA, AAPL)
+const DOMESTIC_CODE_RE = /^\d{6}$/
 
 export function resolveStockMeta(stockCode, locationState) {
   const known = STOCK_META_BY_CODE[stockCode]
@@ -31,9 +33,15 @@ export function resolveStockMeta(stockCode, locationState) {
   const marketType = locationState?.marketType
     ?? known?.market
     ?? (exchangeCode ? MARKET_TYPE_BY_EXCHANGE_CODE[exchangeCode] : null)
-  const isDomestic = exchangeCode == null
-    ? (!marketType || ['KOSPI', 'KOSDAQ'].includes(marketType))
-    : ['KOSPI', 'KOSDAQ'].includes(marketType)
+
+  // 종목코드 패턴 기반 해외 여부 (marketType/exchangeCode 없을 때 최후 가드)
+  const looksLikeForeign = !DOMESTIC_CODE_RE.test(stockCode)
+
+  const isDomestic = looksLikeForeign
+    ? false  // 알파벳 포함 코드는 항상 해외
+    : exchangeCode == null
+      ? (!marketType || ['KOSPI', 'KOSDAQ'].includes(marketType))
+      : ['KOSPI', 'KOSDAQ'].includes(marketType)
 
   return {
     name: known?.name ?? locationState?.stockName ?? stockCode,

--- a/src/features/invest/useInvestMarketData.js
+++ b/src/features/invest/useInvestMarketData.js
@@ -38,7 +38,7 @@ export default function useInvestMarketData(stockCode, locationState, { activeLe
 
     return {
       ...baseStockMeta,
-      marketType: baseStockMeta.market,
+      marketType: baseStockMeta.market,  // NASDAQ / NYSE / AMEX — API 파라미터용으로 유지
       name: infoQuery.data?.korname ?? baseStockMeta.name,
       nameEn: infoQuery.data?.engname ?? baseStockMeta.nameEn,
       market: infoQuery.data?.exchangeName ?? baseStockMeta.market,

--- a/src/features/invest/useInvestMarketData.js
+++ b/src/features/invest/useInvestMarketData.js
@@ -9,7 +9,7 @@ import {
 import useDomesticMarketData from '@/features/invest/domestic/useMarketData'
 import useForeignMarketData from '@/features/invest/foreign/useMarketData'
 
-export default function useInvestMarketData(stockCode, locationState, { activeLeftTab = 'daily' } = {}) {
+export default function useInvestMarketData(stockCode, locationState, { activeLeftTab = 'daily', initialPeriod, initialMinuteInterval } = {}) {
   const baseStockMeta = resolveStockMeta(stockCode, locationState)
   const { isDomestic } = baseStockMeta
   const exchcd = isDomestic ? null : getExchcd(baseStockMeta.exchangeCode)
@@ -45,8 +45,8 @@ export default function useInvestMarketData(stockCode, locationState, { activeLe
     }
   }, [baseStockMeta, infoQuery.data, isDomestic])
 
-  const domestic = useDomesticMarketData(stockCode, { enabled: isDomestic, activeDetailTab: activeLeftTab })
-  const foreign = useForeignMarketData(stockCode, exchcd, { enabled: !isDomestic, activeDetailTab: activeLeftTab })
+  const domestic = useDomesticMarketData(stockCode, { enabled: isDomestic, activeDetailTab: activeLeftTab, initialPeriod, initialMinuteInterval })
+  const foreign = useForeignMarketData(stockCode, exchcd, { enabled: !isDomestic, activeDetailTab: activeLeftTab, initialPeriod, initialMinuteInterval })
 
   const active = isDomestic ? domestic : foreign
   const { marketState, chartState, detailState, selectedChartPeriod, selectedMinuteInterval } = active

--- a/src/features/invest/useInvestMarketData.js
+++ b/src/features/invest/useInvestMarketData.js
@@ -36,9 +36,12 @@ export default function useInvestMarketData(stockCode, locationState, { activeLe
       }
     }
 
+    // exchangeName은 표시용(예: '나스닥'), marketType은 API 파라미터용(NASDAQ/NYSE/AMEX)
+    const MARKET_TYPE_BY_EXCHCD = { '82': 'NASDAQ', '81': 'NYSE' }
+    const resolvedMarketType = baseStockMeta.market ?? MARKET_TYPE_BY_EXCHCD[exchcd] ?? 'NASDAQ'
     return {
       ...baseStockMeta,
-      marketType: baseStockMeta.market,  // NASDAQ / NYSE / AMEX — API 파라미터용으로 유지
+      marketType: resolvedMarketType,
       name: infoQuery.data?.korname ?? baseStockMeta.name,
       nameEn: infoQuery.data?.engname ?? baseStockMeta.nameEn,
       market: infoQuery.data?.exchangeName ?? baseStockMeta.market,

--- a/src/features/invest/useInvestMarketData.js
+++ b/src/features/invest/useInvestMarketData.js
@@ -27,10 +27,11 @@ export default function useInvestMarketData(stockCode, locationState, { activeLe
 
   const stockMeta = useMemo(() => {
     if (isDomestic) {
+      const resolvedMarket = infoQuery.data?.marketName ?? baseStockMeta.market
       return {
         ...baseStockMeta,
-        marketType: baseStockMeta.market,
-        market: infoQuery.data?.marketName ?? baseStockMeta.market,
+        marketType: resolvedMarket,
+        market: resolvedMarket,
         sector: infoQuery.data?.sector ?? baseStockMeta.sector,
       }
     }

--- a/src/features/market/useForexChart.js
+++ b/src/features/market/useForexChart.js
@@ -1,0 +1,62 @@
+import { useQuery } from '@tanstack/react-query'
+import { marketApi } from '@/api/market'
+
+const PERIOD_MAP = {
+  '1D': { interval: '5m', range: '1d'  },
+  '1M': { interval: '1h', range: '1mo' },
+  '3M': { interval: '1d', range: '3mo' },
+  '1Y': { interval: '1d', range: '1y'  },
+}
+
+// 1d 미만 interval: Unix timestamp (초) — datetime 문자열
+// 1d interval: "YYYY-MM-DD" 문자열 — 타임존 이슈 방지
+function toTime(timeStr, isIntraday) {
+  if (isIntraday) return Math.floor(new Date(timeStr).getTime() / 1000)
+  return timeStr.slice(0, 10)
+}
+
+function toLineData(candles, isIntraday) {
+  return candles
+    .map((c) => ({ time: toTime(c.time, isIntraday), value: Number(c.close) }))
+    .sort((a, b) => (a.time > b.time ? 1 : a.time < b.time ? -1 : 0))
+}
+
+function toCandleData(candles, isIntraday) {
+  return candles
+    .map((c) => ({
+      time:  toTime(c.time, isIntraday),
+      open:  Number(c.open),
+      high:  Number(c.high),
+      low:   Number(c.low),
+      close: Number(c.close),
+    }))
+    .sort((a, b) => (a.time > b.time ? 1 : a.time < b.time ? -1 : 0))
+}
+
+export default function useForexChart(symbol, period) {
+  const isIntraday = period === '1D' || period === '1M'
+  const { interval, range } = PERIOD_MAP[period] ?? PERIOD_MAP['3M']
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['forex', 'chart', symbol, period],
+    queryFn: async () => {
+      const res = await marketApi.getForexChart({ symbol, interval, range })
+      const candles = res.data ?? []
+      return {
+        lineData:   toLineData(candles, isIntraday),
+        candleData: toCandleData(candles, isIntraday),
+      }
+    },
+    enabled: !!symbol && !!period,
+    staleTime: isIntraday ? 30 * 1000 : 5 * 60 * 1000,
+    retry: false,
+  })
+
+  return {
+    lineData:   data?.lineData   ?? [],
+    candleData: data?.candleData ?? [],
+    isLoading,
+    isIntraday,
+    error,
+  }
+}

--- a/src/features/market/useIndexChart.js
+++ b/src/features/market/useIndexChart.js
@@ -1,0 +1,55 @@
+import { useQuery } from '@tanstack/react-query'
+import { marketApi } from '@/api/market'
+
+function toTime(item, isIntraday) {
+  return Math.floor(new Date(isIntraday ? item.datetime : item.date).getTime() / 1000)
+}
+
+function toLineData(items, isIntraday) {
+  return items
+    .map((d) => ({ time: toTime(d, isIntraday), value: Number(d.close) }))
+    .sort((a, b) => a.time - b.time)
+}
+
+function toCandleData(items, isIntraday) {
+  return items
+    .map((d) => ({
+      time:  toTime(d, isIntraday),
+      open:  Number(d.open),
+      high:  Number(d.high),
+      low:   Number(d.low),
+      close: Number(d.close),
+    }))
+    .sort((a, b) => a.time - b.time)
+}
+
+// '1D': 분봉(오늘 장중) / 나머지: 일봉
+export default function useIndexChart(code, period = '3M') {
+  const isIntraday = period === '1D'
+  const count = period === '1M' ? 30 : period === '1Y' ? 250 : 90
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['index', 'chart', code, period],
+    queryFn: async () => {
+      const res = isIntraday
+        ? await marketApi.getIndexMinuteChart(code, { ncnt: 5 })
+        : await marketApi.getIndexChart(code, { count })
+      const items = res.data ?? []
+      return {
+        lineData:   toLineData(items, isIntraday),
+        candleData: toCandleData(items, isIntraday),
+      }
+    },
+    enabled: !!code && period !== null,
+    staleTime: isIntraday ? 30 * 1000 : 5 * 60 * 1000,
+    retry: false,
+  })
+
+  return {
+    lineData:   data?.lineData   ?? [],
+    candleData: data?.candleData ?? [],
+    isLoading,
+    isIntraday,
+    error,
+  }
+}

--- a/src/features/market/useLatestNews.js
+++ b/src/features/market/useLatestNews.js
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query'
+import { newsApi } from '@/api/news'
+
+const KR_INDICES = ['KOSPI', 'KOSDAQ']
+const US_INDICES = ['NASDAQ', 'S&P500', 'DOW']
+
+export default function useLatestNews(size = 10) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['news', 'latest', size],
+    queryFn: () => newsApi.getLatestNews({ size }),
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  })
+
+  const all = data ?? []
+  const kr  = all.filter((n) => !n.stockIndex || KR_INDICES.includes(n.stockIndex))
+  const us  = all.filter((n) => US_INDICES.includes(n.stockIndex))
+
+  return { news: all, krNews: kr, usNews: us, isLoading, error }
+}

--- a/src/features/market/useMarketIndices.js
+++ b/src/features/market/useMarketIndices.js
@@ -8,7 +8,7 @@ const DEBUG_MARKET_INDICES = import.meta.env.DEV
 // 백엔드 code → WebSocket topic 매핑
 const INDEX_TOPICS = {
   '001':      '/topic/index/domestic/001',
-  '101':      '/topic/index/domestic/101',
+  '301':      '/topic/index/domestic/301',
   'SPI@SPX':  '/topic/index/foreign/SPI@SPX',
   'NAS@IXIC': '/topic/index/foreign/NAS@IXIC',
   USD:        '/topic/currency/USD',

--- a/src/features/market/useSparkline.js
+++ b/src/features/market/useSparkline.js
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query'
+import { marketApi, foreignMarketApi, getExchcd } from '@/api/market'
+import { normalizeMinuteSeries } from '@/features/invest/domestic/normalize'
+import { isForeignMarketType } from '@/features/invest/formatters'
+
+const EXCHANGE_CODE_BY_MARKET_TYPE = { NASDAQ: 'NAS', NYSE: 'NYS', AMEX: 'AMS' }
+
+export default function useSparkline(stockCode, marketType, { enabled = true } = {}) {
+  const isForeign = isForeignMarketType(marketType)
+  const exchcd    = isForeign ? getExchcd(EXCHANGE_CODE_BY_MARKET_TYPE[marketType]) : null
+
+  return useQuery({
+    queryKey: ['sparkline', stockCode, marketType],
+    queryFn: async () => {
+      const res = isForeign
+        ? await foreignMarketApi.getMinuteChart(stockCode, exchcd, { ncnt: 5 })
+        : await marketApi.getMinuteChart(stockCode, { ncnt: 5 })
+      return normalizeMinuteSeries(res?.data ?? [])
+    },
+    staleTime: 1000 * 60,
+    enabled: enabled && Boolean(stockCode),
+  })
+}

--- a/src/features/market/useSparkline.js
+++ b/src/features/market/useSparkline.js
@@ -4,13 +4,17 @@ import { normalizeMinuteSeries } from '@/features/invest/domestic/normalize'
 import { isForeignMarketType } from '@/features/invest/formatters'
 
 const EXCHANGE_CODE_BY_MARKET_TYPE = { NASDAQ: 'NAS', NYSE: 'NYS', AMEX: 'AMS' }
+const MARKET_TYPE_BY_EXCHANGE_CODE  = { NAS: 'NASDAQ', NYS: 'NYSE', AMS: 'AMEX' }
 
-export default function useSparkline(stockCode, marketType, { enabled = true } = {}) {
-  const isForeign = isForeignMarketType(marketType)
-  const exchcd    = isForeign ? getExchcd(EXCHANGE_CODE_BY_MARKET_TYPE[marketType]) : null
+export default function useSparkline(stockCode, marketType, exchangeCode, { enabled = true } = {}) {
+  // exchangeCode(NAS/NYS/AMS)가 있으면 우선, 없으면 marketType으로 판별
+  const resolvedMarketType = marketType ?? (exchangeCode ? MARKET_TYPE_BY_EXCHANGE_CODE[exchangeCode] : null)
+  const isForeign = isForeignMarketType(resolvedMarketType)
+  const resolvedExchangeCode = exchangeCode ?? (resolvedMarketType ? EXCHANGE_CODE_BY_MARKET_TYPE[resolvedMarketType] : null)
+  const exchcd = isForeign ? getExchcd(resolvedExchangeCode) : null
 
   return useQuery({
-    queryKey: ['sparkline', stockCode, marketType],
+    queryKey: ['sparkline', stockCode, resolvedMarketType],
     queryFn: async () => {
       const res = isForeign
         ? await foreignMarketApi.getMinuteChart(stockCode, exchcd, { ncnt: 5 })

--- a/src/features/market/useSparkline.js
+++ b/src/features/market/useSparkline.js
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { marketApi, foreignMarketApi, getExchcd } from '@/api/market'
 import { normalizeMinuteSeries } from '@/features/invest/domestic/normalize'
+import { normalizeForeignMinuteSeries } from '@/features/invest/foreign/normalize'
 import { isForeignMarketType } from '@/features/invest/formatters'
 
 const EXCHANGE_CODE_BY_MARKET_TYPE = { NASDAQ: 'NAS', NYSE: 'NYS', AMEX: 'AMS' }
@@ -16,9 +17,11 @@ export default function useSparkline(stockCode, marketType, exchangeCode, { enab
   return useQuery({
     queryKey: ['sparkline', stockCode, resolvedMarketType],
     queryFn: async () => {
-      const res = isForeign
-        ? await foreignMarketApi.getMinuteChart(stockCode, exchcd, { ncnt: 5 })
-        : await marketApi.getMinuteChart(stockCode, { ncnt: 5 })
+      if (isForeign) {
+        const res = await foreignMarketApi.getMinuteChart(stockCode, exchcd, { ncnt: 5 })
+        return normalizeForeignMinuteSeries(res?.data ?? [])
+      }
+      const res = await marketApi.getMinuteChart(stockCode, { ncnt: 5 })
       return normalizeMinuteSeries(res?.data ?? [])
     },
     staleTime: 1000 * 60,

--- a/src/features/market/useSparkline.js
+++ b/src/features/market/useSparkline.js
@@ -18,7 +18,7 @@ export default function useSparkline(stockCode, marketType, exchangeCode, { enab
     queryKey: ['sparkline', stockCode, resolvedMarketType],
     queryFn: async () => {
       if (isForeign) {
-        const res = await foreignMarketApi.getMinuteChart(stockCode, exchcd, { ncnt: 5 })
+        const res = await foreignMarketApi.getMinuteChart(stockCode, exchcd, { nmin: 5 })
         return normalizeForeignMinuteSeries(res?.data ?? [])
       }
       const res = await marketApi.getMinuteChart(stockCode, { ncnt: 5 })

--- a/src/features/market/useStockNews.js
+++ b/src/features/market/useStockNews.js
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query'
+import { newsApi } from '@/api/news'
+
+export default function useStockNews(stockCode, size = 5) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['stock-news', stockCode, size],
+    queryFn: () => newsApi.getStockNews(stockCode, size),
+    enabled: !!stockCode,
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  })
+
+  return { news: data ?? [], isLoading, error }
+}

--- a/src/features/widget/stockChartConfig.js
+++ b/src/features/widget/stockChartConfig.js
@@ -1,0 +1,20 @@
+export const STOCK_CODE_MAP = {
+  samsung: '005930',
+  skhynix: '000660',
+}
+
+export const PERIODS = ['1일', '1주', '1달', '3달']
+
+export const PERIOD_CONFIG = {
+  '1일': { type: 'minute', ncnt: 5                             },
+  '1주': { type: 'daily',  period: 'DAILY',  days: 7          },
+  '1달': { type: 'daily',  period: 'DAILY',  days: 30         },
+  '3달': { type: 'weekly', period: 'WEEKLY', days: 90         },
+}
+
+export function fmtVolume(v) {
+  if (v == null) return '-'
+  if (v >= 100_000_000) return `${(v / 100_000_000).toFixed(1)}억`
+  if (v >= 10_000)      return `${Math.round(v / 10_000).toLocaleString('ko-KR')}만`
+  return v.toLocaleString('ko-KR')
+}

--- a/src/index.css
+++ b/src/index.css
@@ -103,6 +103,9 @@
   --shadow-focus-ring:    0 0 0 3px rgba(0,70,255,.08);
   --shadow-delete-btn:    0 2px 6px rgba(0,0,0,.22);
 
+  /* ── Summary Card ── */
+  --background-summary-card: linear-gradient(135deg, var(--color-primary-light) 0%, var(--color-primary-dim) 100%);
+
   /* ── Animation ── */
   --animate-pulse-dot:  pulse-dot 2000ms ease-in-out infinite;
   --animate-bubble-in:  bubble-in 220ms ease both;

--- a/src/index.css
+++ b/src/index.css
@@ -108,7 +108,9 @@
   --animate-bubble-in:  bubble-in 220ms ease both;
   --animate-wiggle:     wiggle 1100ms ease-in-out infinite;
   --animate-modal-in:   modal-in 200ms ease both;
-  --animate-fill-up: fill-up 1.4s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+  --animate-fill-up:    fill-up    1.4s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+  --animate-slide-up:   slide-up   300ms cubic-bezier(0.32, 0.72, 0, 1) both;
+  --animate-slide-down: slide-down 240ms ease-in both;
 }
 
 /* ─────────────────────────────────────────────
@@ -138,6 +140,16 @@
 @keyframes fill-up {
   0%   { clip-path: inset(100% 0 0 0); }
   100% { clip-path: inset(0% 0 0 0); }
+}
+
+@keyframes slide-up {
+  from { transform: translateY(100%); }
+  to   { transform: translateY(0); }
+}
+
+@keyframes slide-down {
+  from { transform: translateY(0); }
+  to   { transform: translateY(100%); }
 }
 
 /* ─────────────────────────────────────────────

--- a/src/lib/fetchWithAuth.js
+++ b/src/lib/fetchWithAuth.js
@@ -3,6 +3,25 @@ import useAuthStore from '@/store/useAuthStore'
 let isRefreshing = false
 let refreshSubscribers = []
 
+// 탭 간 refresh/logout 동기화
+const authChannel = typeof BroadcastChannel !== 'undefined'
+  ? new BroadcastChannel('sol_auth')
+  : null
+
+authChannel?.addEventListener('message', ({ data }) => {
+  if (data.type === 'TOKEN_REFRESHED') {
+    const { accessToken } = data
+    const storage = localStorage.getItem('accessToken') ? localStorage : sessionStorage
+    storage.setItem('accessToken', accessToken)
+    useAuthStore.setState({ accessToken })
+  } else if (data.type === 'LOGOUT') {
+    if (useAuthStore.getState().isAuthenticated) {
+      useAuthStore.getState().logout({ broadcast: false })
+      useAuthStore.getState().openLoginModal()
+    }
+  }
+})
+
 function onRefreshed(newToken) {
   refreshSubscribers.forEach((cb) => cb(newToken))
   refreshSubscribers = []
@@ -83,12 +102,23 @@ export async function fetchWithAuth(url, options = {}) {
         const storage = localStorage.getItem('accessToken') ? localStorage : sessionStorage
         storage.setItem('accessToken', newToken)
         useAuthStore.setState({ accessToken: newToken })
+        // 다른 탭에 새 토큰 브로드캐스트
+        authChannel?.postMessage({ type: 'TOKEN_REFRESHED', accessToken: newToken })
         onRefreshed(newToken)
       })
       .catch((err) => {
-        onRefreshFailed(err)
-        useAuthStore.getState().logout()
-        useAuthStore.getState().openLoginModal()
+        // 다른 탭이 이미 rotation 완료했는지 확인 (멀티탭 race condition)
+        const latestToken =
+          localStorage.getItem('accessToken') ?? sessionStorage.getItem('accessToken')
+        const currentToken = useAuthStore.getState().accessToken
+        if (latestToken && latestToken !== currentToken) {
+          useAuthStore.setState({ accessToken: latestToken })
+          onRefreshed(latestToken)
+        } else {
+          onRefreshFailed(err)
+          useAuthStore.getState().logout({ broadcast: true })
+          useAuthStore.getState().openLoginModal()
+        }
       })
       .finally(() => {
         isRefreshing = false

--- a/src/pages/AssetPage.jsx
+++ b/src/pages/AssetPage.jsx
@@ -626,6 +626,10 @@ function AuthGuard() {
 
 // ── 메인 페이지 ───────────────────────────────────────────────────
 export default function AssetPage() {
+  return <AssetContent />
+}
+
+export function AssetContent() {
   const { isAuthenticated, isRestoring, user } = useAuthStore()
   const [assetFlowRange, setAssetFlowRange] = useState('1M')
   const data = useAssetPage(isAuthenticated && !isRestoring, assetFlowRange)

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useCallback, useState } from 'react'
-import { Pencil, LayoutTemplate, X, ChevronRight } from 'lucide-react'
+import { Pencil, LayoutTemplate, X, ChevronRight, LayoutGrid, Plus } from 'lucide-react'
 import { useDashboardSave } from '@/hooks/useDashboardSync'
 import { useDroppable } from '@dnd-kit/core'
 import LiveDot from '@/components/ui/LiveDot'

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback, useState } from 'react'
-import { Pencil } from 'lucide-react'
+import { Pencil, LayoutTemplate, X, ChevronRight } from 'lucide-react'
+import { useDashboardSave } from '@/hooks/useDashboardSync'
 import { useDroppable } from '@dnd-kit/core'
 import LiveDot from '@/components/ui/LiveDot'
 import useEditModeStore from '@/store/useEditModeStore'
@@ -11,6 +12,73 @@ import SortableWidgetCard from '@/components/widgets/SortableWidgetCard'
 import PageEditModal from '@/components/layout/PageEditModal'
 import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry'
 import { GRID_COLS, GRID_ROWS, GRID_GAP, MIN_GRID_WIDTH, MIN_GRID_HEIGHT, MIN_CELL_WIDTH, MIN_CELL_HEIGHT, gridElementRef } from '@/lib/gridConstants'
+import { DASHBOARD_PRESETS } from '@/data/dashboardPresets'
+import { PreviewContent } from '@/components/layout/EditPanel/WidgetSizeList'
+
+function PresetThumbnail({ widgets }) {
+  return (
+    <div className="bg-background h-[152px] p-1.5 grid grid-cols-6 grid-rows-4 gap-[2px]">
+      {widgets.map((w, i) => (
+        <div
+          key={i}
+          className="relative overflow-hidden rounded-[3px] border border-stroke bg-surface min-w-0 min-h-0"
+          style={{
+            gridColumn: `${w.gridCol} / span ${w.colSpan}`,
+            gridRow:    `${w.gridRow} / span ${w.rowSpan}`,
+          }}
+        >
+          <div className="absolute top-0 left-0 w-[400%] h-[400%] origin-top-left scale-[0.25] p-3">
+            <PreviewContent type={w.variantId} />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function PresetPickerModal({ onSelect, onClose }) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-6">
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-[6px]" onClick={onClose} />
+
+      <div className="relative bg-surface rounded-[20px] p-7 w-[860px] max-w-full border border-stroke shadow-modal animate-modal-in">
+        <div className="flex items-start justify-between mb-5">
+          <div>
+            <h2 className="text-base font-extrabold text-foreground">위젯 프리셋</h2>
+            <p className="text-[11px] text-foreground-disabled mt-0.5">
+              선택한 프리셋으로 새 페이지가 추가됩니다
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="w-7 h-7 rounded-full border border-stroke-input bg-surface-muted flex items-center justify-center text-foreground-tertiary hover:text-foreground transition-colors"
+          >
+            <X className="w-3.5 h-3.5" />
+          </button>
+        </div>
+
+        <div className="grid grid-cols-3 gap-3.5">
+          {DASHBOARD_PRESETS.map((preset) => (
+            <button
+              key={preset.id}
+              onClick={() => onSelect(preset)}
+              className="text-left rounded-[14px] border border-stroke hover:border-primary hover:shadow-widget-hover transition-all duration-150 overflow-hidden group"
+            >
+              <PresetThumbnail widgets={preset.widgets} />
+              <div className="flex items-center justify-between px-3.5 py-2.5 border-t border-stroke-subtle">
+                <div>
+                  <div className="text-[12px] font-bold text-foreground">{preset.name}</div>
+                  <div className="text-[10px] text-foreground-disabled mt-0.5">{preset.description}</div>
+                </div>
+                <ChevronRight className="w-3.5 h-3.5 text-foreground-disabled group-hover:text-primary transition-colors shrink-0" />
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
 
 /* new-widget 드래그 중 삽입 예정 위치를 표시하는 placeholder.
    pointer-events-none으로 drag 이벤트를 그대로 통과시킨다. */
@@ -32,7 +100,19 @@ export default function HomePage() {
   const { setCellSize, setPreviewCellSize } = useGridStore()
   const { widgets, isLoaded, removeWidget, phantomWidget, isDraggingNewWidget, pages, currentPageId, switchPage } = useWidgetStore()
   const { isAuthenticated, isRestoring } = useAuthStore()
-  const [isPageEditOpen, setIsPageEditOpen] = useState(false)
+  const [isPageEditOpen, setIsPageEditOpen]         = useState(false)
+  const [isPresetPickerOpen, setIsPresetPickerOpen] = useState(false)
+  const { applyPageChanges } = useWidgetStore()
+  const { mutate: saveDashboard } = useDashboardSave()
+
+  function handleApplyPreset(preset) {
+    const newId      = crypto.randomUUID()
+    const newWidgets = preset.widgets.map((w) => ({ ...w, instanceId: crypto.randomUUID() }))
+    const newPages   = [...pages, { id: newId, name: preset.name, widgets: newWidgets }]
+    applyPageChanges(newPages, newId)
+    setIsPresetPickerOpen(false)
+    saveDashboard()
+  }
 
   // 로드 완료 전에는 위젯 미표시 (새로고침 flash 방지)
   // - 인증 확인 중(isRestoring): 대기
@@ -127,15 +207,24 @@ export default function HomePage() {
               ))}
           </div>
           {isEditMode && (
-            <button
-              onClick={() => setIsPageEditOpen(true)}
-              className="flex items-center gap-1 px-2.5 py-1 rounded-lg border border-stroke-input bg-surface text-foreground-tertiary text-[11px] font-medium hover:border-primary hover:text-primary hover:bg-primary-light transition-all duration-[150ms]"
-            >
-              <svg className="w-[11px] h-[11px]" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h7" />
-              </svg>
-              페이지 편집
-            </button>
+            <div className="flex items-center gap-1.5">
+              <button
+                onClick={() => setIsPresetPickerOpen(true)}
+                className="flex items-center gap-1 px-2.5 py-1 rounded-lg border border-stroke-input bg-surface text-foreground-tertiary text-[11px] font-medium hover:border-primary hover:text-primary hover:bg-primary-light transition-all duration-[150ms]"
+              >
+                <LayoutTemplate className="w-[11px] h-[11px]" />
+                위젯 프리셋
+              </button>
+              <button
+                onClick={() => setIsPageEditOpen(true)}
+                className="flex items-center gap-1 px-2.5 py-1 rounded-lg border border-stroke-input bg-surface text-foreground-tertiary text-[11px] font-medium hover:border-primary hover:text-primary hover:bg-primary-light transition-all duration-[150ms]"
+              >
+                <svg className="w-[11px] h-[11px]" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h7" />
+                </svg>
+                페이지 편집
+              </button>
+            </div>
           )}
         </div>
       </div>
@@ -195,7 +284,13 @@ export default function HomePage() {
       </div>
     </div>
 
-    {isPageEditOpen && <PageEditModal onClose={() => setIsPageEditOpen(false)} />}
+    {isPageEditOpen    && <PageEditModal onClose={() => setIsPageEditOpen(false)} />}
+    {isPresetPickerOpen && (
+      <PresetPickerModal
+        onSelect={handleApplyPreset}
+        onClose={() => setIsPresetPickerOpen(false)}
+      />
+    )}
     </>
   )
 }

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -50,6 +50,7 @@ function PresetPickerModal({ onSelect, onClose }) {
             </p>
           </div>
           <button
+            aria-label="닫기"
             onClick={onClose}
             className="w-7 h-7 rounded-full border border-stroke-input bg-surface-muted flex items-center justify-center text-foreground-tertiary hover:text-foreground transition-colors"
           >

--- a/src/pages/MarketPage.jsx
+++ b/src/pages/MarketPage.jsx
@@ -98,9 +98,9 @@ function StockTableHeader({ sortFilter }) {
   )
 }
 
-export default function MarketPage() {
+export default function MarketPage({ initialSortFilter }) {
   const [marketFilter, setMarketFilter] = useState('kr')
-  const [sortFilter, setSortFilter]     = useState('volume_value')
+  const [sortFilter, setSortFilter]     = useState(initialSortFilter ?? 'volume_value')
   const { watchedSet, toggle }          = useWatchlistSet()
 
   const { stocks, isLoading, errorMessage } = useMarketRanking(sortFilter, marketFilter)

--- a/src/pages/MarketPage.jsx
+++ b/src/pages/MarketPage.jsx
@@ -98,7 +98,11 @@ function StockTableHeader({ sortFilter }) {
   )
 }
 
-export default function MarketPage({ initialSortFilter }) {
+export default function MarketPage() {
+  return <MarketContent />
+}
+
+export function MarketContent({ initialSortFilter }) {
   const [marketFilter, setMarketFilter] = useState('kr')
   const [sortFilter, setSortFilter]     = useState(initialSortFilter ?? 'volume_value')
   const { watchedSet, toggle }          = useWatchlistSet()

--- a/src/store/useAuthStore.js
+++ b/src/store/useAuthStore.js
@@ -68,13 +68,18 @@ const useAuthStore = create((set, get) => ({
     }
   },
 
-  logout: () => {
+  logout: ({ broadcast = true } = {}) => {
     localStorage.removeItem('accessToken')
     localStorage.removeItem('user')
     sessionStorage.removeItem('accessToken')
     sessionStorage.removeItem('user')
     queryClient.clear()
     set({ isAuthenticated: false, user: null, accessToken: null })
+    if (broadcast && typeof BroadcastChannel !== 'undefined') {
+      const ch = new BroadcastChannel('sol_auth')
+      ch.postMessage({ type: 'LOGOUT' })
+      ch.close()
+    }
   },
 
   openLoginModal: (view = 'login') => {

--- a/src/store/useWidgetDetailStore.js
+++ b/src/store/useWidgetDetailStore.js
@@ -1,9 +1,28 @@
 import { create } from 'zustand'
 
-const useWidgetDetailStore = create((set) => ({
-  openWidget: null, // { widgetTypeId, config }
-  open:  (widget) => set({ openWidget: widget }),
-  close: ()       => set({ openWidget: null }),
+const useWidgetDetailStore = create((set, get) => ({
+  openWidget: null,  // { widgetTypeId, config }
+  history:    [],    // 이전 위젯 스택
+  isBack:     false, // back() 호출 여부 — 애니메이션 스킵용
+
+  open: (widget) => set((s) => ({
+    history:    s.openWidget ? [...s.history, s.openWidget] : s.history,
+    openWidget: widget,
+    isBack:     false,
+  })),
+
+  back: () => set((s) => {
+    const prev = s.history[s.history.length - 1]
+    return {
+      history:    s.history.slice(0, -1),
+      openWidget: prev ?? null,
+      isBack:     true,
+    }
+  }),
+
+  close: () => set({ openWidget: null, history: [], isBack: false }),
+
+  canGoBack: () => get().history.length > 0,
 }))
 
 export default useWidgetDetailStore

--- a/src/store/useWidgetDetailStore.js
+++ b/src/store/useWidgetDetailStore.js
@@ -1,0 +1,9 @@
+import { create } from 'zustand'
+
+const useWidgetDetailStore = create((set) => ({
+  openWidget: null, // { widgetTypeId, config }
+  open:  (widget) => set({ openWidget: widget }),
+  close: ()       => set({ openWidget: null }),
+}))
+
+export default useWidgetDetailStore


### PR DESCRIPTION
## 변경 사항

### feat: 위젯 상세 모달
- 홈 위젯 클릭 시 아래에서 위로 슬라이드되는 바텀 시트 모달 구현
- `absolute inset-0` 포지셔닝으로 RightPanel(채팅) 미침범
- `slide-up` / `slide-down` 애니메이션 적용
- `useWidgetDetailStore` (Zustand) 로 열림 상태 전역 관리
- 계좌잔고 위젯 클릭 → 자산 페이지 전체 내용 표시 (`BalanceDetail`)
- 주식 차트 위젯 클릭 → 종목 상세 (`StockChartDetail`)

### feat: 위젯 프리셋 기능
- 편집 모드 서브바에 **위젯 프리셋** 버튼 추가 (페이지 편집 버튼 옆)
- 프리셋 선택 시 새 페이지로 추가되며 즉시 DB 저장
- DB(fin97901@gmail.com)에서 읽은 5개 프리셋 제공
  - 종합형 / 거래 분석형 / 시황·뉴스형 / 자산 관리형 / 차트 집중형
- 프리셋 썸네일에 `PreviewContent` 실제 위젯 미리보기 렌더링 (400%/scale(0.25) 기법)
- 종합형·자산관리형 빈 셀 채움

### fix: StockHoldingCard 크래시
- `holding`이 `undefined`일 때 null 체크 전에 프로퍼티 접근하던 버그 수정
- 변수 선언을 `if (!holding)` early return 이후로 이동

## 스크린샷
> 위젯 상세 모달(바텀 시트) / 프리셋 선택 모달

## 테스트 체크리스트
- [ ] 위젯 클릭 → 바텀 시트 슬라이드업 / 배경 클릭 · X 버튼으로 닫힘
- [ ] 편집 모드에서만 모달 미열림 (드래그 충돌 방지)
- [ ] 계좌잔고 위젯 상세 → 자산 페이지 정상 렌더
- [ ] 채팅 패널(RightPanel) 미침범 확인
- [ ] 위젯 프리셋 버튼 → 모달 오픈 → 프리셋 선택 → 새 페이지 추가 확인
- [ ] 프리셋 선택 후 DB 저장 확인 (새로고침 시 유지)
- [ ] 보유하지 않은 종목 상세 클릭 시 StockHoldingCard 크래시 없음