### PR TITLE
hotfix(home): STORAGE_KEY_CURRENT_PAGE 자기참조 오류 revert

### DIFF
--- a/src/components/layout/PageEditModal.jsx
+++ b/src/components/layout/PageEditModal.jsx
@@ -4,6 +4,19 @@ import useWidgetStore from '@/store/useWidgetStore'
 import { cn } from '@/lib/cn'
 import { PreviewContent } from '@/components/layout/EditPanel/WidgetSizeList'
 
+const WIDGET_LABELS = {
+  'balance':         '계좌잔고',
+  'index':           '주요지수',
+  'portfolio':       '포트폴리오',
+  'stock-chart':     '차트',
+  'ranking':         '순위',
+  'watchlist':       '관심종목',
+  'market-overview': '시황',
+  'stock-news':      '뉴스',
+  'exchange':        '환율',
+  'trade-history':   '거래내역',
+}
+
 /* 6×4 미니 그리드 썸네일 */
 function PageThumbnail({ widgets }) {
   if (widgets.length === 0) {
@@ -24,6 +37,7 @@ function PageThumbnail({ widgets }) {
             gridRow:    `${w.gridRow} / span ${w.rowSpan}`,
           }}
         >
+          {/* 실제 위젯 미리보기: 600% 크기로 렌더링 후 1/6 스케일 축소 */}
           <div className="absolute top-0 left-0 w-[600%] h-[600%] origin-top-left scale-[0.1667] pointer-events-none p-[14px_16px]">
             <PreviewContent type={w.variantId} />
           </div>
@@ -33,21 +47,17 @@ function PageThumbnail({ widgets }) {
   )
 }
 
-function PageCard({ page, isActive, canDelete, onDelete, onNavigate }) {
+function PageCard({ page, isActive, canDelete, onDelete }) {
   return (
     <div className="w-[148px] shrink-0">
-      <button
-        onClick={isActive ? undefined : onNavigate}
-        aria-label={isActive ? undefined : `${page.name}으로 이동`}
-        className={cn(
-          'w-full rounded-[14px] overflow-hidden text-left',
-          isActive
-            ? 'border-2 border-primary shadow-widget-hover cursor-default'
-            : 'border border-stroke hover:border-primary hover:shadow-widget-hover transition-all duration-150 cursor-pointer',
-        )}
-      >
+      <div className={cn(
+        'rounded-[14px] overflow-hidden',
+        isActive
+          ? 'border-2 border-primary shadow-widget-hover'
+          : 'border border-stroke',
+      )}>
         <PageThumbnail widgets={page.widgets} />
-      </button>
+      </div>
 
       <div className="flex items-center justify-between mt-2.5 px-0.5">
         <div className="flex items-center gap-1 min-w-0">
@@ -68,9 +78,9 @@ function PageCard({ page, isActive, canDelete, onDelete, onNavigate }) {
           )}
         </div>
 
-        {canDelete && (
+        {!isActive && canDelete && (
           <button
-            onClick={(e) => { e.stopPropagation(); onDelete() }}
+            onClick={onDelete}
             aria-label={`${page.name} 삭제`}
             className="flex items-center gap-0.5 px-2 py-0.5 rounded-lg border border-danger/20 bg-danger/5 text-danger text-[10px] font-semibold hover:opacity-80 transition-opacity shrink-0"
           >
@@ -103,55 +113,11 @@ function AddPageSlot({ onClick }) {
   )
 }
 
-/* 변경사항 저장 확인 모달
-   - type 'close'    : 저장 → applyPageChanges 후 닫기 / 저장 안 함 → 그냥 닫기
-   - type 'navigate' : 저장 → applyPageChanges 후 닫기 / 저장 안 함 → switchPage 후 닫기 */
-function ConfirmModal({ onSave, onDiscard, onCancel }) {
-  return (
-    <div
-      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40"
-      onClick={onCancel}
-    >
-      <div
-        className="bg-surface rounded-2xl shadow-modal w-[320px] p-6"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <h3 className="text-sm font-bold text-foreground mb-1">저장하지 않은 변경사항이 있습니다</h3>
-        <p className="text-xs text-foreground-secondary mb-5">저장하지 않으면 변경사항이 사라집니다.</p>
-        <div className="flex gap-2">
-          <button
-            onClick={onDiscard}
-            className="flex-1 py-2 rounded-xl border border-stroke-input text-xs text-foreground-secondary font-medium hover:bg-surface-muted transition-colors"
-          >
-            저장 안 함
-          </button>
-          <button
-            onClick={onSave}
-            className="flex-1 py-2 rounded-xl bg-primary text-white text-xs font-semibold hover:bg-primary-hover transition-colors shadow-primary-btn"
-          >
-            저장
-          </button>
-        </div>
-      </div>
-    </div>
-  )
-}
-
 export default function PageEditModal({ onClose }) {
-  const { pages, currentPageId, applyPageChanges, switchPage } = useWidgetStore()
+  const { pages, currentPageId, applyPageChanges } = useWidgetStore()
 
-  const [stagedPages, setStagedPages]         = useState(() => pages.map((p) => ({ ...p })))
-  const [stagedCurrentId, setStagedCurrentId] = useState(currentPageId)
-  // null | { type: 'close' } | { type: 'navigate', pageId: string }
-  const [pendingAction, setPendingAction]     = useState(null)
-
-  /* staged 변경사항 여부: 원본 대비 페이지 추가/삭제가 있으면 true */
-  const originalIds = new Set(pages.map((p) => p.id))
-  const stagedIds   = new Set(stagedPages.map((p) => p.id))
-  const hasStagedChanges =
-    stagedIds.size !== originalIds.size ||
-    [...stagedIds].some((id) => !originalIds.has(id)) ||
-    [...originalIds].some((id) => !stagedIds.has(id))
+  const [stagedPages, setStagedPages] = useState(() => pages.map((p) => ({ ...p })))
+  const [stagedCurrentId] = useState(currentPageId)
 
   function handleAddPage() {
     const newId = crypto.randomUUID()
@@ -164,66 +130,23 @@ export default function PageEditModal({ onClose }) {
 
   function handleDeletePage(pageId) {
     if (stagedPages.length <= 1) return
-    setStagedPages((prev) => {
-      const next = prev.filter((p) => p.id !== pageId)
-      // 현재 페이지를 삭제한 경우 stagedCurrentId를 인접 페이지로 갱신
-      if (pageId === stagedCurrentId) {
-        const deletedIndex = prev.findIndex((p) => p.id === pageId)
-        const fallback = next[deletedIndex] ?? next[deletedIndex - 1]
-        setStagedCurrentId(fallback.id)
-      }
-      return next
-    })
+    setStagedPages((prev) => prev.filter((p) => p.id !== pageId))
   }
 
   function handleSave() {
-    applyPageChanges(stagedPages, stagedCurrentId)
-    onClose()
-  }
-
-  /* 백드롭 / X 버튼 클릭 */
-  function handleAttemptClose() {
-    if (hasStagedChanges) {
-      setPendingAction({ type: 'close' })
-      return
-    }
-    onClose()
-  }
-
-  /* 비활성 페이지 카드 클릭 */
-  function handleNavigateTo(pageId) {
-    if (!hasStagedChanges) {
-      switchPage(pageId)
-      onClose()
-      return
-    }
-    setPendingAction({ type: 'navigate', pageId })
-  }
-
-  /* 확인 모달 — 저장 후 처리 */
-  function handleConfirmSave() {
-    const targetId = pendingAction.type === 'navigate' ? pendingAction.pageId : stagedCurrentId
+    const targetId = stagedPages.find((p) => p.id === stagedCurrentId)
+      ? stagedCurrentId
+      : stagedPages[0].id
     applyPageChanges(stagedPages, targetId)
-    setPendingAction(null)
-    onClose()
-  }
-
-  /* 확인 모달 — 저장 없이 처리 */
-  function handleConfirmDiscard() {
-    if (pendingAction.type === 'navigate') {
-      switchPage(pendingAction.pageId)
-    }
-    setPendingAction(null)
     onClose()
   }
 
   return (
-    <>
     <div className="fixed inset-0 z-50 flex items-center justify-center p-6">
       {/* 백드롭 */}
       <div
         className="absolute inset-0 bg-black/50 backdrop-blur-[6px]"
-        onClick={handleAttemptClose}
+        onClick={onClose}
       />
 
       {/* 모달 카드 */}
@@ -237,7 +160,7 @@ export default function PageEditModal({ onClose }) {
             </p>
           </div>
           <button
-            onClick={handleAttemptClose}
+            onClick={onClose}
             aria-label="닫기"
             className="w-7 h-7 rounded-full border border-stroke-input bg-surface-muted flex items-center justify-center text-foreground-tertiary hover:text-foreground transition-colors"
           >
@@ -254,7 +177,6 @@ export default function PageEditModal({ onClose }) {
               isActive={page.id === stagedCurrentId}
               canDelete={stagedPages.length > 1}
               onDelete={() => handleDeletePage(page.id)}
-              onNavigate={() => handleNavigateTo(page.id)}
             />
           ))}
           <AddPageSlot onClick={handleAddPage} />
@@ -277,14 +199,5 @@ export default function PageEditModal({ onClose }) {
         </div>
       </div>
     </div>
-
-    {pendingAction && (
-      <ConfirmModal
-        onSave={handleConfirmSave}
-        onDiscard={handleConfirmDiscard}
-        onCancel={() => setPendingAction(null)}
-      />
-    )}
-    </>
   )
 }

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -2,8 +2,6 @@ import { create } from 'zustand'
 import { GRID_COLS, GRID_ROWS } from '@/lib/gridConstants'
 import { fromApiResponse } from './widgetApi'
 
-const STORAGE_KEY_CURRENT_PAGE = STORAGE_KEY_CURRENT_PAGE
-
 /* ── 충돌 판정 ──────────────────────────────────────────────
    모든 좌표는 1-indexed (CSS grid와 동일).
 ──────────────────────────────────────────────────────────── */
@@ -226,10 +224,7 @@ const useWidgetStore = create((set) => ({
         const emptyPage = { id: 'page-1', name: '대시보드 1', widgets: [] }
         return { pages: [emptyPage], currentPageId: 'page-1', widgets: [], isLoaded: true }
       }
-      // 새로고침 전 마지막 페이지 복원 (sessionStorage에 저장된 값 우선)
-      const savedPageId = sessionStorage.getItem(STORAGE_KEY_CURRENT_PAGE)
-      const restoredPage = savedPageId ? pages.find((p) => p.id === savedPageId) : null
-      const currentPage = restoredPage ?? pages[0]
+      const currentPage = pages[0]
       return {
         pages,
         currentPageId: currentPage.id,
@@ -240,15 +235,13 @@ const useWidgetStore = create((set) => ({
 
   // 로그아웃 시 INITIAL 레이아웃으로 초기화.
   // isLoaded를 false로 되돌려 재로그인 시 서버에서 새로 불러올 수 있게 함.
-  resetLayout: () => {
-    sessionStorage.removeItem(STORAGE_KEY_CURRENT_PAGE)
+  resetLayout: () =>
     set({
       pages:         INITIAL_PAGES,
       currentPageId: 'page-1',
       widgets:       INITIAL_WIDGETS,
       isLoaded:      false,
-    })
-  },
+    }),
 
 
   // ── 페이지 전환 ─────────────────────────────────────────
@@ -256,7 +249,6 @@ const useWidgetStore = create((set) => ({
     set((state) => {
       const page = state.pages.find((p) => p.id === pageId)
       if (!page || page.id === state.currentPageId) return state
-      sessionStorage.setItem(STORAGE_KEY_CURRENT_PAGE, pageId)
       return { currentPageId: pageId, widgets: page.widgets }
     }),
 
@@ -270,7 +262,6 @@ const useWidgetStore = create((set) => ({
   applyPageChanges: (newPages, newCurrentId) =>
     set(() => {
       const currentPage = newPages.find((p) => p.id === newCurrentId) ?? newPages[0]
-      sessionStorage.setItem(STORAGE_KEY_CURRENT_PAGE, currentPage.id)
       return {
         pages: newPages,
         currentPageId: currentPage.id,


### PR DESCRIPTION
## 원인

PR #110 squash merge 시 `useWidgetStore.js` 5번째 줄에 다음과 같은 버그가 포함됨:

```js
const STORAGE_KEY_CURRENT_PAGE = STORAGE_KEY_CURRENT_PAGE
```

`const` 선언 시 자기 자신을 참조하여 Temporal Dead Zone(TDZ) 위반 → `ReferenceError` 발생, 앱 전체 로딩 불가.

## 변경 내용

- PR #110 커밋(`68046e0`) revert

## 관련 이슈

- PR #110 squash merge 결과물의 버그