### PR TITLE
feat(layout): 편집 모드 탭 이동 시 저장 확인 모달 구현

### DIFF
--- a/src/components/layout/NavTabs.jsx
+++ b/src/components/layout/NavTabs.jsx
@@ -1,6 +1,10 @@
+import { useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { cn } from '@/lib/cn'
 import { LAST_INVEST_PATH_KEY, LAST_INVEST_STATE_KEY } from '@/features/invest/navigation'
+import useEditModeStore from '@/store/useEditModeStore'
+import useWidgetStore, { hasUnsavedChanges } from '@/store/useWidgetStore'
+import { useDashboardSave } from '@/hooks/useDashboardSync'
 
 const TABS = [
   { label: '홈',  path: '/' },
@@ -9,48 +13,135 @@ const TABS = [
   { label: '잔고', path: '/asset' },
 ]
 
+/* 이동 경로를 결정 — /invest는 마지막 방문 경로 복원 */
+function resolveNavigatePath(path) {
+  if (path !== '/invest') return { path, state: undefined }
+  const lastInvestPath = sessionStorage.getItem(LAST_INVEST_PATH_KEY) || '/invest'
+  const savedState = sessionStorage.getItem(LAST_INVEST_STATE_KEY)
+  let parsedState
+  try { parsedState = savedState ? JSON.parse(savedState) : undefined } catch { parsedState = undefined }
+  return { path: lastInvestPath, state: parsedState }
+}
+
+/* 편집 모드 탭 이동 확인 모달 */
+function NavConfirmModal({ isPending, onSave, onDiscard, onCancel }) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={onCancel}
+    >
+      <div
+        className="bg-surface rounded-2xl shadow-xl w-[320px] p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="text-[14px] font-bold text-foreground mb-1">편집 중인 내용이 있습니다</h3>
+        <p className="text-[12px] text-foreground-secondary mb-5">저장하지 않으면 변경사항이 사라집니다.</p>
+        <div className="flex gap-2">
+          <button
+            onClick={onDiscard}
+            disabled={isPending}
+            className="flex-1 py-2 rounded-xl border border-stroke-input text-[12px] text-foreground-secondary font-medium hover:bg-surface-muted transition-colors disabled:opacity-50"
+          >
+            저장 안 함
+          </button>
+          <button
+            onClick={onSave}
+            disabled={isPending}
+            className="flex-1 py-2 rounded-xl bg-primary text-white text-[12px] font-semibold hover:bg-primary-hover transition-colors shadow-primary-btn disabled:opacity-50"
+          >
+            {isPending ? '저장 중…' : '저장'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export default function NavTabs() {
   const navigate = useNavigate()
   const { pathname } = useLocation()
+  const { isEditMode, exitEditMode, saveLayout } = useEditModeStore()
+  const { restoreSnapshot, clearSnapshot } = useWidgetStore()
+  const unsaved = useWidgetStore(hasUnsavedChanges)
+  const { mutate: saveDashboard, isPending } = useDashboardSave()
+
+  const [pendingNav, setPendingNav] = useState(null) // { path, state }
 
   const isActive = (path) =>
     path === '/' ? pathname === '/' : pathname.startsWith(path)
 
-  function handleNavigate(path) {
-    if (path !== '/invest') {
-      navigate(path)
+  function doNavigate({ path, state }) {
+    navigate(path, state ? { state } : undefined)
+  }
+
+  function handleTabClick(tabPath) {
+    const target = resolveNavigatePath(tabPath)
+
+    if (!isEditMode) {
+      doNavigate(target)
       return
     }
 
-    const lastInvestPath = sessionStorage.getItem(LAST_INVEST_PATH_KEY) || '/invest'
-    const savedState = sessionStorage.getItem(LAST_INVEST_STATE_KEY)
-
-    let parsedState
-    try {
-      parsedState = savedState ? JSON.parse(savedState) : undefined
-    } catch {
-      parsedState = undefined
+    if (!unsaved) {
+      // 변경사항 없음 — 편집 모드만 종료 후 이동
+      exitEditMode()
+      doNavigate(target)
+      return
     }
 
-    navigate(lastInvestPath, { state: parsedState })
+    // 변경사항 있음 — 모달 표시
+    setPendingNav(target)
+  }
+
+  function handleSave() {
+    clearSnapshot()
+    saveDashboard(undefined, {
+      onSuccess: () => {
+        saveLayout()
+        doNavigate(pendingNav)
+        setPendingNav(null)
+      },
+    })
+  }
+
+  function handleDiscard() {
+    restoreSnapshot()
+    exitEditMode()
+    doNavigate(pendingNav)
+    setPendingNav(null)
+  }
+
+  function handleCancel() {
+    setPendingNav(null)
   }
 
   return (
-    <nav className="flex items-center gap-0.5 bg-background rounded-xl p-1">
-      {TABS.map(({ label, path }) => (
-        <button
-          key={path}
-          onClick={() => handleNavigate(path)}
-          className={cn(
-            'px-4 py-1.5 text-[12px] rounded-lg transition-colors duration-[150ms]',
-            isActive(path)
-              ? 'bg-surface text-foreground font-semibold shadow-sm'
-              : 'text-foreground-disabled hover:text-foreground-secondary',
-          )}
-        >
-          {label}
-        </button>
-      ))}
-    </nav>
+    <>
+      <nav className="flex items-center gap-0.5 bg-background rounded-xl p-1">
+        {TABS.map(({ label, path }) => (
+          <button
+            key={path}
+            onClick={() => handleTabClick(path)}
+            className={cn(
+              'px-4 py-1.5 text-[12px] rounded-lg transition-colors duration-150',
+              isActive(path)
+                ? 'bg-surface text-foreground font-semibold shadow-sm'
+                : 'text-foreground-disabled hover:text-foreground-secondary',
+            )}
+          >
+            {label}
+          </button>
+        ))}
+      </nav>
+
+      {pendingNav && (
+        <NavConfirmModal
+          isPending={isPending}
+          onSave={handleSave}
+          onDiscard={handleDiscard}
+          onCancel={handleCancel}
+        />
+      )}
+    </>
   )
 }

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -153,6 +153,12 @@ export function canFitInGrid(widgets, colSpan, rowSpan) {
   return false
 }
 
+/* 편집 모드 저장되지 않은 변경사항 여부 확인 */
+export function hasUnsavedChanges(state) {
+  if (!state._snapshot) return false
+  return JSON.stringify(state._snapshot.pages) !== JSON.stringify(state.pages)
+}
+
 /* 첫 번째 빈 셀 탐색 (addWidget 자동 배치용) */
 function _findFirstFreeCell(widgets, colSpan, rowSpan) {
   for (let r = 1; r <= GRID_ROWS - rowSpan + 1; r++) {


### PR DESCRIPTION
## 관련 이슈

Closes #83

## 구현 내용

편집 모드 중 NavTabs(홈·시세·주문·잔고) 클릭 시 변경사항 여부에 따라 분기 처리.

### 동작 흐름

```
탭 클릭
  └─ 편집 모드 아님 → 즉시 이동 (기존 동작 유지)
  └─ 편집 모드 + 변경사항 없음 → exitEditMode() + 이동
  └─ 편집 모드 + 변경사항 있음 → 확인 모달 표시
        [저장]       → saveDashboard → saveLayout → 이동
        [저장 안 함] → restoreSnapshot → exitEditMode → 이동
        [취소]       → 모달 닫기, 편집 모드 유지
```

### 변경 파일

- **`src/store/useWidgetStore.js`** — `hasUnsavedChanges(state)` selector 추가
- **`src/components/layout/NavTabs.jsx`** — 편집 모드 분기 처리 + `NavConfirmModal` 인라인 구현

### 기타

- `/invest` 탭의 마지막 방문 경로 복원 로직(`sessionStorage`) 기존대로 유지
- 저장 중(`isPending`) 버튼 비활성화 처리