### PR TITLE
fix(widget): PR #101 리뷰 반영 내용 dev 미반영 수정

### DIFF
--- a/src/components/widgets/BalanceWidget.jsx
+++ b/src/components/widgets/BalanceWidget.jsx
@@ -76,14 +76,14 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
               : <div className={`text-widget-11 font-semibold mt-0.5 ${BALANCE.isProfit ? 'text-up' : 'text-down'}`}>{BALANCE.isProfit ? '▲' : '▼'} {BALANCE.profit} ({BALANCE.profitRate})</div>
             }
           </div>
-          <div className="flex flex-col justify-center gap-2 shrink-0 border-l border-stroke pl-3">
+          <div className="flex flex-col justify-center gap-1 shrink-0 border-l border-stroke pl-3">
             {[
               { label: '투자원금', val: BALANCE.invested, color: 'text-foreground' },
               { label: '평가손익', val: BALANCE.profit,   color: BALANCE.isProfit ? 'text-up' : 'text-down' },
               { label: '주문가능', val: BALANCE.available, color: 'text-foreground' },
             ].map(({ label, val, color }) => (
               <div key={label}>
-                <div className="text-widget-9 text-foreground-disabled">{label}</div>
+                <div className="text-widget-7 text-foreground-disabled">{label}</div>
                 <div className={`text-widget-10 font-semibold ${color}`}>{val}</div>
               </div>
             ))}

--- a/src/components/widgets/BalanceWidget.jsx
+++ b/src/components/widgets/BalanceWidget.jsx
@@ -65,27 +65,26 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
       </div>
 
       {variant === 'balance-lg' ? (
-        <div className="flex flex-col flex-1 gap-1.5 min-h-0">
-          <div className="shrink-0">
-            <div className="text-widget-8 text-foreground-disabled">총 평가자산</div>
+        <div className="flex flex-1 gap-3 min-h-0">
+          <div className="flex flex-col justify-center flex-1 min-w-0">
+            <div className="text-widget-11 text-foreground-disabled">총 평가자산</div>
             <div className="text-widget-18 font-bold leading-tight tracking-tight text-foreground mt-0.5">
               {BALANCE.total}
             </div>
             {BALANCE.isLoading
               ? <div className="text-widget-9 text-foreground-disabled mt-0.5">-</div>
-              : <div className={`text-widget-9 font-semibold mt-0.5 ${BALANCE.isProfit ? 'text-up' : 'text-down'}`}>{BALANCE.isProfit ? '▲' : '▼'} {BALANCE.profit} ({BALANCE.profitRate})</div>
+              : <div className={`text-widget-11 font-semibold mt-0.5 ${BALANCE.isProfit ? 'text-up' : 'text-down'}`}>{BALANCE.isProfit ? '▲' : '▼'} {BALANCE.profit} ({BALANCE.profitRate})</div>
             }
           </div>
-          <div className="h-px bg-stroke-subtle shrink-0" />
-          <div className="flex gap-2 flex-1 items-start">
+          <div className="flex flex-col justify-center gap-2 shrink-0 border-l border-stroke pl-3">
             {[
               { label: '투자원금', val: BALANCE.invested, color: 'text-foreground' },
               { label: '평가손익', val: BALANCE.profit,   color: BALANCE.isProfit ? 'text-up' : 'text-down' },
               { label: '주문가능', val: BALANCE.available, color: 'text-foreground' },
             ].map(({ label, val, color }) => (
-              <div key={label} className="flex-1 min-w-0">
-                <div className="text-widget-10 text-foreground-disabled">{label}</div>
-                <div className={`text-widget-13 font-semibold truncate ${color}`}>{val}</div>
+              <div key={label}>
+                <div className="text-widget-9 text-foreground-disabled">{label}</div>
+                <div className={`text-widget-10 font-semibold ${color}`}>{val}</div>
               </div>
             ))}
           </div>
@@ -100,17 +99,17 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
               </div>
               {BALANCE.isLoading
                 ? <div className="text-widget-10 text-foreground-disabled mt-0.5">-</div>
-                : <div className={`text-widget-10 font-semibold mt-0.5 ${BALANCE.isProfit ? 'text-up' : 'text-down'}`}>{BALANCE.isProfit ? '▲' : '▼'} {BALANCE.profit} ({BALANCE.profitRate})</div>
+                : <div className={`text-widget-9 font-semibold mt-0.5 ${BALANCE.isProfit ? 'text-up' : 'text-down'}`}>{BALANCE.isProfit ? '▲' : '▼'} {BALANCE.profit} ({BALANCE.profitRate})</div>
               }
             </div>
             <div className="flex gap-6 shrink-0">
               <div>
-                <div className="text-widget-9 text-foreground-disabled">투자원금</div>
-                <div className="text-widget-11 font-semibold text-foreground">{BALANCE.invested}</div>
+                <div className="text-widget-7 text-foreground-disabled">투자원금</div>
+                <div className="text-widget-10 font-semibold text-foreground">{BALANCE.invested}</div>
               </div>
               <div>
-                <div className="text-widget-9 text-foreground-disabled">주문가능</div>
-                <div className="text-widget-11 font-semibold text-foreground">{BALANCE.available}</div>
+                <div className="text-widget-7 text-foreground-disabled">주문가능</div>
+                <div className="text-widget-10 font-semibold text-foreground">{BALANCE.available}</div>
               </div>
             </div>
           </div>

--- a/src/components/widgets/PortfolioWidget.jsx
+++ b/src/components/widgets/PortfolioWidget.jsx
@@ -13,6 +13,20 @@ const CHART_COLORS = [
   'var(--color-chart-5)',
 ]
 
+function ItemBar({ item, barHeight = 'h-[3px]' }) {
+  return (
+    <div>
+      <div className="flex justify-between mb-0.5">
+        <span className="text-widget-10 text-foreground-secondary">{item.name}</span>
+        <span className="text-widget-10 font-semibold text-foreground">{item.ratio}%</span>
+      </div>
+      <div className={`${barHeight} bg-surface-muted rounded-full overflow-hidden`}>
+        <div className="h-full rounded-full" style={{ width: `${item.ratio}%`, background: item.color }} />
+      </div>
+    </div>
+  )
+}
+
 function usePortfolio(enabled) {
   const { data: holdings = [], isLoading } = useDomesticHoldings({ enabled })
 
@@ -91,24 +105,16 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
             <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 비중</span>
             <span className={`text-widget-10 font-semibold ${returnRateColor}`}>{returnRateStr}</span>
           </div>
-          <div className="flex flex-col gap-2 flex-1 min-h-0">
-            {portfolio.items.slice(0, 3).map((item) => (
-              <div key={item.name}>
-                <div className="flex justify-between mb-0.5">
-                  <span className="text-widget-10 text-foreground-secondary">{item.name}</span>
-                  <span className="text-widget-10 font-semibold text-foreground">{item.ratio}%</span>
-                </div>
-                <div className="h-[3px] bg-surface-muted rounded-full overflow-hidden">
-                  <div className="h-full rounded-full" style={{ width: `${item.ratio}%`, background: item.color }} />
-                </div>
-              </div>
+          <div className="flex flex-col gap-1 flex-1 min-h-0 overflow-hidden">
+            {portfolio.items.map((item) => (
+              <ItemBar key={item.name} item={item} barHeight="h-[3px]" />
             ))}
           </div>
         </>
       ) : variant === 'portfolio-2x2' ? (
         <>
           <div className="flex items-center justify-between mb-1 shrink-0">
-            <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">섹터별 비중</span>
+            <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 비중</span>
           </div>
           <div className="flex flex-col flex-1 gap-3">
             <div className="flex items-center gap-3 shrink-0">

--- a/src/components/widgets/PortfolioWidget.jsx
+++ b/src/components/widgets/PortfolioWidget.jsx
@@ -11,23 +11,24 @@ const CHART_COLORS = [
   'var(--color-chart-3)',
   'var(--color-chart-4)',
   'var(--color-chart-5)',
+  'var(--color-chart-other)',
 ]
 
 function ItemBar({ item, barHeight = 'h-[3px]' }) {
   return (
-    <div>
-      <div className="flex justify-between mb-0.5">
-        <span className="text-widget-10 text-foreground-secondary">{item.name}</span>
-        <span className="text-widget-10 font-semibold text-foreground">{item.ratio}%</span>
+    <div className="min-w-0">
+      <div className="flex justify-between gap-2 mb-0.5">
+        <span className="text-widget-10 text-foreground-secondary tracking-tight truncate">{item.name}</span>
+        <span className="text-widget-10 font-semibold text-foreground shrink-0">{item.ratio}%</span>
       </div>
       <div className={`${barHeight} bg-surface-muted rounded-full overflow-hidden`}>
-        <div className="h-full rounded-full" style={{ width: `${item.ratio}%`, background: item.color }} />
+        <div className="h-full rounded-full" style={{ width: `max(2px, ${item.ratio}%)`, background: item.color }} />
       </div>
     </div>
   )
 }
 
-function usePortfolio(enabled) {
+function usePortfolio(enabled, topN = 3) {
   const { data: holdings = [], isLoading } = useDomesticHoldings({ enabled })
 
   return useMemo(() => {
@@ -52,8 +53,8 @@ function usePortfolio(enabled) {
 
     if (total === 0) return { items: [], returnRate: null, isLoading: false }
 
-    const top = withValues.slice(0, 3)
-    const rest = withValues.slice(3)
+    const top = withValues.slice(0, topN)
+    const rest = withValues.slice(topN)
 
     const items = top.map((h, i) => ({
       name: h.name,
@@ -65,7 +66,7 @@ function usePortfolio(enabled) {
       items.push({
         name: '기타',
         ratio: 100 - items.reduce((s, item) => s + item.ratio, 0),
-        color: CHART_COLORS[3],
+        color: CHART_COLORS[topN],
       })
     } else {
       const sum = items.reduce((s, item) => s + item.ratio, 0)
@@ -84,7 +85,9 @@ function usePortfolio(enabled) {
 export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1, rowSpan = 1, onDelete }) {
   const { isAuthenticated, isRestoring } = useAuthStore()
   const { open } = useWidgetDetailStore()
-  const portfolio = usePortfolio(isAuthenticated && !isRestoring)
+  // 2×2는 최대 5종목+기타, 나머지는 3종목+기타
+  const topN = variant === 'portfolio-2x2' ? 5 : 3
+  const portfolio = usePortfolio(isAuthenticated && !isRestoring, topN)
 
   const conicStops = portfolio.items.reduce((acc, item, i) => {
     const start = portfolio.items.slice(0, i).reduce((s, x) => s + x.ratio, 0)
@@ -116,7 +119,7 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
           <div className="flex items-center justify-between mb-1 shrink-0">
             <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 비중</span>
           </div>
-          <div className="flex flex-col flex-1 gap-3">
+          <div className="flex flex-col flex-1 gap-3 min-h-0">
             <div className="flex items-center gap-3 shrink-0">
               <div
                 className="w-16 h-16 rounded-full shrink-0"
@@ -128,17 +131,9 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
                 <div className="text-widget-9 text-foreground-disabled mt-0.5">+4,280,000원</div>
               </div>
             </div>
-            <div className="flex flex-col gap-2.5 flex-1">
+            <div className="flex flex-col gap-1.5 flex-1 min-h-0 overflow-hidden">
               {portfolio.items.map((item) => (
-                <div key={item.name}>
-                  <div className="flex justify-between mb-0.5">
-                    <span className="text-widget-10 text-foreground-tertiary">{item.name}</span>
-                    <span className="text-widget-10 font-semibold text-foreground">{item.ratio}%</span>
-                  </div>
-                  <div className="h-[4px] bg-surface-muted rounded-full overflow-hidden">
-                    <div className="h-full rounded-full" style={{ width: `${item.ratio}%`, background: item.color }} />
-                  </div>
-                </div>
+                <ItemBar key={item.name} item={item} barHeight="h-[4px]" />
               ))}
             </div>
           </div>
@@ -155,11 +150,11 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
               className="w-14 h-14 rounded-full shrink-0"
               style={{ background: `conic-gradient(${conicStops})` }}
             />
-            <div className="flex flex-col gap-1">
+            <div className="flex flex-col gap-1 min-w-0 flex-1">
               {portfolio.items.map((item) => (
-                <div key={item.name} className="flex items-center gap-1">
+                <div key={item.name} className="flex items-center gap-1 min-w-0">
                   <div className="w-1.5 h-1.5 rounded-full shrink-0" style={{ background: item.color }} />
-                  <span className="text-widget-10 text-foreground-secondary">{item.name}</span>
+                  <span className="text-widget-10 text-foreground-secondary tracking-tight truncate">{item.name}</span>
                 </div>
               ))}
             </div>

--- a/src/components/widgets/RankingWidget.jsx
+++ b/src/components/widgets/RankingWidget.jsx
@@ -1,10 +1,11 @@
-import { useState } from 'react'
+import { useState, useRef, useLayoutEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import PriceChange from '@/components/ui/PriceChange'
 import TabChip from '@/components/ui/TabChip'
 import WidgetCard from './WidgetCard'
 import useMarketRanking from '@/features/market/useMarketRanking'
 import useWidgetDetailStore from '@/store/useWidgetDetailStore'
+import useUIStore from '@/store/useUIStore'
 
 const TABS = ['거래대금', '급상승', '거래량']
 
@@ -32,6 +33,31 @@ export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, r
     localStorage.setItem('rankingWidget.activeTab', tab)
   }
   const { stocks } = useMarketRanking(TAB_TO_SORT[activeTab], '')
+  const fontSize = useUIStore((s) => s.fontSize)
+
+  // ── ranking-lg (2x2): 컨테이너 높이 실측 후 완전한 행만 표시 ──
+  const lgListRef = useRef(null)
+  const lgFirstRowRef = useRef(null)
+  const [lgMax, setLgMax] = useState(undefined)
+
+  // fontSize 변경 시 maxHeight 초기화 → 컨테이너가 자연 높이로 복귀
+  useLayoutEffect(() => {
+    setLgMax(undefined)
+  }, [fontSize])
+
+  // lgMax가 undefined일 때(= 컨테이너가 flex-1 자연 높이) 실측 후 설정
+  useLayoutEffect(() => {
+    if (lgMax !== undefined) return
+    const container = lgListRef.current
+    const firstRow = lgFirstRowRef.current
+    if (!container || !firstRow || !stocks.length) return
+    const containerH = container.getBoundingClientRect().height
+    const rowH = firstRow.getBoundingClientRect().height
+    if (rowH <= 0 || containerH <= 0) return
+    const gapPx = 2 // gap-0.5 = 0.125rem = 2px
+    const n = Math.floor(containerH / (rowH + gapPx))
+    setLgMax(`${Math.floor(n * (rowH + gapPx) - gapPx)}px`)
+  }, [lgMax, stocks.length])
 
   if (variant === 'ranking-lg') {
     return (
@@ -50,11 +76,16 @@ export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, r
             ))}
           </div>
         </div>
-        <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-0.5">
-          {stocks.map((stock) => (
+        <div
+          ref={lgListRef}
+          className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-0.5"
+          style={{ maxHeight: lgMax }}
+        >
+          {stocks.map((stock, i) => (
             <div
               key={stock.id ?? stock.rank}
-              className="flex items-center justify-between px-1 py-1 rounded-r-lg border-l-2 border-transparent hover:border-primary hover:bg-surface-subtle transition-colors cursor-pointer"
+              ref={i === 0 ? lgFirstRowRef : undefined}
+              className="flex items-center justify-between px-1 py-1 hover:bg-surface-subtle rounded-lg transition-colors cursor-pointer shrink-0"
               onClick={(e) => handleStockClick(e, stock)}
             >
               <div className="flex items-center gap-1.5">
@@ -88,11 +119,11 @@ export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, r
           ))}
         </div>
       </div>
-      <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-0.5">
+      <div className="flex-1 min-h-0 overflow-y-auto flex flex-col">
         {stocks.map((stock) => (
           <div
             key={stock.id ?? stock.rank}
-            className="flex items-center justify-between px-1.5 py-1.5 rounded-r-xl border-l-2 border-transparent hover:border-primary hover:bg-surface-subtle transition-colors cursor-pointer"
+            className="flex items-center justify-between px-1.5 py-1 rounded-xl hover:bg-surface-subtle transition-colors cursor-pointer shrink-0"
             onClick={(e) => handleStockClick(e, stock)}
           >
             <div className="flex items-center gap-1.5">

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -469,14 +469,14 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
   return (
     <>
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleCardClick}>
-        <div className="flex items-center justify-between shrink-0">
-          <div className="flex items-center gap-1.5">
-            <StockAvatar name={stock.name} stockCode={stock.code} marketType={stock.marketType} color={stock.color} size="sm" />
-            <span className="text-widget-12 font-bold text-foreground leading-none">{stock.name}</span>
-          </div>
-          <div className="flex items-center gap-1">
-            <span className="text-widget-9 text-foreground-disabled">{stock.code}</span>
-            {settingsBtn}
+        <div className="flex items-center gap-1.5 shrink-0 min-w-0">
+          <StockAvatar name={stock.name} stockCode={stock.code} marketType={stock.marketType} color={stock.color} size="sm" />
+          <div className="min-w-0">
+            <div className="flex items-center gap-1">
+              <div className="text-widget-12 font-bold text-foreground leading-none truncate">{stock.name}</div>
+              {settingsBtn}
+            </div>
+            <div className="text-widget-9 text-foreground-disabled mt-0.5">{stock.code}{stock.marketType ? ` · ${stock.marketType}` : ''}</div>
           </div>
         </div>
         <div className="flex-1 flex flex-col justify-end min-h-0">

--- a/src/components/widgets/WatchlistEditModal.jsx
+++ b/src/components/widgets/WatchlistEditModal.jsx
@@ -1,0 +1,136 @@
+import { useState, useEffect } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { X, Search, Heart } from 'lucide-react'
+import { marketApi } from '@/api/market'
+
+export default function WatchlistEditModal({ items, onAdd, onRemove, onClose }) {
+  const [localItems, setLocalItems] = useState(() =>
+    items.map((i) => ({ stockCode: i.stockCode, stockName: i.stockName, isWatched: true }))
+  )
+  const [keyword, setKeyword] = useState('')
+  const [debouncedKeyword, setDebouncedKeyword] = useState('')
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedKeyword(keyword), 300)
+    return () => clearTimeout(timer)
+  }, [keyword])
+
+  const { data: results = [], isFetching } = useQuery({
+    queryKey: ['stock', 'search', debouncedKeyword],
+    queryFn: () => marketApi.searchStocks(debouncedKeyword),
+    enabled: debouncedKeyword.trim().length >= 1,
+    staleTime: 30_000,
+  })
+
+  function toggleTopItem(stockCode) {
+    const item = localItems.find((i) => i.stockCode === stockCode)
+    if (!item) return
+    if (item.isWatched) {
+      onRemove(stockCode)
+      setLocalItems((prev) => prev.map((i) => i.stockCode === stockCode ? { ...i, isWatched: false } : i))
+    } else {
+      onAdd(stockCode)
+      setLocalItems((prev) => prev.map((i) => i.stockCode === stockCode ? { ...i, isWatched: true } : i))
+    }
+  }
+
+  function toggleSearchResult(stock) {
+    const existing = localItems.find((i) => i.stockCode === stock.stockCode)
+    if (existing) {
+      toggleTopItem(stock.stockCode)
+    } else {
+      onAdd(stock.stockCode)
+      setLocalItems((prev) => [...prev, { stockCode: stock.stockCode, stockName: stock.stockName, isWatched: true }])
+    }
+  }
+
+  const localSet = new Map(localItems.map((i) => [i.stockCode, i.isWatched]))
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={onClose}
+    >
+      <div
+        className="bg-surface rounded-2xl shadow-modal w-[320px] p-5"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <span className="text-widget-13 font-bold text-foreground">관심 종목 편집</span>
+          <button
+            aria-label="닫기"
+            onClick={onClose}
+            className="text-foreground-disabled hover:text-foreground transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* 상단: 관심종목 목록 (로컬 state 기준) */}
+        {localItems.length > 0 && (
+          <div className="flex flex-col gap-0.5 max-h-[180px] overflow-y-auto mb-3">
+            {localItems.map(({ stockCode, stockName, isWatched }) => (
+              <div key={stockCode} className="flex items-center justify-between px-3 py-2 rounded-xl hover:bg-surface-subtle">
+                <span className={`text-widget-12 font-semibold ${isWatched ? 'text-foreground' : 'text-foreground-disabled'}`}>
+                  {stockName}
+                </span>
+                <div className="flex items-center gap-2">
+                  <span className="text-widget-10 text-foreground-disabled">{stockCode}</span>
+                  <button
+                    aria-label={isWatched ? '관심종목 해제' : '관심종목 추가'}
+                    onClick={() => toggleTopItem(stockCode)}
+                    className={`transition-colors ${isWatched ? 'text-primary hover:text-primary/60' : 'text-stroke-input hover:text-primary'}`}
+                  >
+                    <Heart className="w-3.5 h-3.5" fill={isWatched ? 'currentColor' : 'none'} />
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {localItems.length > 0 && <div className="h-px bg-stroke-subtle mb-3" />}
+
+        {/* 검색 */}
+        <div className="relative mb-3">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-foreground-disabled" />
+          <input
+            autoFocus
+            type="text"
+            value={keyword}
+            onChange={(e) => setKeyword(e.target.value)}
+            placeholder="종목명 또는 코드 검색"
+            className="w-full pl-8 pr-3 py-2 text-widget-12 bg-background border border-stroke rounded-xl outline-none focus:border-primary transition-colors"
+          />
+        </div>
+
+        <div className="flex flex-col gap-0.5 max-h-[200px] overflow-y-auto">
+          {isFetching && (
+            <div className="text-widget-11 text-foreground-disabled text-center py-4">검색 중...</div>
+          )}
+          {!isFetching && debouncedKeyword.trim().length >= 1 && results.length === 0 && (
+            <div className="text-widget-11 text-foreground-disabled text-center py-4">검색 결과 없음</div>
+          )}
+          {results.map((stock) => {
+            const isWatched = localSet.get(stock.stockCode) ?? false
+            return (
+              <div key={stock.stockCode} className="flex items-center justify-between px-3 py-2 rounded-xl hover:bg-surface-subtle">
+                <span className="text-widget-12 font-semibold text-foreground">{stock.stockName}</span>
+                <div className="flex items-center gap-2">
+                  <span className="text-widget-10 text-foreground-disabled">{stock.stockCode}</span>
+                  <button
+                    aria-label={isWatched ? '관심종목 해제' : '관심종목 추가'}
+                    onClick={() => toggleSearchResult(stock)}
+                    className={`transition-colors ${isWatched ? 'text-primary hover:text-primary/60' : 'text-stroke-input hover:text-primary'}`}
+                  >
+                    <Heart className="w-3.5 h-3.5" fill={isWatched ? 'currentColor' : 'none'} />
+                  </button>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/widgets/WatchlistWidget.jsx
+++ b/src/components/widgets/WatchlistWidget.jsx
@@ -1,11 +1,11 @@
 import { useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { X } from 'lucide-react'
+import { Settings2 } from 'lucide-react'
 import PriceChange from '@/components/ui/PriceChange'
 import LockedOverlay from '@/components/ui/LockedOverlay'
 import useAuthStore from '@/store/useAuthStore'
 import WidgetCard from './WidgetCard'
-import StockSelectModal from './StockSelectModal'
+import WatchlistEditModal from './WatchlistEditModal'
 import { useWatchlist, watchlistApi } from '@/api/watchlist'
 import useWidgetDetailStore from '@/store/useWidgetDetailStore'
 import { isForeignMarketType } from '@/features/invest/formatters'
@@ -40,7 +40,7 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
   const { isAuthenticated, isRestoring } = useAuthStore()
   const { data: items = [], isError } = useWatchlist({ enabled: isAuthenticated && !isRestoring })
   const { add, remove } = useWatchlistMutations()
-  const [isAddOpen, setIsAddOpen] = useState(false)
+  const [isEditOpen, setIsEditOpen] = useState(false)
   const openDetail = useWidgetDetailStore((s) => s.open)
 
   function handleWidgetClick() {
@@ -57,31 +57,33 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
     })
   }
 
-  const list = items.slice(0, 5)
+  const list = items
 
-  function handleAdd({ stockCode }) {
-    add.mutate(stockCode, { onSuccess: () => setIsAddOpen(false) })
+  function handleAdd(stockCode) {
+    add.mutate(stockCode)
   }
 
-  function handleRemove(e, stockCode) {
-    e.stopPropagation()
+  function handleRemove(stockCode) {
     remove.mutate(stockCode)
   }
 
-  const addModal = isAddOpen && (
-    <StockSelectModal
-      onSave={handleAdd}
-      onClose={() => setIsAddOpen(false)}
-    />
+  const editBtn = (
+    <button
+      aria-label="관심 종목 편집"
+      onClick={(e) => { e.stopPropagation(); setIsEditOpen(true) }}
+      className="text-foreground-disabled hover:text-foreground transition-colors"
+    >
+      <Settings2 className="w-3 h-3" />
+    </button>
   )
 
-  const addBtn = (
-    <button
-      onClick={(e) => { e.stopPropagation(); setIsAddOpen(true) }}
-      className="text-widget-10 text-primary font-semibold hover:underline"
-    >
-      + 추가
-    </button>
+  const editModal = isEditOpen && (
+    <WatchlistEditModal
+      items={items}
+      onAdd={handleAdd}
+      onRemove={handleRemove}
+      onClose={() => setIsEditOpen(false)}
+    />
   )
 
   if (variant === 'watchlist-wide') {
@@ -90,16 +92,16 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
         <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
           <div className="flex items-center justify-between mb-2 shrink-0">
             <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">관심 종목</span>
-            {addBtn}
+            {editBtn}
           </div>
-          <div className="flex-1 flex flex-col gap-1.5 min-h-0">
+          <div className="flex-1 flex flex-col gap-1 min-h-0 overflow-y-auto">
             {isError
               ? <span className="text-widget-10 text-foreground-disabled">불러오기에 실패했습니다</span>
               : list.length > 0 ? list.map((item) => (
               <div
                 key={item.stockCode}
                 onClick={(e) => handleStockClick(e, item)}
-                className="flex items-center justify-between gap-2 group cursor-pointer pl-1.5 border-l-2 border-l-transparent hover:border-l-primary transition-colors"
+                className="flex items-center justify-between gap-2 cursor-pointer pl-1.5 border-l-2 border-l-transparent hover:border-l-primary transition-colors"
               >
                 <span className="text-widget-10 font-medium text-foreground truncate">{item.stockName}</span>
                 <div className="flex items-center gap-1.5 shrink-0">
@@ -109,12 +111,6 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
                     </span>
                   )}
                   <PriceChange value={item.changeRate} className="text-widget-9 font-medium" />
-                  <button
-                    onClick={(e) => handleRemove(e, item.stockCode)}
-                    className="opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded text-foreground-disabled hover:text-down"
-                  >
-                    <X className="w-3 h-3" />
-                  </button>
                 </div>
               </div>
             )) : (
@@ -123,7 +119,7 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
           </div>
           {!isRestoring && !isAuthenticated && <LockedOverlay message="관심 종목을 보려면" />}
         </WidgetCard>
-        {addModal}
+        {editModal}
       </>
     )
   }
@@ -134,27 +130,19 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
         <div className="flex items-center justify-between mb-2 shrink-0">
           <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">관심 종목</span>
-          {addBtn}
+          {editBtn}
         </div>
-        <div className="flex-1 flex flex-col gap-1.5 min-h-0">
+        <div className="flex-1 flex flex-col gap-1 min-h-0 overflow-y-auto">
           {isError
             ? <span className="text-widget-10 text-foreground-disabled">불러오기에 실패했습니다</span>
             : list.length > 0 ? list.map((item) => (
             <div
               key={item.stockCode}
               onClick={(e) => handleStockClick(e, item)}
-              className="flex items-center justify-between group cursor-pointer pl-1.5 border-l-2 border-l-transparent hover:border-l-primary transition-colors"
+              className="flex items-center justify-between cursor-pointer pl-1.5 border-l-2 border-l-transparent hover:border-l-primary transition-colors"
             >
               <span className="text-widget-10 font-medium text-foreground truncate">{item.stockName}</span>
-              <div className="flex items-center gap-1 shrink-0">
-                <PriceChange value={item.changeRate} className="text-widget-9 font-semibold" />
-                <button
-                  onClick={(e) => handleRemove(e, item.stockCode)}
-                  className="opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded text-foreground-disabled hover:text-down"
-                >
-                  <X className="w-3 h-3" />
-                </button>
-              </div>
+              <PriceChange value={item.changeRate} className="text-widget-9 font-semibold shrink-0" />
             </div>
           )) : (
             <div className="flex-1 flex items-center justify-center text-widget-9 text-foreground-disabled">관심 종목 없음</div>
@@ -162,7 +150,7 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
         </div>
         {!isRestoring && !isAuthenticated && <LockedOverlay message="관심 종목을 보려면" />}
       </WidgetCard>
-      {addModal}
+      {editModal}
     </>
   )
 }


### PR DESCRIPTION
## 개요

PR #101(위젯 글꼴 크기 설정) 머지 이후 리뷰 반영 커밋이 `dev`에 포함되지 않은 문제를 수정합니다.

closes #107

## 원인

`feat/font-size-settings` 브랜치에서 PR #101 squash merge 이후 추가된 커밋(`refactor(ui): PR #101 리뷰 반영 및 위젯 UI 개선`)이 `dev`에 반영되지 않은 채로 남아 있었습니다. dev에는 widget-detail-modal PR이 먼저 머지되어 충돌이 발생했고, 충돌 해결 후 적용합니다.

## 변경 내용

- `WatchlistWidget`: `StockSelectModal` → `WatchlistEditModal` 교체, 개별 X 버튼 제거 후 편집 모달로 통합
- `BalanceWidget`: `balance-lg` variant 레이아웃 수평(side-by-side) 정렬로 개선
- `PortfolioWidget`: `portfolio-wide` variant 전체 종목 표시 및 `ItemBar` 컴포넌트 분리
- `RankingWidget`: 글꼴 크기 변경 시 행 높이 재계산 로직(`useLayoutEffect`) 추가

## 변경 파일

- `src/components/widgets/WatchlistWidget.jsx`
- `src/components/widgets/BalanceWidget.jsx`
- `src/components/widgets/PortfolioWidget.jsx`
- `src/components/widgets/RankingWidget.jsx`