### PR TITLE
feat(home): 수평 스와이프로 대시보드 페이지 전환

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,15 @@
 @import "tailwindcss";
 
 /* ─────────────────────────────────────────────
+   글로벌 스타일
+───────────────────────────────────────────── */
+html, body {
+  /* 트랙패드 수평 스와이프 브라우저 뒤로가기/앞으로가기 제스처 비활성화
+     대시보드 수평 스와이프 페이지 전환과의 충돌 방지 */
+  overscroll-behavior-x: none;
+}
+
+/* ─────────────────────────────────────────────
    Pretendard 폰트 로드
 ───────────────────────────────────────────── */
 @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -15,6 +15,9 @@ import { GRID_COLS, GRID_ROWS, GRID_GAP, MIN_GRID_WIDTH, MIN_GRID_HEIGHT, MIN_CE
 import { DASHBOARD_PRESETS } from '@/data/dashboardPresets'
 import { PreviewContent } from '@/components/layout/EditPanel/WidgetSizeList'
 
+const SCROLL_COOLDOWN_MS = 500
+const SCROLL_THRESHOLD   = 30
+
 function PresetThumbnail({ widgets }) {
   return (
     <div className="bg-background h-[152px] p-1.5 grid grid-cols-6 grid-rows-4 gap-[2px]">
@@ -122,6 +125,10 @@ export default function HomePage() {
   const safeWidgets = (!isRestoring && (isLoaded || !isAuthenticated)) ? widgets : []
   const gridRef = useRef(null)
   const isEditModeRef = useRef(isEditMode)
+  const pageContainerRef = useRef(null)
+  const scrollCooldownRef = useRef(0)
+  const pagesRef = useRef(pages)
+  const currentPageIdRef = useRef(currentPageId)
 
   // 빈 대시보드에서도 드롭 가능하도록 그리드 전체를 droppable로 등록
   const { setNodeRef: setGridDroppableRef } = useDroppable({ id: 'dashboard-grid' })
@@ -132,9 +139,38 @@ export default function HomePage() {
     gridElementRef.current = node
   }, [setGridDroppableRef])
 
+  useEffect(() => { isEditModeRef.current = isEditMode },       [isEditMode])
+  useEffect(() => { pagesRef.current = pages },                [pages])
+  useEffect(() => { currentPageIdRef.current = currentPageId }, [currentPageId])
+
+  // 수평 스와이프로 페이지 전환 (편집 모드 포함)
+  // passive: false — 수평 스와이프 감지 즉시 브라우저 뒤로가기/앞으로가기 제스처 차단
   useEffect(() => {
-    isEditModeRef.current = isEditMode
-  }, [isEditMode])
+    const el = pageContainerRef.current
+    if (!el) return
+
+    function handleWheel(e) {
+      const { deltaX, deltaY } = e
+      if (Math.abs(deltaX) <= Math.abs(deltaY)) return
+      // 수평 이벤트 전체에 preventDefault — threshold 이하 초기 이벤트도 차단해야 브라우저 제스처 막힘
+      e.preventDefault()
+      if (Math.abs(deltaX) < SCROLL_THRESHOLD) return
+
+      const pages = pagesRef.current
+      if (pages.length <= 1) return
+
+      const now = Date.now()
+      if (now - scrollCooldownRef.current < SCROLL_COOLDOWN_MS) return
+      scrollCooldownRef.current = now
+
+      const idx = pages.findIndex((p) => p.id === currentPageIdRef.current)
+      if (deltaX > 0 && idx < pages.length - 1) switchPage(pages[idx + 1].id)
+      else if (deltaX < 0 && idx > 0)           switchPage(pages[idx - 1].id)
+    }
+
+    el.addEventListener('wheel', handleWheel, { passive: false })
+    return () => el.removeEventListener('wheel', handleWheel)
+  }, [switchPage])
 
   useEffect(() => {
     const el = gridRef.current
@@ -174,7 +210,7 @@ export default function HomePage() {
 
   return (
     <>
-    <div className="flex flex-col h-full overflow-hidden p-3 gap-2.5">
+    <div ref={pageContainerRef} className="flex flex-col h-full overflow-hidden p-3 gap-2.5">
       {/* 서브바 */}
       <div className="flex items-center justify-between shrink-0 px-1 h-7">
         <div className="flex items-center gap-2">

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -156,16 +156,16 @@ export default function HomePage() {
       e.preventDefault()
       if (Math.abs(deltaX) < SCROLL_THRESHOLD) return
 
-      const pages = pagesRef.current
-      if (pages.length <= 1) return
+      const currentPages = pagesRef.current
+      if (currentPages.length <= 1) return
 
       const now = Date.now()
       if (now - scrollCooldownRef.current < SCROLL_COOLDOWN_MS) return
       scrollCooldownRef.current = now
 
-      const idx = pages.findIndex((p) => p.id === currentPageIdRef.current)
-      if (deltaX > 0 && idx < pages.length - 1) switchPage(pages[idx + 1].id)
-      else if (deltaX < 0 && idx > 0)           switchPage(pages[idx - 1].id)
+      const idx = currentPages.findIndex((p) => p.id === currentPageIdRef.current)
+      if (deltaX > 0 && idx < currentPages.length - 1) switchPage(currentPages[idx + 1].id)
+      else if (deltaX < 0 && idx > 0)                  switchPage(currentPages[idx - 1].id)
     }
 
     el.addEventListener('wheel', handleWheel, { passive: false })


### PR DESCRIPTION
## 개요

closes #111

#110 이후 스와이프 기능을 dev에 반영합니다.

## 변경사항

### 수평 스와이프 페이지 전환 (`HomePage.jsx`)

- 트랙패드 수평 스와이프(deltaX 우세)로 이전/다음 페이지 이동
- 수평 이벤트 감지 즉시 `preventDefault` 호출 — 브라우저 뒤로가기 제스처 차단
- 편집 모드에서도 동작
- 500ms 쿨다운으로 연속 전환 방지

### 브라우저 뒤로가기 제스처 전역 차단 (`index.css`)

- `html, body`에 `overscroll-behavior-x: none` 전역 적용
- ChatPanel 등 다른 영역에서 스와이프해도 브라우저 이동 제스처 발생 안 함

## QA 체크리스트

- [ ] 트랙패드 수평 스와이프 → 다음/이전 페이지로 전환
- [ ] 빠른 연속 스와이프 → 500ms 쿨다운으로 한 번에 한 페이지씩만 전환
- [ ] 첫 번째 페이지에서 오른쪽 스와이프 → 아무 반응 없음
- [ ] 마지막 페이지에서 왼쪽 스와이프 → 아무 반응 없음
- [ ] 페이지 1개일 때 스와이프 → 아무 반응 없음
- [ ] 수직 스크롤 → 페이지 전환 없음, 위젯 내 스크롤만 동작
- [ ] 편집 모드에서 수평 스와이프 → 페이지 전환 됨
- [ ] ChatPanel에서 스와이프 후 대시보드로 돌아와 스와이프 → 브라우저 이동 없이 페이지 전환
- [ ] 시세/주문/잔고 탭에서 수평 스와이프 → 브라우저 이동 없음 (전역 차단)