### PR TITLE
feat(chart): 차트 시간 데이터 epoch ms 마이그레이션 및 KST 표시 통일

### DIFF
--- a/src/components/invest/InvestBottomPanels.jsx
+++ b/src/components/invest/InvestBottomPanels.jsx
@@ -1,5 +1,7 @@
+import { useEffect } from 'react'
 import { cn } from '@/lib/cn'
 import { LEFT_TABS, RIGHT_TABS } from '@/features/invest/constants'
+import { isForeignMarketType } from '@/features/invest/formatters'
 import DailyPriceTable from '@/components/invest/panels/DailyPriceTable'
 import RealtimeTradeTable from '@/components/invest/panels/RealtimeTradeTable'
 import OpinionTable from '@/components/invest/panels/OpinionTable'
@@ -49,10 +51,22 @@ export default function InvestBottomPanels({
   displayCurrency,
   usdRate,
 }) {
+  const isForeign = isForeignMarketType(marketType)
+  const DOMESTIC_ONLY_TABS = ['investor', 'opinion', 'finance']
+  const visibleLeftTabs = isForeign
+    ? LEFT_TABS.filter((t) => !DOMESTIC_ONLY_TABS.includes(t.key))
+    : LEFT_TABS
+
+  useEffect(() => {
+    if (isForeign && DOMESTIC_ONLY_TABS.includes(leftTab)) {
+      onLeftTabChange('daily')
+    }
+  }, [isForeign, leftTab, onLeftTabChange])
+
   return (
     <div className="flex h-[210px] shrink-0 overflow-hidden border-t-2 border-stroke bg-surface">
       <section className="flex min-w-0 flex-1 flex-col overflow-hidden border-r border-stroke">
-        <SectionTabs items={LEFT_TABS} activeKey={leftTab} onChange={onLeftTabChange} />
+        <SectionTabs items={visibleLeftTabs} activeKey={leftTab} onChange={onLeftTabChange} />
         {leftTab === 'daily' && <DailyPriceTable rows={dailyRows} isLoading={dailyLoading} errorMessage={errorMessage} marketType={marketType} displayCurrency={displayCurrency} usdRate={usdRate} />}
         {leftTab === 'realtime' && <RealtimeTradeTable rows={realtimeRows} isLoading={realtimeLoading} errorMessage={errorMessage} marketType={marketType} displayCurrency={displayCurrency} usdRate={usdRate} />}
         {leftTab === 'opinion' && <OpinionTable data={opinion} isLoading={detailLoading} marketType={marketType} displayCurrency={displayCurrency} usdRate={usdRate} />}

--- a/src/components/layout/CurrencySync.jsx
+++ b/src/components/layout/CurrencySync.jsx
@@ -1,8 +1,34 @@
 import { useEffect } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import useStompSubscription from '@/hooks/useStompSubscription'
 import useCurrencyStore from '@/store/useCurrencyStore'
+import { marketApi } from '@/api/market'
 
 const TRACKED = ['USD', 'JPY', 'EUR']
+
+// STOMP 연결 전 USD 초기값을 Yahoo Finance에서 받아 store에 채움
+function UsdInitializer() {
+  const setRate = useCurrencyStore((s) => s.setRate)
+  const hasRate = useCurrencyStore((s) => s.rates['USD'] != null)
+
+  useQuery({
+    queryKey: ['currency', 'initial', 'USD'],
+    queryFn: async () => {
+      const res = await marketApi.getForexChart({ symbol: 'USDKRW=X', interval: '5m', range: '1d' })
+      const candles = res.data ?? []
+      if (!candles.length) return null
+      const rate = Number(candles[candles.length - 1].close)
+      if (!rate) return null
+      setRate('USD', { rate, change: null, drate: null, offer: null, bid: null })
+      return rate
+    },
+    enabled: !hasRate,
+    staleTime: Infinity,
+    retry: false,
+  })
+
+  return null
+}
 
 function CurrencySubscriber({ code }) {
   const msg = useStompSubscription(`/topic/currency/${code}`)
@@ -23,5 +49,10 @@ function CurrencySubscriber({ code }) {
 }
 
 export default function CurrencySync() {
-  return TRACKED.map((code) => <CurrencySubscriber key={code} code={code} />)
+  return (
+    <>
+      <UsdInitializer />
+      {TRACKED.map((code) => <CurrencySubscriber key={code} code={code} />)}
+    </>
+  )
 }

--- a/src/components/market/InvestStockChart.jsx
+++ b/src/components/market/InvestStockChart.jsx
@@ -24,13 +24,13 @@ function toChartTime(timestamp) {
   return Math.floor(timestamp / 1000)
 }
 
-function formatChartDateTime(time, { isIntraday, useUtc }) {
+function formatChartDateTime(time, { isIntraday }) {
   const date = new Date(time * 1000)
-  const yyyy = useUtc ? date.getUTCFullYear() : date.getFullYear()
-  const mm = String((useUtc ? date.getUTCMonth() : date.getMonth()) + 1).padStart(2, '0')
-  const dd = String(useUtc ? date.getUTCDate() : date.getDate()).padStart(2, '0')
-  const hh = String(useUtc ? date.getUTCHours() : date.getHours()).padStart(2, '0')
-  const mi = String(useUtc ? date.getUTCMinutes() : date.getMinutes()).padStart(2, '0')
+  const yyyy = date.getFullYear()
+  const mm = String(date.getMonth() + 1).padStart(2, '0')
+  const dd = String(date.getDate()).padStart(2, '0')
+  const hh = String(date.getHours()).padStart(2, '0')
+  const mi = String(date.getMinutes()).padStart(2, '0')
 
   return isIntraday ? `${yyyy}/${mm}/${dd} ${hh}:${mi}` : `${yyyy}/${mm}/${dd}`
 }
@@ -99,7 +99,6 @@ const InvestStockChart = memo(function InvestStockChart({
   }, [chartType])
 
   const isIntraday = selectedPeriod === 'MINUTE'
-  const usesExchangeUtcSlot = !['KOSPI', 'KOSDAQ'].includes(marketType)
 // Effect 1: 차트 생성 — chartType / isIntraday 바뀔 때만 재생성
   useEffect(() => {
     const container = containerRef.current
@@ -130,7 +129,7 @@ const InvestStockChart = memo(function InvestStockChart({
         rightOffset: 6,
         barSpacing: isIntraday ? 10 : 8,
         tickMarkFormatter: (time) => {
-          const formatted = formatChartDateTime(time, { isIntraday, useUtc: usesExchangeUtcSlot })
+          const formatted = formatChartDateTime(time, { isIntraday })
           return isIntraday ? formatted.slice(11) : formatted.slice(5)
         },
       },
@@ -145,7 +144,7 @@ const InvestStockChart = memo(function InvestStockChart({
         locale: 'ko-KR',
         dateFormat: 'yyyy/MM/dd',
         priceFormatter: (price) => formatVisiblePrice(price, { marketType, displayCurrency, usdRate }),
-        timeFormatter: (time) => formatChartDateTime(time, { isIntraday, useUtc: usesExchangeUtcSlot }),
+        timeFormatter: (time) => formatChartDateTime(time, { isIntraday }),
       },
     })
 
@@ -277,7 +276,7 @@ const InvestStockChart = memo(function InvestStockChart({
       volumeSeriesRef.current = null
       areaSeriesRef.current = null
     }
-  }, [chartType, displayCurrency, isIntraday, marketType, usdRate, usesExchangeUtcSlot])
+  }, [chartType, displayCurrency, isIntraday, marketType, usdRate])
 
   // Effect 2: 데이터 업데이트 — series 바뀔 때만 (차트 재생성 없음)
   useEffect(() => {

--- a/src/components/signup/DecoyCursorOverlay.jsx
+++ b/src/components/signup/DecoyCursorOverlay.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 
 const CURSOR_OPACITY = 0.86
 const CURSOR_SCALE = 1
@@ -235,7 +236,7 @@ export default function DecoyCursorOverlay({ active, containerRef, count = 5 }) 
 
   if (!active || !isPointerDevice || !overlayState) return null
 
-  return (
+  return createPortal(
     <div className="pointer-events-none fixed inset-0 z-[70] hidden md:block">
       <div
         className="absolute left-0 top-0 -translate-x-[6px] -translate-y-[2px] transition-transform duration-75 ease-out"
@@ -261,6 +262,7 @@ export default function DecoyCursorOverlay({ active, containerRef, count = 5 }) 
           </div>
         )
       })}
-    </div>
+    </div>,
+    document.body,
   )
 }

--- a/src/components/widgets/ExchangeWidget.jsx
+++ b/src/components/widgets/ExchangeWidget.jsx
@@ -3,7 +3,6 @@ import { Settings2 } from 'lucide-react'
 import LockedOverlay from '@/components/ui/LockedOverlay'
 import useAuthStore from '@/store/useAuthStore'
 import useCurrencyRate from '@/hooks/useCurrencyRate'
-import useMarketIndices from '@/features/market/useMarketIndices'
 import WidgetCard from './WidgetCard'
 import ExchangeConfigModal from './ExchangeConfigModal'
 import useWidgetStore from '@/store/useWidgetStore'
@@ -43,7 +42,7 @@ function RateDisplay({ live, rateClassName = 'text-widget-15' }) {
       <div className={`${rateClassName} font-bold text-foreground leading-tight`}>
         {formatRate(live?.rate)}
       </div>
-      {live && (
+      {live?.change != null && (
         <div className={`text-widget-9 ${isUp ? 'text-up' : 'text-down'}`}>
           {isUp ? '▲' : '▼'} {Math.abs(live.change)} ({formatPct(live.drate)})
         </div>
@@ -124,7 +123,7 @@ export default function ExchangeWidget({ instanceId, variant = 'exchange-sm', co
                   <div className="text-center">
                     <div className="text-widget-9 text-foreground-disabled">{pair}</div>
                     <div className={`${rateSize[i] ?? 'text-widget-16'} font-bold text-foreground leading-tight`}>{formatRate(live?.rate)}</div>
-                    {live && (
+                    {live?.change != null && (
                       <div className={`text-widget-9 ${isUp ? 'text-up' : 'text-down'}`}>
                         {isUp ? '▲' : '▼'} {Math.abs(live.change)}
                       </div>
@@ -167,7 +166,7 @@ export default function ExchangeWidget({ instanceId, variant = 'exchange-sm', co
                   <div className="text-center">
                     <div className="text-widget-9 text-foreground-disabled">{pair}</div>
                     <div className={`${rateSize} font-bold text-foreground leading-tight`}>{formatRate(live?.rate)}</div>
-                    {live && (
+                    {live?.change != null && (
                       <div className={`text-widget-9 ${isUp ? 'text-up' : 'text-down'}`}>
                         {isUp ? '▲' : '▼'} {Math.abs(live.change)}
                       </div>
@@ -242,11 +241,7 @@ export default function ExchangeWidget({ instanceId, variant = 'exchange-sm', co
   }
 
   /* exchange-sm (default, 1x1) */
-  const { indices } = useMarketIndices()
-  const usdIdx = indices.find((i) => i.code === 'USD')
-  const smLive = usdIdx
-    ? { rate: usdIdx.price, change: usdIdx.change, drate: usdIdx.changeRate }
-    : currencies[0]?.live ?? null
+  const smLive = currencies[0]?.live ?? null
 
   return (
     <>

--- a/src/components/widgets/detail/DetailChart.jsx
+++ b/src/components/widgets/detail/DetailChart.jsx
@@ -11,8 +11,13 @@ function getColors() {
   }
 }
 
-function formatTz(epochSec, timezone, isMinute) {
-  const d = new Date(epochSec * 1000)
+// LightweightCharts는 yyyy-mm-dd 문자열을 BusinessDay { year, month, day } 객체로 변환해 formatter에 전달
+function formatTz(time, timezone, isMinute) {
+  if (typeof time === 'object' && time !== null) {
+    const { year, month, day } = time
+    return `${year}/${String(month).padStart(2, '0')}/${String(day).padStart(2, '0')}`
+  }
+  const d = new Date(time * 1000)
   if (timezone) {
     const parts = new Intl.DateTimeFormat('en-US', {
       timeZone: timezone,
@@ -33,8 +38,13 @@ function formatTz(epochSec, timezone, isMinute) {
   return `${d.getFullYear()}/${m}/${dd}`
 }
 
-function getTickLabel(epochSec, tickMarkType, timezone, isMinute) {
-  const d = new Date(epochSec * 1000)
+function getTickLabel(time, tickMarkType, timezone, isMinute) {
+  if (typeof time === 'object' && time !== null) {
+    const { month, day } = time
+    if (tickMarkType <= 1) return `${month}월`
+    return `${month}/${day}`
+  }
+  const d = new Date(time * 1000)
   if (timezone) {
     const parts = new Intl.DateTimeFormat('en-US', {
       timeZone: timezone,

--- a/src/features/asset/useAssetPage.js
+++ b/src/features/asset/useAssetPage.js
@@ -1,5 +1,5 @@
-import { useMemo } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useEffect, useMemo, useState } from 'react'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { balanceApi, useDomesticHoldings, useOverseasHoldings } from '@/api/balance'
 import { useMyAccount } from '@/api/account'
 import { orderApi } from '@/api/order'
@@ -7,6 +7,79 @@ import useCurrencyStore from '@/store/useCurrencyStore'
 
 const SEED_MONEY = 100_000_000
 const FALLBACK_USD_RATE = 1350
+const ASSET_PAGE_SNAPSHOT_KEY = 'asset.page.snapshot.v1'
+
+function formatDateKey(date) {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function fillAssetFlowPoints(points, range, startDate) {
+  if (!Array.isArray(points) || points.length === 0 || !startDate) {
+    return points
+  }
+
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+
+  const accountStart = new Date(startDate)
+  accountStart.setHours(0, 0, 0, 0)
+
+  let effectiveStart = accountStart
+  if (range === '1W' || range === '1M') {
+    const days = range === '1W' ? 7 : 30
+    const windowStart = new Date(today)
+    windowStart.setDate(windowStart.getDate() - (days - 1))
+    effectiveStart = accountStart > windowStart ? accountStart : windowStart
+  }
+  const byDate = new Map(points.map((point) => [point.date, point]))
+  const firstPointDate = points[0]?.date ?? null
+
+  let carry = null
+  const filled = []
+
+  for (let cursor = new Date(effectiveStart); cursor <= today; cursor.setDate(cursor.getDate() + 1)) {
+    const key = formatDateKey(cursor)
+    const existing = byDate.get(key)
+    if (existing) {
+      carry = existing
+      filled.push(existing)
+      continue
+    }
+    if (firstPointDate && key < firstPointDate) {
+      filled.push({
+        date: key,
+        totalAssets: SEED_MONEY,
+        dailyReturnRate: 0,
+        cumulativeReturnRate: 0,
+      })
+      continue
+    }
+    if (carry) {
+      filled.push({
+        ...carry,
+        date: key,
+        dailyReturnRate: 0,
+      })
+    }
+  }
+
+  return filled.length > 0 ? filled : points
+}
+
+function readAssetPageSnapshot(range) {
+  try {
+    const raw = localStorage.getItem(ASSET_PAGE_SNAPSHOT_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw)
+    if (parsed?.range !== range) return null
+    return parsed?.data ?? null
+  } catch {
+    return null
+  }
+}
 
 function buildHoldingRow(h) {
   const qty = h.holdingQuantity ?? 0
@@ -33,8 +106,13 @@ function buildHoldingRow(h) {
   }
 }
 
-export function useAssetPage(enabled, assetFlowRange = '1M') {
+export function useAssetPage(enabled, assetFlowRange = '1W') {
   const usdRate = useCurrencyStore((s) => s.rates['USD']?.rate ?? FALLBACK_USD_RATE)
+  const [cachedSnapshot, setCachedSnapshot] = useState(() => readAssetPageSnapshot(assetFlowRange))
+
+  useEffect(() => {
+    setCachedSnapshot(readAssetPageSnapshot(assetFlowRange))
+  }, [assetFlowRange])
 
   const { data: summary, isLoading: sl } = useQuery({
     queryKey: ['balance', 'summary'],
@@ -58,6 +136,7 @@ export function useAssetPage(enabled, assetFlowRange = '1M') {
     queryFn: () => balanceApi.getAssetFlow(assetFlowRange),
     enabled,
     staleTime: 30_000,
+    placeholderData: keepPreviousData,
   })
 
   const { data: accountInfo } = useMyAccount()
@@ -69,8 +148,9 @@ export function useAssetPage(enabled, assetFlowRange = '1M') {
     staleTime: 60_000,
   })
 
-  return useMemo(() => {
-    const isLoading = enabled && (sl || dl || ol || pl || fl)
+  const derived = useMemo(() => {
+    const isLoading = enabled && (sl || dl || ol || pl)
+    const flowLoading = enabled && fl
 
     // Cash
     const cashList = summary?.cashBalances ?? []
@@ -120,12 +200,13 @@ export function useAssetPage(enabled, assetFlowRange = '1M') {
       : totalAssets > 0 ? ((totalAssets - SEED_MONEY) / SEED_MONEY) * 100 : 0
     const isSimProfit = simReturn >= 0
 
-    const assetFlowPoints = (assetFlow?.points ?? []).map((point) => ({
+    const rawAssetFlowPoints = (assetFlow?.points ?? []).map((point) => ({
       date: point.date,
       totalAssets: Number(point.totalAssets ?? 0),
       dailyReturnRate: Number(point.dailyReturnRate ?? 0),
       cumulativeReturnRate: Number(point.cumulativeReturnRate ?? 0),
     }))
+    const assetFlowPoints = fillAssetFlowPoints(rawAssetFlowPoints, assetFlowRange, startDate)
     const latestFlowPoint = assetFlowPoints[assetFlowPoints.length - 1] ?? null
     const latestDailyReturnRate = latestFlowPoint?.dailyReturnRate ?? 0
     const latestCumulativeReturnRate = latestFlowPoint?.cumulativeReturnRate ?? 0
@@ -163,6 +244,7 @@ export function useAssetPage(enabled, assetFlowRange = '1M') {
 
     return {
       isLoading,
+      flowLoading,
       // Summary
       totalAssets,
       accountProfit,
@@ -192,5 +274,38 @@ export function useAssetPage(enabled, assetFlowRange = '1M') {
       latestCumulativeReturnRate,
       tradeCount: filledOrders.length,
     }
-  }, [summary, domestic, overseas, portfolio, assetFlow, accountInfo, filledOrders, usdRate, sl, dl, ol, pl, fl, enabled])
+  }, [summary, domestic, overseas, portfolio, assetFlow, accountInfo, filledOrders, usdRate, sl, dl, ol, pl, fl, enabled, assetFlowRange])
+
+  useEffect(() => {
+    if (!enabled || derived.isLoading) {
+      return
+    }
+    try {
+      localStorage.setItem(
+        ASSET_PAGE_SNAPSHOT_KEY,
+        JSON.stringify({
+          range: assetFlowRange,
+          data: derived,
+          savedAt: Date.now(),
+        }),
+      )
+      setCachedSnapshot(derived)
+    } catch {
+      // ignore storage failures
+    }
+  }, [enabled, assetFlowRange, derived])
+
+  return useMemo(() => {
+    if (enabled && cachedSnapshot && derived.isLoading) {
+      return {
+        ...cachedSnapshot,
+        flowLoading: derived.flowLoading,
+        isRefreshing: true,
+      }
+    }
+    return {
+      ...derived,
+      isRefreshing: false,
+    }
+  }, [cachedSnapshot, derived, enabled])
 }

--- a/src/features/invest/domestic/normalize.js
+++ b/src/features/invest/domestic/normalize.js
@@ -3,8 +3,8 @@ import { toLocalTimestamp, extractDateKey, computeDepth } from '@/features/inves
 export function normalizeDailySeries(data) {
   return (data ?? [])
     .map((item) => ({
-      date: extractDateKey(item.date),
-      timestamp: toLocalTimestamp(item.date),
+      date: extractDateKey(item.time),
+      timestamp: toLocalTimestamp(item.time),
       open: Number(item.open),
       high: Number(item.high),
       low: Number(item.low),
@@ -18,8 +18,8 @@ export function normalizeMinuteSeries(data) {
   const now = Date.now()
   const normalized = (data ?? [])
     .map((item) => ({
-      timestamp: toLocalTimestamp(item.datetime),
-      sessionDate: extractDateKey(item.datetime),
+      timestamp: toLocalTimestamp(item.time),
+      sessionDate: extractDateKey(item.time),
       open: Number(item.open),
       high: Number(item.high),
       low: Number(item.low),

--- a/src/features/invest/foreign/normalize.js
+++ b/src/features/invest/foreign/normalize.js
@@ -28,30 +28,12 @@ function isLsRawFormat(raw) {
   return raw?.offerho1 != null || raw?.bidho1 != null || raw?.totofferrem != null || raw?.totbidrem != null
 }
 
-function toExchangeLocalTimestamp(value, fallbackTime = '00:00:00') {
-  if (typeof value === 'string') {
-    const [datePart, timePart = fallbackTime] = value.includes('T')
-      ? value.split('T')
-      : [value, fallbackTime]
-    const [year, month, day] = datePart.split('-').map(Number)
-    const [hour = 0, minute = 0, second = 0] = timePart.split(':').map(Number)
-
-    return Date.UTC(year, (month ?? 1) - 1, day ?? 1, hour, minute, second)
-  }
-
-  if (Array.isArray(value)) {
-    const [year = 1970, month = 1, day = 1, hour = 0, minute = 0, second = 0] = value
-    return Date.UTC(year, month - 1, day, hour, minute, second)
-  }
-
-  return Number.NaN
-}
 
 export function normalizeForeignDailySeries(dataPoints) {
   return (dataPoints ?? [])
     .map((item) => ({
-      date: extractDateKey(item.date),
-      timestamp: toExchangeLocalTimestamp(item.date),
+      date: extractDateKey(item.time),
+      timestamp: toLocalTimestamp(item.time),
       open: Number(item.open),
       high: Number(item.high),
       low: Number(item.low),
@@ -64,8 +46,8 @@ export function normalizeForeignDailySeries(dataPoints) {
 export function normalizeForeignMinuteSeries(dataPoints) {
   return (dataPoints ?? [])
     .map((item) => ({
-      timestamp: toLocalTimestamp(item.dateTime),
-      sessionDate: extractDateKey(item.dateTime),
+      timestamp: toLocalTimestamp(item.time),
+      sessionDate: extractDateKey(item.time),
       open: Number(item.open),
       high: Number(item.high),
       low: Number(item.low),

--- a/src/features/invest/marketData.js
+++ b/src/features/invest/marketData.js
@@ -64,6 +64,8 @@ export function resolveStockMeta(stockCode, locationState) {
 
 // 날짜/시간 파싱 유틸 (domestic/foreign normalize에서 공유)
 export function toLocalTimestamp(value, fallbackTime = '00:00:00') {
+  if (typeof value === 'number') return value  // epoch ms (새 API 포맷)
+
   if (typeof value === 'string') {
     const [datePart, timePart = fallbackTime] = value.includes('T')
       ? value.split('T')
@@ -83,6 +85,11 @@ export function toLocalTimestamp(value, fallbackTime = '00:00:00') {
 }
 
 export function extractDateKey(value) {
+  if (typeof value === 'number') {  // epoch ms (새 API 포맷)
+    const d = new Date(value)
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+  }
+
   if (typeof value === 'string') {
     return value.slice(0, 10)
   }

--- a/src/features/market/useForexChart.js
+++ b/src/features/market/useForexChart.js
@@ -8,34 +8,31 @@ const PERIOD_MAP = {
   '1Y': { interval: '1d', range: '1y'  },
 }
 
-// 1d 미만 interval: Unix timestamp (초) — datetime 문자열
-// 1d interval: "YYYY-MM-DD" 문자열 — 타임존 이슈 방지
-function toTime(timeStr, isIntraday) {
-  if (isIntraday) return Math.floor(new Date(timeStr).getTime() / 1000)
-  if (typeof timeStr === 'number') return new Date(timeStr).toISOString().slice(0, 10)
-  return String(timeStr).slice(0, 10)
+function toTime(timeStr) {
+  if (typeof timeStr === 'number') return Math.floor(timeStr / 1000)
+  return Math.floor(new Date(timeStr).getTime() / 1000)
 }
 
-function toLineData(candles, isIntraday) {
+function toLineData(candles) {
   return candles
-    .map((c) => ({ time: toTime(c.time, isIntraday), value: Number(c.close) }))
-    .sort((a, b) => (a.time > b.time ? 1 : a.time < b.time ? -1 : 0))
+    .map((c) => ({ time: toTime(c.time), value: Number(c.close) }))
+    .sort((a, b) => a.time - b.time)
 }
 
-function toCandleData(candles, isIntraday) {
+function toCandleData(candles) {
   return candles
     .map((c) => ({
-      time:  toTime(c.time, isIntraday),
+      time:  toTime(c.time),
       open:  Number(c.open),
       high:  Number(c.high),
       low:   Number(c.low),
       close: Number(c.close),
     }))
-    .sort((a, b) => (a.time > b.time ? 1 : a.time < b.time ? -1 : 0))
+    .sort((a, b) => a.time - b.time)
 }
 
 export default function useForexChart(symbol, period) {
-  const isIntraday = period === '1D' || period === '1M'
+  const isIntraday = period === '1D'
   const { interval, range } = PERIOD_MAP[period] ?? PERIOD_MAP['3M']
 
   const { data, isLoading, error } = useQuery({
@@ -44,8 +41,8 @@ export default function useForexChart(symbol, period) {
       const res = await marketApi.getForexChart({ symbol, interval, range })
       const candles = res.data ?? []
       return {
-        lineData:   toLineData(candles, isIntraday),
-        candleData: toCandleData(candles, isIntraday),
+        lineData:   toLineData(candles),
+        candleData: toCandleData(candles),
       }
     },
     enabled: !!symbol && !!period,

--- a/src/features/market/useForexChart.js
+++ b/src/features/market/useForexChart.js
@@ -12,7 +12,8 @@ const PERIOD_MAP = {
 // 1d interval: "YYYY-MM-DD" 문자열 — 타임존 이슈 방지
 function toTime(timeStr, isIntraday) {
   if (isIntraday) return Math.floor(new Date(timeStr).getTime() / 1000)
-  return timeStr.slice(0, 10)
+  if (typeof timeStr === 'number') return new Date(timeStr).toISOString().slice(0, 10)
+  return String(timeStr).slice(0, 10)
 }
 
 function toLineData(candles, isIntraday) {

--- a/src/features/market/useIndexChart.js
+++ b/src/features/market/useIndexChart.js
@@ -2,13 +2,14 @@ import { useQuery } from '@tanstack/react-query'
 import { marketApi } from '@/api/market'
 
 function toTime(item, isIntraday) {
-  return Math.floor(new Date(isIntraday ? item.datetime : item.date).getTime() / 1000)
+  if (!isIntraday) return String(item.date).slice(0, 10)
+  return Math.floor(new Date(item.datetime).getTime() / 1000)
 }
 
 function toLineData(items, isIntraday) {
   return items
     .map((d) => ({ time: toTime(d, isIntraday), value: Number(d.close) }))
-    .sort((a, b) => a.time - b.time)
+    .sort((a, b) => (a.time > b.time ? 1 : a.time < b.time ? -1 : 0))
 }
 
 function toCandleData(items, isIntraday) {
@@ -20,7 +21,7 @@ function toCandleData(items, isIntraday) {
       low:   Number(d.low),
       close: Number(d.close),
     }))
-    .sort((a, b) => a.time - b.time)
+    .sort((a, b) => (a.time > b.time ? 1 : a.time < b.time ? -1 : 0))
 }
 
 // '1D': 분봉(오늘 장중) / 나머지: 일봉

--- a/src/features/market/useIndexChart.js
+++ b/src/features/market/useIndexChart.js
@@ -1,31 +1,28 @@
 import { useQuery } from '@tanstack/react-query'
 import { marketApi } from '@/api/market'
 
-function toTime(item, isIntraday) {
+function toTime(item) {
   const raw = item.date ?? item.datetime ?? item.time
-  if (!isIntraday) {
-    if (typeof raw === 'number') return new Date(raw).toISOString().slice(0, 10)
-    return String(raw).slice(0, 10)
-  }
+  if (typeof raw === 'number') return Math.floor(raw / 1000)
   return Math.floor(new Date(raw).getTime() / 1000)
 }
 
-function toLineData(items, isIntraday) {
+function toLineData(items) {
   return items
-    .map((d) => ({ time: toTime(d, isIntraday), value: Number(d.close) }))
-    .sort((a, b) => (a.time > b.time ? 1 : a.time < b.time ? -1 : 0))
+    .map((d) => ({ time: toTime(d), value: Number(d.close) }))
+    .sort((a, b) => a.time - b.time)
 }
 
-function toCandleData(items, isIntraday) {
+function toCandleData(items) {
   return items
     .map((d) => ({
-      time:  toTime(d, isIntraday),
+      time:  toTime(d),
       open:  Number(d.open),
       high:  Number(d.high),
       low:   Number(d.low),
       close: Number(d.close),
     }))
-    .sort((a, b) => (a.time > b.time ? 1 : a.time < b.time ? -1 : 0))
+    .sort((a, b) => a.time - b.time)
 }
 
 // '1D': 분봉(오늘 장중) / 나머지: 일봉
@@ -41,8 +38,8 @@ export default function useIndexChart(code, period = '3M') {
         : await marketApi.getIndexChart(code, { count })
       const items = res.data ?? []
       return {
-        lineData:   toLineData(items, isIntraday),
-        candleData: toCandleData(items, isIntraday),
+        lineData:   toLineData(items),
+        candleData: toCandleData(items),
       }
     },
     enabled: !!code && period !== null,

--- a/src/features/market/useIndexChart.js
+++ b/src/features/market/useIndexChart.js
@@ -2,8 +2,12 @@ import { useQuery } from '@tanstack/react-query'
 import { marketApi } from '@/api/market'
 
 function toTime(item, isIntraday) {
-  if (!isIntraday) return String(item.date).slice(0, 10)
-  return Math.floor(new Date(item.datetime).getTime() / 1000)
+  const raw = item.date ?? item.datetime ?? item.time
+  if (!isIntraday) {
+    if (typeof raw === 'number') return new Date(raw).toISOString().slice(0, 10)
+    return String(raw).slice(0, 10)
+  }
+  return Math.floor(new Date(raw).getTime() / 1000)
 }
 
 function toLineData(items, isIntraday) {

--- a/src/pages/AssetPage.jsx
+++ b/src/pages/AssetPage.jsx
@@ -1,12 +1,14 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { ArrowLeftRight } from 'lucide-react'
 import ReactECharts from 'echarts-for-react'
 import { getStockLogoUrl } from '@/lib/stockLogo'
 import { extractDominantColor } from '@/lib/extractLogoColor'
 import StockAvatar from '@/components/ui/StockAvatar'
-import FilterChip from '@/components/ui/FilterChip'
+import { cn } from '@/lib/cn'
 import ExchangeModal from '@/components/asset/ExchangeModal'
 import useAuthStore from '@/store/useAuthStore'
+import useWidgetDetailStore from '@/store/useWidgetDetailStore'
 import { useMyAccount } from '@/api/account'
 import { useAssetPage } from '@/features/asset/useAssetPage'
 
@@ -123,7 +125,7 @@ function AccountCard({ data }) {
 
   return (
     <section className="flex h-full min-w-0 flex-col border-r border-stroke-subtle">
-      <div className="px-5 py-2.5">
+      <div className="flex min-h-[44px] items-center px-5">
         <div className="text-[13px] font-bold text-foreground">계좌</div>
       </div>
       <div className="h-px bg-stroke-subtle" />
@@ -180,7 +182,7 @@ function AssetBreakdownCard({ data }) {
 
   return (
     <section className="flex h-full min-w-0 flex-col border-r border-stroke-subtle">
-      <div className="px-5 py-2.5">
+      <div className="flex min-h-[44px] items-center px-5">
         <div className="text-[13px] font-bold text-foreground">자산 구성</div>
       </div>
       <div className="h-px bg-stroke-subtle" />
@@ -205,19 +207,32 @@ function AssetBreakdownCard({ data }) {
 
 // ── 자산 흐름 카드 ────────────────────────────────────────────────
 function AssetFlowCard({ data, assetFlowRange, onChangeAssetFlowRange }) {
-  const { isAccountProfit, isLoading, assetFlowPoints, latestDailyReturnRate, latestCumulativeReturnRate } = data
+  const { isAccountProfit, assetFlowPoints } = data
   const hasFlow = assetFlowPoints.length > 0
   const [mode, setMode] = useState('assets')
+  const [chartOpacity, setChartOpacity] = useState(1)
+  const pendingMode = useRef(null)
+
+  function handleModeChange(newMode) {
+    if (newMode === mode) return
+    pendingMode.current = newMode
+    setChartOpacity(0)
+  }
+
+  function handleTransitionEnd() {
+    if (pendingMode.current === null) return
+    setMode(pendingMode.current)
+    pendingMode.current = null
+    setChartOpacity(1)
+  }
 
   const isAssetMode = mode === 'assets'
   const seriesData = isAssetMode
     ? assetFlowPoints.map((point) => point.totalAssets)
     : assetFlowPoints.map((point) => point.cumulativeReturnRate)
-  const headlineValue = isAssetMode ? latestDailyReturnRate : latestCumulativeReturnRate
-  const headlineLabel = isAssetMode ? '전일 대비 수익률' : '누적 수익률'
   const chartColor = isAssetMode
     ? (isAccountProfit ? '#16A34A' : '#E11D48')
-    : (headlineValue >= 0 ? '#16A34A' : '#E11D48')
+    : ((assetFlowPoints[assetFlowPoints.length - 1]?.cumulativeReturnRate ?? 0) >= 0 ? '#16A34A' : '#E11D48')
 
   const chartOption = {
     backgroundColor: 'transparent',
@@ -275,49 +290,58 @@ function AssetFlowCard({ data, assetFlowRange, onChangeAssetFlowRange }) {
         data: seriesData,
         lineStyle: { width: 3, color: chartColor },
         itemStyle: { color: chartColor },
-        areaStyle: {
-          color: chartColor === '#16A34A'
-            ? 'rgba(22,163,74,0.14)'
-            : 'rgba(225,29,72,0.14)',
-        },
       },
     ],
   }
 
   return (
     <section className="flex h-full min-w-0 flex-col overflow-hidden">
-      <div className="flex items-center justify-between px-5 py-2.5">
+      <div className="flex min-h-[44px] items-center justify-between gap-3 px-5">
         <div className="text-[13px] font-bold text-foreground">자산 흐름</div>
+        <div className="flex items-center rounded-lg bg-surface-muted p-0.5">
+          {ASSET_FLOW_MODES.map(({ key, label }) => (
+            <button
+              key={key}
+              onClick={() => handleModeChange(key)}
+              className={cn(
+                'rounded-md px-2.5 py-0.5 text-[10px] font-semibold transition-all',
+                mode === key
+                  ? 'bg-primary text-white shadow-control'
+                  : 'text-foreground-disabled hover:text-foreground-secondary',
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
       </div>
       <div className="h-px bg-stroke-subtle" />
-
-      <div className="flex items-center justify-between gap-2 px-5 pt-2.5">
-        <div className="flex items-center gap-1.5">
-          {ASSET_FLOW_MODES.map(({ key, label }) => (
-            <FilterChip key={key} isActive={mode === key} onClick={() => setMode(key)}>
-              {label}
-            </FilterChip>
-          ))}
-        </div>
-        <div className="flex items-center gap-1.5">
+      <div className="flex justify-end px-5 py-1 shrink-0">
+        <div className="flex items-center rounded-lg bg-surface-muted p-0.5">
           {ASSET_FLOW_RANGES.map(({ key, label }) => (
-            <FilterChip key={key} isActive={assetFlowRange === key} onClick={() => onChangeAssetFlowRange(key)}>
+            <button
+              key={key}
+              onClick={() => onChangeAssetFlowRange(key)}
+              className={cn(
+                'rounded-md px-2.5 py-0.5 text-[10px] font-semibold transition-all',
+                assetFlowRange === key
+                  ? 'bg-primary text-white shadow-control'
+                  : 'text-foreground-disabled hover:text-foreground-secondary',
+              )}
+            >
               {label}
-            </FilterChip>
+            </button>
           ))}
         </div>
       </div>
 
-      <div className="shrink-0 px-5 pt-2">
-        <div className="text-[9px] text-foreground-disabled">{headlineLabel}</div>
-        <div className={`text-[18px] font-black ${headlineValue >= 0 ? 'text-up' : 'text-down'}`}>
-          {isLoading ? '-' : fmtRate(headlineValue)}
-        </div>
-      </div>
-
-      <div className="h-[88px] overflow-hidden rounded-xl px-5">
+      <div
+        className="flex-1 min-h-0 overflow-hidden px-5 pb-3"
+        style={{ opacity: chartOpacity, transition: 'opacity 150ms ease' }}
+        onTransitionEnd={handleTransitionEnd}
+      >
         {hasFlow ? (
-          <ReactECharts option={chartOption} className="w-full h-full" opts={{ renderer: 'svg' }} />
+          <ReactECharts option={chartOption} style={{ width: '100%', height: '100%' }} opts={{ renderer: 'svg' }} />
         ) : (
           <div className="flex items-center justify-center h-full text-[11px] text-foreground-disabled">
             데이터 없음
@@ -472,12 +496,27 @@ function PortfolioPanel({ data }) {
   )
 }
 
+const EXCHANGE_CODE_BY_MARKET_TYPE = { NASDAQ: 'NAS', NYSE: 'NYS', AMEX: 'AMS' }
+
 // ── 보유 종목 행 ──────────────────────────────────────────────────
 function HoldingRow({ h }) {
   const { stockName, stockCode, marketType, qty, cur, avg, investedLocal, pnl, pnlRate, isUp, isKrw, hasCurrentPrice } = h
+  const open = useWidgetDetailStore((s) => s.open)
+
+  function handleClick() {
+    open({
+      widgetTypeId: 'stock-chart',
+      config: {
+        stockCode,
+        stockName,
+        marketType,
+        exchangeCode: EXCHANGE_CODE_BY_MARKET_TYPE[marketType] ?? null,
+      },
+    })
+  }
 
   return (
-    <div className="grid grid-cols-[1fr_62px_82px_78px_92px] items-center px-4 py-2.5 border-b border-stroke-subtle cursor-pointer hover:bg-surface-subtle transition-colors">
+    <div onClick={handleClick} className="grid grid-cols-[1fr_62px_82px_78px_92px] items-center px-4 py-2.5 border-b border-stroke-subtle cursor-pointer hover:bg-surface-subtle transition-colors">
       <div className="flex items-center gap-2.5">
         <StockAvatar name={stockName} stockCode={stockCode} marketType={marketType} size="md" />
         <div className="min-w-0">
@@ -532,27 +571,31 @@ function HoldingsPanel({ data }) {
   const totalIsUp = totalPnl >= 0
 
   const filters = [
-    { key: 'all',      label: `전체 ${allRows.length}` },
-    { key: 'domestic', label: `국내주식 ${domesticRows.length}` },
-    { key: 'overseas', label: `해외주식 ${overseasRows.length}` },
+    { key: 'all',      label: '전체' },
+    { key: 'domestic', label: '국내주식' },
+    { key: 'overseas', label: '해외주식' },
   ]
 
   return (
     <div className="flex-1 min-w-0 bg-surface flex flex-col overflow-hidden">
 
       {/* 헤더: 필터 + 시간 */}
-      <div className="shrink-0 flex min-h-[44px] items-center justify-between px-4 py-2.5 border-b border-stroke">
+      <div className="shrink-0 flex min-h-[44px] items-center justify-between px-4 border-b border-stroke">
         <div className="text-[13px] font-bold text-foreground">보유종목</div>
-        <div className="flex items-center gap-0.5">
+        <div className="flex items-center rounded-lg bg-surface-muted p-0.5">
           {filters.map(({ key, label }) => (
-            <FilterChip
+            <button
               key={key}
-              isActive={filter === key}
               onClick={() => setFilter(key)}
-              className="px-1.5 py-0.5 text-[9px]"
+              className={cn(
+                'rounded-md px-2.5 py-0.5 text-[10px] font-semibold transition-all',
+                filter === key
+                  ? 'bg-primary text-white shadow-control'
+                  : 'text-foreground-disabled hover:text-foreground-secondary',
+              )}
             >
               {label}
-            </FilterChip>
+            </button>
           ))}
         </div>
       </div>
@@ -631,7 +674,7 @@ export default function AssetPage() {
 
 export function AssetContent() {
   const { isAuthenticated, isRestoring, user } = useAuthStore()
-  const [assetFlowRange, setAssetFlowRange] = useState('1M')
+  const [assetFlowRange, setAssetFlowRange] = useState('1W')
   const data = useAssetPage(isAuthenticated && !isRestoring, assetFlowRange)
   const [showExchange, setShowExchange] = useState(false)
 


### PR DESCRIPTION
## Summary
- `marketData.js` `toLocalTimestamp`·`extractDateKey`에 epoch ms(number) 타입 처리 추가
- `domestic/normalize.js`, `foreign/normalize.js` 필드명 `item.time` 으로 통일 (구 string 포맷 제거)
- `foreign/normalize.js` `toExchangeLocalTimestamp` 제거 — 백엔드가 `America/New_York` 기준 epoch ms 직접 제공
- `useForexChart`, `useIndexChart` epoch ms 기반 `toTime` 변환으로 변경
- `InvestStockChart` `useUtc` 로직 제거, 로컬 시간(KST) 표시로 통일

## Test plan
- [ ] 국내주식 분봉/일봉 차트 시간 KST 정상 표시 확인
- [ ] 해외주식(NVDA 등) 분봉/일봉 차트 시간 KST 정상 표시 확인
- [ ] 환율(USD/KRW) 차트 시간 KST 정상 표시 확인
- [ ] KOSPI/KOSDAQ/S&P/NASDAQ 지수 차트 시간 KST 정상 표시 확인