### PR TITLE
feat(chat): 채팅 AI 주문·환전 PIN 인증 및 즉시 실행 기능

### DIFF
--- a/src/components/invest/InvestOrderSection.jsx
+++ b/src/components/invest/InvestOrderSection.jsx
@@ -43,7 +43,7 @@ export default function InvestOrderSection({
   const [pinError, setPinError] = useState('')
   const [orderError, setOrderError] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [rememberPin, setRememberPin] = useState(true)
+  const [rememberPin, setRememberPin] = useState(false)
   const [isPinVerified, setIsPinVerified] = useState(false)
   const hasManualPriceSelectionRef = useRef(false)
 
@@ -158,7 +158,7 @@ export default function InvestOrderSection({
       setSelectedPrice(marketPrice ?? defaultPrice ?? null)
       setQuantity(1)
       setIsPinVerified(false)
-      setRememberPin(true)
+      setRememberPin(false)
       queryClient.invalidateQueries({ queryKey: ['balance'] })
       queryClient.invalidateQueries({ queryKey: ['orders'] })
     } catch (error) {
@@ -177,7 +177,7 @@ export default function InvestOrderSection({
       setShowPin(true)
       setPin('')
       setPinError('')
-      setRememberPin(true)
+      setRememberPin(false)
     }
   }
 
@@ -207,7 +207,7 @@ export default function InvestOrderSection({
     setShowPin(false)
     setPin('')
     setPinError('')
-    setRememberPin(true)
+    setRememberPin(false)
     setIsPinVerified(false)
   }
 
@@ -219,7 +219,7 @@ export default function InvestOrderSection({
     setShowPin(false)
     setPin('')
     setPinError('')
-    setRememberPin(true)
+    setRememberPin(false)
     setIsPinVerified(false)
   }
 

--- a/src/components/layout/ChatExchangeCard.jsx
+++ b/src/components/layout/ChatExchangeCard.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { ArrowLeftRight, Loader2 } from 'lucide-react'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { exchangeApi } from '@/api/exchange'
+import SplashScreenFill from '@/components/ui/SplashScreenFill'
 
 // ── 포맷 헬퍼 (ExchangeModal과 동일) ──────────────────────────────
 function fmt(n) {
@@ -13,6 +13,10 @@ function fmtUsd(n, min = 0, max = 4) {
     minimumFractionDigits: min,
     maximumFractionDigits: max,
   })
+}
+
+function fmtUsdMoney(n) {
+  return fmtUsd(n, 2, 2)
 }
 
 function fmtRate(n) {
@@ -35,7 +39,7 @@ function normalizeInputRaw(value, direction) {
 
 function getMaxInputRaw(balance, direction) {
   if (direction === 'KRW_TO_USD') return String(Math.floor(Number(balance ?? 0)))
-  return normalizeInputRaw(String(balance ?? 0), direction)
+  return Number(balance ?? 0).toFixed(2)
 }
 
 function Row({ label, value, bold }) {
@@ -49,30 +53,22 @@ function Row({ label, value, bold }) {
   )
 }
 
-const RESULT_DELAY_MS = 1400
-
 /**
  * 채팅창 환전 카드 (ExchangeModal UI 기반)
  * @param {number} krwBalance  - 보유 원화 (availableAmount)
  * @param {number} usdBalance  - 보유 달러 (totalAmount)
  */
-export default function ChatExchangeCard({ krwBalance, usdBalance }) {
-  const queryClient = useQueryClient()
-
+export default function ChatExchangeCard({ krwBalance, usdBalance, onSubmit, isDisabled = false, isPending = false }) {
   const [dir, setDir] = useState('KRW_TO_USD')
   const [inputRaw, setInputRaw] = useState('')
   const [preview, setPreview] = useState(null)
   const [previewLoading, setPreviewLoading] = useState(false)
   const [previewError, setPreviewError] = useState(null)
-  const [resultLoading, setResultLoading] = useState(false)
-  const [done, setDone] = useState(null)
 
   const debounceRef = useRef(null)
-  const resultTimerRef = useRef(null)
 
   useEffect(() => () => {
     clearTimeout(debounceRef.current)
-    clearTimeout(resultTimerRef.current)
   }, [])
 
   const fromCurrency = dir === 'KRW_TO_USD' ? 'KRW' : 'USD'
@@ -117,63 +113,22 @@ export default function ChatExchangeCard({ krwBalance, usdBalance }) {
     setPreviewError(null)
   }
 
-  const { mutate: doExchange, isPending } = useMutation({
-    mutationFn: () =>
-      exchangeApi.exchange(fromCurrency, toCurrency, parseAmount(inputRaw)),
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['balance'] })
-      queryClient.invalidateQueries({ queryKey: ['portfolio'] })
-      setResultLoading(true)
-      clearTimeout(resultTimerRef.current)
-      resultTimerRef.current = setTimeout(() => {
-        setResultLoading(false)
-        setDone(data)
-      }, RESULT_DELAY_MS)
-    },
-  })
-
   const amount = parseAmount(inputRaw)
-  const canSubmit = amount > 0 && amount <= maxBalance && preview && !isPending && !resultLoading
+  const canSubmit = amount > 0 && amount <= maxBalance && preview && !previewLoading && !isDisabled
 
-  // ── 처리 중 화면 ───────────────────────────────────────────────
-  if (resultLoading) {
+  if (isPending) {
     return (
-      <div className="bg-surface border border-stroke rounded-2xl p-6 w-full flex flex-col items-center gap-3 min-h-[160px] justify-center">
-        <Loader2 className="w-7 h-7 text-primary animate-spin" />
-        <p className="text-[13px] font-bold text-foreground">환전 처리 중</p>
-        <p className="text-[11px] text-foreground-disabled text-center leading-relaxed">
-          환전 결과를 정리하고 있어요.<br />잠시만 기다려주세요.
-        </p>
-      </div>
-    )
-  }
-
-  // ── 완료 화면 ─────────────────────────────────────────────────
-  if (done) {
-    const wasKrwToUsd = done.fromCurrency === 'KRW'
-    return (
-      <div className="bg-surface border border-stroke rounded-2xl p-4 w-full flex flex-col gap-3">
-        <div className="flex items-center gap-2">
-          <div className="w-7 h-7 rounded-[9px] bg-primary flex items-center justify-center shadow-brand-glow-sm">
-            <ArrowLeftRight className="w-3.5 h-3.5 text-white" strokeWidth={2.5} />
+      <div className="bg-surface border border-stroke rounded-2xl p-4 w-full">
+        <div className="flex min-h-[320px] flex-col items-center justify-center text-center">
+          <div className="mb-6">
+            <SplashScreenFill inline animated />
           </div>
-          <span className="text-[14px] font-bold text-foreground">환전 완료</span>
-        </div>
-        <div className="flex flex-col gap-2 bg-surface-subtle rounded-xl p-3 text-[11px]">
-          <Row
-            label="환전 금액"
-            value={wasKrwToUsd ? `${fmt(done.requestAmount)}원` : `$${fmtUsd(done.requestAmount)}`}
-          />
-          <Row label="적용 환율" value={`${fmtRate(done.appliedRate)}원/USD`} />
-          <Row
-            label="수수료 (1.75%)"
-            value={wasKrwToUsd ? `${fmtRate(done.feeAmount)}원` : `$${fmtUsd(done.feeAmount, 0, 4)}`}
-          />
-          <Row
-            label="수령 금액"
-            value={wasKrwToUsd ? `$${fmtUsd(done.receiveAmount)}` : `${fmt(done.receiveAmount)}원`}
-            bold
-          />
+          <p className="text-[13px] font-bold text-foreground">환전 처리 중</p>
+          <p className="mt-1 text-[11px] leading-relaxed text-foreground-disabled">
+            환전 결과를 정리하고 있어요.
+            <br />
+            잠시만 기다려주세요.
+          </p>
         </div>
       </div>
     )
@@ -218,7 +173,15 @@ export default function ChatExchangeCard({ krwBalance, usdBalance }) {
           <input
             type="text"
             inputMode="numeric"
-            value={inputRaw ? parseAmount(inputRaw).toLocaleString('ko-KR') : ''}
+            value={
+              inputRaw
+                ? (
+                    dir === 'KRW_TO_USD'
+                      ? parseAmount(inputRaw).toLocaleString('ko-KR')
+                      : fmtUsdMoney(parseAmount(inputRaw))
+                  )
+                : ''
+            }
             onChange={handleInput}
             placeholder="0"
             className="flex-1 text-[16px] font-bold text-foreground bg-transparent outline-none placeholder:text-foreground-disabled"
@@ -227,7 +190,7 @@ export default function ChatExchangeCard({ krwBalance, usdBalance }) {
         </div>
         <div className="flex items-center justify-between mt-1.5">
           <span className="text-[10px] text-foreground-disabled">
-            보유 {fromCurrency}: {dir === 'KRW_TO_USD' ? `${fmt(maxBalance)}원` : `$${fmtUsd(maxBalance)}`}
+            보유 {fromCurrency}: {dir === 'KRW_TO_USD' ? `${fmt(maxBalance)}원` : `$${fmtUsdMoney(maxBalance)}`}
           </span>
           <button
             onClick={handleMax}
@@ -257,11 +220,11 @@ export default function ChatExchangeCard({ krwBalance, usdBalance }) {
           <Row label="적용 환율" value={`${fmtRate(preview.exchangeRate)}원/USD`} />
           <Row
             label="수수료 (1.75%)"
-            value={dir === 'KRW_TO_USD' ? `${fmtRate(preview.feeAmount)}원` : `$${fmtUsd(preview.feeAmount)}`}
+            value={dir === 'KRW_TO_USD' ? `${fmtRate(preview.feeAmount)}원` : `$${fmtUsdMoney(preview.feeAmount)}`}
           />
           <Row
             label="예상 수령액"
-            value={dir === 'KRW_TO_USD' ? `$${fmtUsd(preview.estimatedReceiveAmount)}` : `${fmt(preview.estimatedReceiveAmount)}원`}
+            value={dir === 'KRW_TO_USD' ? `$${fmtUsdMoney(preview.estimatedReceiveAmount)}` : `${fmt(preview.estimatedReceiveAmount)}원`}
             bold
           />
         </div>
@@ -270,10 +233,14 @@ export default function ChatExchangeCard({ krwBalance, usdBalance }) {
       {/* 환전 실행 */}
       <button
         disabled={!canSubmit}
-        onClick={() => doExchange()}
+        onClick={() => onSubmit?.({
+          fromCurrency,
+          toCurrency,
+          requestAmount: amount,
+        })}
         className="w-full py-2.5 rounded-xl bg-primary text-white text-[13px] font-bold shadow-primary-btn hover:bg-primary-hover transition-colors duration-150 disabled:opacity-40 disabled:cursor-not-allowed"
       >
-        {isPending ? '처리 중…' : '환전 실행'}
+        환전 실행
       </button>
 
     </div>

--- a/src/components/layout/ChatExchangePinBubble.jsx
+++ b/src/components/layout/ChatExchangePinBubble.jsx
@@ -1,35 +1,17 @@
-import { useState, useRef } from 'react'
+import { useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { useQueryClient } from '@tanstack/react-query'
-import { orderApi, ORDER_SIDE, ORDER_KIND } from '@/api/order'
-import usePinAuth from '@/hooks/usePinAuth'
 import AccountPinKeypad from '@/components/signup/AccountPinKeypad'
 import DecoyCursorOverlay from '@/components/signup/DecoyCursorOverlay'
 
-/**
- * 채팅창 PIN 입력 버블
- * 매수/매도 확인 후 PIN 검증 → 주문 실행까지 self-contained
- */
-export default function ChatPinBubble({
-  stockCode,
-  marketType,
-  side,
-  quantity,
-  idempotencyKey,
+export default function ChatExchangePinBubble({
   onClose,
-  onSuccess,
+  onSubmit,
   onError,
 }) {
-  const queryClient = useQueryClient()
-  const { verifyAndCachePin } = usePinAuth()
-
   const shellRef = useRef(null)
   const [pin, setPin] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [rememberPin, setRememberPin] = useState(false)
-
-  const isBuy = side === 'buy'
-  const dotColor = isBuy ? 'bg-up' : 'bg-down'
 
   function handleClose() {
     if (submitting) return
@@ -43,47 +25,32 @@ export default function ChatPinBubble({
       onError?.('4자리를 입력해주세요.')
       return
     }
+
     setSubmitting(true)
     try {
-      await verifyAndCachePin(pin, rememberPin)
-      await orderApi.placeOrder({
-        stockCode,
-        marketType,
-        orderSide: ORDER_SIDE[side],
-        orderKind: ORDER_KIND.market,
-        orderChannel: 'CHAT',
-        orderQuantity: quantity,
-        idempotencyKey,
-      })
-      queryClient.invalidateQueries({ queryKey: ['balance'] })
-      queryClient.invalidateQueries({ queryKey: ['orders'] })
+      await onSubmit?.({ pin, rememberPin })
       setPin('')
       setRememberPin(false)
-      onSuccess?.()
-    } catch (err) {
-      onError?.(err?.message ?? '비밀번호가 올바르지 않습니다.')
+    } catch {
       setPin('')
     } finally {
       setSubmitting(false)
     }
   }
 
-  // ── PIN 입력 상태 ─────────────────────────────────────────────
   return (
     <div className="w-full flex flex-col gap-2">
-      {/* PIN 도트 */}
       <div className="flex justify-center gap-2 py-1">
         {Array.from({ length: 4 }, (_, i) => (
           <div
             key={i}
             className={`w-2.5 h-2.5 rounded-full transition-colors ${
-              i < pin.length ? dotColor : 'bg-stroke-input'
+              i < pin.length ? 'bg-primary' : 'bg-stroke-input'
             }`}
           />
         ))}
       </div>
 
-      {/* 키패드 */}
       <div ref={shellRef} className="sol-pin-keypad-compact">
         <AccountPinKeypad
           isOpen
@@ -96,14 +63,14 @@ export default function ChatPinBubble({
           showDecoyOverlay={false}
         />
       </div>
+
       {typeof document !== 'undefined'
         ? createPortal(
           <DecoyCursorOverlay active containerRef={shellRef} count={4} />,
-          document.body
+          document.body,
         )
         : null}
 
-      {/* 30분 기억 */}
       <label
         className={`flex cursor-pointer items-center justify-between rounded-[10px] border px-2 py-1.5 transition-colors ${
           rememberPin

--- a/src/components/layout/ChatOrderCard.jsx
+++ b/src/components/layout/ChatOrderCard.jsx
@@ -139,19 +139,15 @@ export default function ChatOrderCard({
   const holdingQuantityLabel = holdingQuantity != null ? `${formatNumber(holdingQuantity)}주` : '-'
 
   function decrease() {
-    setQuantity((current) => {
-      const nextQuantity = Math.max(1, current - 1)
-      setQuantityInput(String(nextQuantity))
-      return nextQuantity
-    })
+    const nextQuantity = Math.max(1, quantity - 1)
+    setQuantity(nextQuantity)
+    setQuantityInput(String(nextQuantity))
   }
 
   function increase() {
-    setQuantity((current) => {
-      const nextQuantity = current + 1
-      setQuantityInput(String(nextQuantity))
-      return nextQuantity
-    })
+    const nextQuantity = quantity + 1
+    setQuantity(nextQuantity)
+    setQuantityInput(String(nextQuantity))
   }
 
   function commitQuantity(nextValue) {

--- a/src/components/layout/ChatOrderCard.jsx
+++ b/src/components/layout/ChatOrderCard.jsx
@@ -1,6 +1,24 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { ArrowUpRight } from 'lucide-react'
+import { foreignMarketApi, getExchcd, marketApi } from '@/api/market'
+import { useBuyableAmount, useDomesticHoldings, useOverseasHoldings } from '@/api/balance'
+import useStompSubscription from '@/hooks/useStompSubscription'
+import {
+  DISPLAY_CURRENCY,
+  formatCurrency,
+  formatNumber,
+  formatSignedPercent,
+  formatVisiblePrice,
+  isForeignMarketType,
+} from '@/features/invest/formatters'
 import StockAvatar from '@/components/ui/StockAvatar'
+
+const EXCHANGE_CODE_BY_MARKET_TYPE = {
+  NASDAQ: 'NAS',
+  NYSE: 'NYS',
+  AMEX: 'AMS',
+}
 
 /**
  * 채팅창 주문 카드
@@ -18,24 +36,156 @@ export default function ChatOrderCard({
   name,
   stockCode,
   marketType = 'KOSPI',
+  exchangeCode = null,
   price,
   changeRate,
   color = 'primary',
   onDetail,
   onBuy,
   onSell,
+  isDisabled = false,
 }) {
   const [quantity, setQuantity] = useState(1)
+  const [quantityInput, setQuantityInput] = useState('1')
+  const [actionLocked, setActionLocked] = useState(false)
 
-  const isUp = changeRate >= 0
-  const estimatedAmount = (price * quantity).toLocaleString()
+  const isForeignMarket = isForeignMarketType(marketType)
+  const displayCurrency = isForeignMarket ? DISPLAY_CURRENCY.USD : DISPLAY_CURRENCY.KRW
+  const resolvedExchangeCode = exchangeCode ?? EXCHANGE_CODE_BY_MARKET_TYPE[marketType] ?? null
+  const exchcd = isForeignMarket ? getExchcd(resolvedExchangeCode) : null
+
+  const { data: priceRaw } = useQuery({
+    queryKey: isForeignMarket
+      ? ['foreign', 'price', stockCode, exchcd]
+      : ['domestic', 'price', stockCode],
+    queryFn: () => (
+      isForeignMarket
+        ? foreignMarketApi.getCurrentPrice(stockCode, exchcd)
+        : marketApi.getCurrentPrice(stockCode)
+    ),
+    enabled: Boolean(stockCode) && (!isForeignMarket || Boolean(exchcd)),
+    staleTime: 1000 * 5,
+  })
+
+  const liveQuote = useStompSubscription(stockCode
+    ? (
+        isForeignMarket
+          ? `/topic/foreign/quote/${stockCode}`
+          : `/topic/stock/trade/${stockCode}`
+      )
+    : null)
+  const livePriceData = useMemo(() => {
+    if (!liveQuote) return null
+
+    const currentPrice = Number(liveQuote.price)
+    if (!Number.isFinite(currentPrice) || currentPrice <= 0) return null
+
+    const liveChangeRate = Number(isForeignMarket ? liveQuote.rate : liveQuote.drate)
+    return {
+      currentPrice,
+      changeRate: Number.isFinite(liveChangeRate) ? liveChangeRate : null,
+    }
+  }, [isForeignMarket, liveQuote])
+
+  const restPriceData = useMemo(() => {
+    if (!priceRaw) return null
+
+    if (isForeignMarket) {
+      return {
+        currentPrice: Number(priceRaw.price),
+        changeRate: Number(priceRaw.rate),
+      }
+    }
+
+    return {
+      currentPrice: Number(priceRaw.currentPrice),
+      changeRate: Number(priceRaw.changeRate),
+    }
+  }, [isForeignMarket, priceRaw])
+
+  const fallbackPrice = Number(price)
+  const fallbackChangeRate = Number(changeRate)
+  const resolvedPrice = [livePriceData?.currentPrice, restPriceData?.currentPrice, fallbackPrice]
+    .find((value) => Number.isFinite(value) && value > 0) ?? null
+  const resolvedChangeRate = [livePriceData?.changeRate, restPriceData?.changeRate, fallbackChangeRate]
+    .find((value) => Number.isFinite(value)) ?? null
+  const priceLabel = resolvedPrice != null
+    ? formatVisiblePrice(resolvedPrice, { marketType, displayCurrency })
+    : '시세 확인 중'
+  const changeRateLabel = resolvedChangeRate != null ? formatSignedPercent(resolvedChangeRate) : '-'
+  const isUp = resolvedChangeRate != null ? resolvedChangeRate >= 0 : true
+  const estimatedAmountLabel = resolvedPrice != null
+    ? formatCurrency(resolvedPrice * quantity, { marketType, displayCurrency })
+    : '-'
+
+  const { data: buyableData } = useBuyableAmount({
+    stockCode,
+    marketType,
+  })
+  const { data: domesticHoldingsData } = useDomesticHoldings({
+    enabled: !isForeignMarket,
+  })
+  const { data: overseasHoldingsData } = useOverseasHoldings({
+    enabled: isForeignMarket,
+  })
+
+  const holdingsData = isForeignMarket ? overseasHoldingsData : domesticHoldingsData
+  const holdingRaw = holdingsData?.find?.((holding) => holding.stockCode === stockCode)
+  const availableAmount = buyableData?.availableAmount
+  const holdingQuantity = holdingRaw?.availableQuantity ?? holdingRaw?.holdingQuantity
+  const availableAmountLabel = availableAmount != null
+    ? formatCurrency(availableAmount, { marketType, displayCurrency })
+    : '-'
+  const holdingQuantityLabel = holdingQuantity != null ? `${formatNumber(holdingQuantity)}주` : '-'
 
   function decrease() {
-    setQuantity((q) => Math.max(1, q - 1))
+    setQuantity((current) => {
+      const nextQuantity = Math.max(1, current - 1)
+      setQuantityInput(String(nextQuantity))
+      return nextQuantity
+    })
   }
 
   function increase() {
-    setQuantity((q) => q + 1)
+    setQuantity((current) => {
+      const nextQuantity = current + 1
+      setQuantityInput(String(nextQuantity))
+      return nextQuantity
+    })
+  }
+
+  function commitQuantity(nextValue) {
+    const digitsOnly = String(nextValue ?? '').replace(/\D/g, '')
+    const parsed = Number.parseInt(digitsOnly, 10)
+    const nextQuantity = Number.isFinite(parsed) && parsed > 0 ? parsed : 1
+    setQuantity(nextQuantity)
+    setQuantityInput(String(nextQuantity))
+    return nextQuantity
+  }
+
+  function handleQuantityInputChange(value) {
+    const digitsOnly = value.replace(/\D/g, '')
+    if (!digitsOnly) {
+      setQuantityInput('')
+      return
+    }
+
+    const nextQuantity = Number.parseInt(digitsOnly, 10)
+    setQuantity(nextQuantity)
+    setQuantityInput(String(nextQuantity))
+  }
+
+  async function handleAction(nextSide) {
+    const callback = nextSide === 'buy' ? onBuy : onSell
+    if (actionLocked || isDisabled || !callback) return
+
+    const committedQuantity = commitQuantity(quantityInput)
+    setActionLocked(true)
+    try {
+      await callback(committedQuantity)
+    } finally {
+      setActionLocked(false)
+    }
   }
 
   return (
@@ -55,17 +205,30 @@ export default function ChatOrderCard({
             <p className="text-[11px] text-foreground-tertiary truncate">{name}</p>
             <button
               onClick={onDetail}
+              disabled={actionLocked || isDisabled}
               className="shrink-0 w-4 h-4 flex items-center justify-center rounded-full hover:bg-surface-subtle transition-colors duration-150"
             >
               <ArrowUpRight className="w-3 h-3 text-foreground-tertiary" />
             </button>
           </div>
           <p className="text-[22px] font-black text-foreground leading-tight">
-            {price.toLocaleString()}원
+            {priceLabel}
           </p>
           <p className={`text-[11px] font-semibold ${isUp ? 'text-up' : 'text-down'}`}>
-            {isUp ? '+' : ''}{changeRate}%
+            {changeRateLabel}
           </p>
+        </div>
+      </div>
+
+      <div className="mb-3 flex items-center gap-4 text-[11px]">
+        <div className="min-w-0 flex-1">
+          <span className="text-foreground-disabled">주문가능금액</span>
+          <p className="mt-0.5 truncate font-bold text-foreground">{availableAmountLabel}</p>
+        </div>
+        <div className="h-7 w-px shrink-0 bg-stroke" />
+        <div className="min-w-0 flex-1 text-right">
+          <span className="text-foreground-disabled">보유 수량</span>
+          <p className="mt-0.5 font-bold text-foreground">{holdingQuantityLabel}</p>
         </div>
       </div>
 
@@ -75,15 +238,31 @@ export default function ChatOrderCard({
         <div className="flex items-center gap-2 flex-1">
           <button
             onClick={decrease}
+            disabled={actionLocked || isDisabled}
             className="w-7 h-7 rounded-lg border border-stroke flex items-center justify-center text-[15px] font-bold text-foreground-secondary hover:bg-surface-subtle transition-colors duration-150"
           >
             -
           </button>
-          <div className="flex-1 text-center py-1 border border-stroke rounded-lg text-[13px] font-semibold text-foreground">
-            {quantity}주
+          <div className="flex flex-1 items-center justify-center rounded-lg border border-stroke px-2 py-1">
+            <input
+              type="text"
+              inputMode="numeric"
+              value={quantityInput}
+              onChange={(e) => handleQuantityInputChange(e.target.value)}
+              onBlur={(e) => commitQuantity(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.currentTarget.blur()
+                }
+              }}
+              disabled={actionLocked || isDisabled}
+              className="w-full bg-transparent text-center text-[13px] font-semibold text-foreground outline-none"
+            />
+            <span className="ml-1 shrink-0 text-[11px] text-foreground-secondary">주</span>
           </div>
           <button
             onClick={increase}
+            disabled={actionLocked || isDisabled}
             className="w-7 h-7 rounded-lg border border-stroke flex items-center justify-center text-[15px] font-bold text-foreground-secondary hover:bg-surface-subtle transition-colors duration-150"
           >
             +
@@ -94,20 +273,22 @@ export default function ChatOrderCard({
       {/* 예상금액 */}
       <div className="flex items-center justify-between mb-3">
         <span className="text-[12px] text-foreground-secondary">예상금액</span>
-        <span className="text-[13px] font-bold text-foreground">{estimatedAmount}원</span>
+        <span className="text-[13px] font-bold text-foreground">{estimatedAmountLabel}</span>
       </div>
 
       {/* 매도/매수 버튼 */}
       <div className="flex gap-2">
         <button
-          onClick={() => onSell?.(quantity)}
-          className="flex-1 py-2.5 rounded-xl bg-down text-white text-[13px] font-bold hover:opacity-90 transition-opacity duration-150"
+          onClick={() => handleAction('sell')}
+          disabled={actionLocked || isDisabled}
+          className="flex-1 py-2.5 rounded-xl bg-down text-white text-[13px] font-bold hover:opacity-90 transition-opacity duration-150 disabled:cursor-not-allowed disabled:opacity-45"
         >
           매도 확인
         </button>
         <button
-          onClick={() => onBuy?.(quantity)}
-          className="flex-1 py-2.5 rounded-xl bg-up text-white text-[13px] font-bold hover:opacity-90 transition-opacity duration-150"
+          onClick={() => handleAction('buy')}
+          disabled={actionLocked || isDisabled}
+          className="flex-1 py-2.5 rounded-xl bg-up text-white text-[13px] font-bold hover:opacity-90 transition-opacity duration-150 disabled:cursor-not-allowed disabled:opacity-45"
         >
           매수 확인
         </button>

--- a/src/components/layout/ChatPanel.jsx
+++ b/src/components/layout/ChatPanel.jsx
@@ -136,7 +136,7 @@ function ChatToastStack({ toasts, onClose }) {
         return (
           <div
             key={toast.id}
-            className="animate-bubble-in rounded-2xl border border-stroke bg-surface px-3.5 py-3 shadow-[0_8px_20px_rgba(15,23,42,0.08)]"
+            className="animate-bubble-in rounded-2xl border border-stroke bg-surface px-3.5 py-3 shadow-toast"
           >
             <div className="flex items-start justify-between gap-3">
               <div className="min-w-0">
@@ -330,7 +330,7 @@ function ChatBubble({
 }
 
 // ── ChatMessages ───────────────────────────────────────────────
-function ChatMessages({ messages, isTyping, bottomRef, onRetry, onOrderAction, onOrderDetail, onPinClose, onPinSuccess, onPinError }) {
+function ChatMessages({ messages, isTyping, bottomRef, onRetry, onOrderAction, onExchangeAction, onOrderDetail, onPinClose, onPinSuccess, onExchangePinSuccess, onPinError }) {
   return (
     <div className="flex-1 overflow-y-auto p-3 flex flex-col gap-3">
       {messages.map((msg) => {
@@ -376,7 +376,7 @@ function ChatMessages({ messages, isTyping, bottomRef, onRetry, onOrderAction, o
             <div key={msg.id} className="flex flex-col gap-1 animate-bubble-in">
               <ChatExchangePinBubble
                 onClose={() => onPinClose?.(msg.id, msg.sourceExchangeId)}
-                onSubmit={(pinData) => onPinSuccess?.(msg.id, msg.sourceExchangeId, {
+                onSubmit={(pinData) => onExchangePinSuccess?.(msg.id, msg.sourceExchangeId, {
                   ...pinData,
                   fromCurrency: msg.fromCurrency,
                   toCurrency: msg.toCurrency,
@@ -398,7 +398,7 @@ function ChatMessages({ messages, isTyping, bottomRef, onRetry, onOrderAction, o
                 krwBalance={msg.krwBalance}
                 usdBalance={msg.usdBalance}
                 isPending={Boolean(msg.isPending)}
-                onSubmit={(payload) => onOrderAction?.(msg.id, payload)}
+                onSubmit={(payload) => onExchangeAction?.(msg.id, payload)}
               />
               {msg.time && (
                 <span className="text-[9px] text-foreground-disabled">{msg.time}</span>
@@ -882,7 +882,6 @@ export default function ChatPanel() {
       pushExchangeToast(result);
     } catch (err) {
       await waitForMinimumDelay(startedAt);
-      setExchangePending(sourceExchangeId, false);
       if (options.pin && !pinVerified) {
         pushErrorToast(err?.message ?? '비밀번호가 올바르지 않습니다.', '계좌 비밀번호 확인');
       } else {
@@ -1015,20 +1014,12 @@ export default function ChatPanel() {
             isTyping={isTyping}
             bottomRef={bottomRef}
             onRetry={handleRetry}
-            onOrderAction={(...args) => {
-              if (args.length === 2 && typeof args[1] === 'object' && args[1]?.fromCurrency) {
-                return handleExchangeAction(args[0], args[1]);
-              }
-              return handleOrderAction(...args);
-            }}
+            onOrderAction={(msgId, stock, side, qty, key) => handleOrderAction(msgId, stock, side, qty, key)}
+            onExchangeAction={(msgId, payload) => handleExchangeAction(msgId, payload)}
             onOrderDetail={handleOrderDetail}
             onPinClose={handlePinClose}
-            onPinSuccess={(...args) => {
-              if (args.length === 3 && args[2]?.fromCurrency) {
-                return handleExchangePinSuccess(args[0], args[1], args[2]);
-              }
-              return handlePinSuccess(...args);
-            }}
+            onPinSuccess={(msgId, sourceOrderId, stockName, side, qty) => handlePinSuccess(msgId, sourceOrderId, stockName, side, qty)}
+            onExchangePinSuccess={(msgId, sourceExchangeId, payload) => handleExchangePinSuccess(msgId, sourceExchangeId, payload)}
             onPinError={handlePinError}
           />
           <ChatToastStack toasts={toasts} onClose={dismissToast} />

--- a/src/components/layout/ChatPanel.jsx
+++ b/src/components/layout/ChatPanel.jsx
@@ -1,7 +1,9 @@
 import { useState, useRef, useEffect, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
 import { MessageCircle, Send } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { useQueryClient } from "@tanstack/react-query";
 import LiveDot from "@/components/ui/LiveDot";
 import useAuthStore from "@/store/useAuthStore";
 import { chatApi } from "@/api/chat";
@@ -9,6 +11,9 @@ import ChatOrderCard from "@/components/layout/ChatOrderCard";
 import ChatExchangeCard from "@/components/layout/ChatExchangeCard";
 import { marketApi } from "@/api/market";
 import { balanceApi } from "@/api/balance";
+import { orderApi, ORDER_SIDE, ORDER_KIND } from "@/api/order";
+import usePinAuth from "@/hooks/usePinAuth";
+import ChatPinBubble from "@/components/layout/ChatPinBubble";
 
 function getTimestamp() {
   return new Date().toLocaleTimeString("ko-KR", {
@@ -202,7 +207,7 @@ function ChatBubble({
 }
 
 // ── ChatMessages ───────────────────────────────────────────────
-function ChatMessages({ messages, isTyping, bottomRef, onRetry }) {
+function ChatMessages({ messages, isTyping, bottomRef, onRetry, onOrderAction, onOrderDetail }) {
   return (
     <div className="flex-1 overflow-y-auto p-3 flex flex-col gap-3">
       {messages.map((msg) => {
@@ -210,10 +215,29 @@ function ChatMessages({ messages, isTyping, bottomRef, onRetry }) {
         if (msg.type === 'order' && msg.stock) {
           return (
             <div key={msg.id} className="flex flex-col gap-1">
-              <ChatOrderCard {...msg.stock} />
+              <ChatOrderCard
+                {...msg.stock}
+                onBuy={(qty) => onOrderAction?.(msg.stock, 'buy', qty)}
+                onSell={(qty) => onOrderAction?.(msg.stock, 'sell', qty)}
+                onDetail={() => onOrderDetail?.(msg.stock)}
+              />
               {msg.time && (
                 <span className="text-[9px] text-foreground-disabled">{msg.time}</span>
               )}
+            </div>
+          )
+        }
+        // PIN 입력 버블
+        if (msg.type === 'pin') {
+          return (
+            <div key={msg.id} className="flex justify-start animate-bubble-in">
+              <ChatPinBubble
+                stockCode={msg.stockCode}
+                marketType={msg.marketType}
+                name={msg.name}
+                side={msg.side}
+                quantity={msg.quantity}
+              />
             </div>
           )
         }
@@ -374,6 +398,9 @@ function LoginPrompt() {
 
 // ── ChatPanel (root) ───────────────────────────────────────────
 export default function ChatPanel() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { isPinCached, verifyAndCachePin } = usePinAuth();
   const { isAuthenticated, isRestoring } = useAuthStore();
   const [messages, setMessages] = useState(loadMessages);
   const [isTyping, setIsTyping] = useState(false);
@@ -381,6 +408,7 @@ export default function ChatPanel() {
   const lastFailedTextRef = useRef(null);
   // 복원 완료 후 isAuthenticated의 이전 값 추적 (null = 복원 전)
   const prevIsAuthRef = useRef(null);
+
 
   // 메시지 변경 시 sessionStorage에 저장
   useEffect(() => {
@@ -492,6 +520,63 @@ export default function ChatPanel() {
     handleSend(text);
   }, [handleSend]);
 
+  function handleOrderAction(stock, side, quantity) {
+    if (isPinCached()) {
+      // PIN 캐시 있으면 바로 PIN 버블 없이 주문 — ChatPinBubble과 동일한 로직
+      orderApi.placeOrder({
+        stockCode: stock.stockCode,
+        marketType: stock.marketType,
+        orderSide: ORDER_SIDE[side],
+        orderKind: ORDER_KIND.market,
+        orderChannel: 'CHAT',
+        orderQuantity: quantity,
+      }).then(() => {
+        queryClient.invalidateQueries({ queryKey: ['balance'] });
+        queryClient.invalidateQueries({ queryKey: ['orders'] });
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: Date.now(),
+            role: 'ai',
+            text: `**${stock.name}** ${side === 'buy' ? '매수' : '매도'} ${quantity}주 주문이 접수되었습니다.`,
+            time: getTimestamp(),
+          },
+        ]);
+      }).catch((err) => {
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: Date.now(),
+            role: 'ai',
+            text: `주문 접수에 실패했습니다. ${err?.message ?? ''}`.trim(),
+            time: getTimestamp(),
+            isError: true,
+          },
+        ]);
+      });
+    } else {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now(),
+          type: 'pin',
+          stockCode: stock.stockCode,
+          marketType: stock.marketType,
+          name: stock.name,
+          side,
+          quantity,
+          time: getTimestamp(),
+        },
+      ]);
+    }
+  }
+
+  function handleOrderDetail(stock) {
+    navigate(`/invest/${stock.stockCode}`, {
+      state: { stockName: stock.name, marketType: stock.marketType },
+    });
+  }
+
   return (
     <>
       <ChatHeader />
@@ -502,12 +587,15 @@ export default function ChatPanel() {
             isTyping={isTyping}
             bottomRef={bottomRef}
             onRetry={handleRetry}
+            onOrderAction={handleOrderAction}
+            onOrderDetail={handleOrderDetail}
           />
           <ChatInput onSend={handleSend} />
         </>
       ) : (
         <LoginPrompt />
       )}
+
     </>
   );
 }

--- a/src/components/layout/ChatPanel.jsx
+++ b/src/components/layout/ChatPanel.jsx
@@ -9,11 +9,17 @@ import useAuthStore from "@/store/useAuthStore";
 import { chatApi } from "@/api/chat";
 import ChatOrderCard from "@/components/layout/ChatOrderCard";
 import ChatExchangeCard from "@/components/layout/ChatExchangeCard";
-import { marketApi } from "@/api/market";
+import { foreignMarketApi, getExchcd, marketApi } from "@/api/market";
 import { balanceApi } from "@/api/balance";
 import { orderApi, ORDER_SIDE, ORDER_KIND } from "@/api/order";
+import { exchangeApi } from "@/api/exchange";
 import usePinAuth from "@/hooks/usePinAuth";
 import ChatPinBubble from "@/components/layout/ChatPinBubble";
+import ChatExchangePinBubble from "@/components/layout/ChatExchangePinBubble";
+import { isForeignMarketType } from "@/features/invest/formatters";
+import { buildInvestNavigationState } from "@/features/invest/navigation";
+
+const EXCHANGE_RESULT_DELAY_MS = 1400
 
 function getTimestamp() {
   return new Date().toLocaleTimeString("ko-KR", {
@@ -24,6 +30,58 @@ function getTimestamp() {
 }
 
 const STORAGE_KEY = "chat_messages";
+
+function buildClientOrderSeed() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `chat-order-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function buildOrderIdempotencyKey(requestKeyBase, side, quantity) {
+  const safeSide = side === "sell" ? "sell" : "buy";
+  const safeQty = Number(quantity) > 0 ? Number(quantity) : 1;
+  return `${requestKeyBase ?? buildClientOrderSeed()}:${safeSide}:${safeQty}`;
+}
+
+function normalizeOrderCardPriceData(marketType, priceData) {
+  if (!priceData) return { price: null, changeRate: null };
+
+  if (isForeignMarketType(marketType)) {
+    const price = Number(priceData.price);
+    const rate = Number(priceData.rate);
+    return {
+      price: Number.isFinite(price) && price > 0 ? price : null,
+      changeRate: Number.isFinite(rate) ? rate : null,
+    };
+  }
+
+  const price = Number(priceData.currentPrice);
+  const rate = Number(priceData.changeRate);
+  return {
+    price: Number.isFinite(price) && price > 0 ? price : null,
+    changeRate: Number.isFinite(rate) ? rate : null,
+  };
+}
+
+function formatExchangeAmount(currency, amount) {
+  if (currency === "USD") {
+    return `$${Number(amount ?? 0).toLocaleString("en-US", {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 4,
+    })}`;
+  }
+
+  return `${Math.round(Number(amount ?? 0)).toLocaleString("ko-KR")}원`;
+}
+
+async function waitForMinimumDelay(startedAt) {
+  const elapsed = Date.now() - startedAt
+  const remaining = Math.max(0, EXCHANGE_RESULT_DELAY_MS - elapsed)
+  if (remaining > 0) {
+    await new Promise((resolve) => window.setTimeout(resolve, remaining))
+  }
+}
 
 // ── 초기 웰컴 메시지 ──────────────────────────────────────────
 function getInitialMessages() {
@@ -40,15 +98,80 @@ function getInitialMessages() {
 function loadMessages() {
   try {
     const saved = sessionStorage.getItem(STORAGE_KEY);
-    if (saved) return JSON.parse(saved);
-  } catch {}
+    if (saved) {
+      const parsed = JSON.parse(saved);
+      return parsed
+        .filter((message) => !['pin', 'pin-result', 'exchange-pin'].includes(message?.type))
+        .map((message) => (
+          message?.type === 'order'
+            ? { ...message, pendingPin: false }
+            : message?.type === 'exchange'
+              ? { ...message, isPending: false }
+            : message
+        ));
+    }
+  } catch {
+    return getInitialMessages();
+  }
   return getInitialMessages();
 }
 
 function saveMessages(messages) {
   try {
     sessionStorage.setItem(STORAGE_KEY, JSON.stringify(messages));
-  } catch {}
+  } catch {
+    return;
+  }
+}
+
+function ChatToastStack({ toasts, onClose }) {
+  if (!toasts.length) return null;
+
+  return (
+    <div className="shrink-0 px-3 pb-2 flex flex-col gap-2">
+      {toasts.map((toast) => {
+        const isOrderSuccess = toast.type === "order-success";
+        const isExchangeSuccess = toast.type === "exchange-success";
+        const isBuy = toast.side === "buy";
+        return (
+          <div
+            key={toast.id}
+            className="animate-bubble-in rounded-2xl border border-stroke bg-surface px-3.5 py-3 shadow-[0_8px_20px_rgba(15,23,42,0.08)]"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <p className={`text-[11px] font-bold uppercase tracking-wide ${
+                  isOrderSuccess
+                    ? (isBuy ? "text-up" : "text-down")
+                    : isExchangeSuccess
+                      ? "text-primary"
+                      : "text-down"
+                }`}>
+                  {toast.title}
+                </p>
+                <p className="mt-1 text-[12px] leading-relaxed text-foreground">
+                  {isOrderSuccess ? (
+                    <>
+                      <span className="font-bold">{toast.name}</span> {isBuy ? "매수" : "매도"} {toast.quantity}주 주문이 접수되었습니다.
+                    </>
+                  ) : (
+                    toast.message
+                  )}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => onClose(toast.id)}
+                className="shrink-0 text-[10px] font-semibold text-foreground-disabled hover:text-foreground"
+              >
+                닫기
+              </button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
 }
 
 // ── 비로그인 기능 소개 카드 ────────────────────────────────────
@@ -207,7 +330,7 @@ function ChatBubble({
 }
 
 // ── ChatMessages ───────────────────────────────────────────────
-function ChatMessages({ messages, isTyping, bottomRef, onRetry, onOrderAction, onOrderDetail }) {
+function ChatMessages({ messages, isTyping, bottomRef, onRetry, onOrderAction, onOrderDetail, onPinClose, onPinSuccess, onPinError }) {
   return (
     <div className="flex-1 overflow-y-auto p-3 flex flex-col gap-3">
       {messages.map((msg) => {
@@ -217,8 +340,8 @@ function ChatMessages({ messages, isTyping, bottomRef, onRetry, onOrderAction, o
             <div key={msg.id} className="flex flex-col gap-1">
               <ChatOrderCard
                 {...msg.stock}
-                onBuy={(qty) => onOrderAction?.(msg.stock, 'buy', qty)}
-                onSell={(qty) => onOrderAction?.(msg.stock, 'sell', qty)}
+                onBuy={(qty) => onOrderAction?.(msg.id, msg.stock, 'buy', qty, msg.requestKeyBase)}
+                onSell={(qty) => onOrderAction?.(msg.id, msg.stock, 'sell', qty, msg.requestKeyBase)}
                 onDetail={() => onOrderDetail?.(msg.stock)}
               />
               {msg.time && (
@@ -230,14 +353,40 @@ function ChatMessages({ messages, isTyping, bottomRef, onRetry, onOrderAction, o
         // PIN 입력 버블
         if (msg.type === 'pin') {
           return (
-            <div key={msg.id} className="flex justify-start animate-bubble-in">
+            <div key={msg.id} className="flex flex-col gap-1 animate-bubble-in">
               <ChatPinBubble
                 stockCode={msg.stockCode}
                 marketType={msg.marketType}
                 name={msg.name}
                 side={msg.side}
                 quantity={msg.quantity}
+                idempotencyKey={msg.idempotencyKey}
+                onClose={() => onPinClose?.(msg.id, msg.sourceOrderId)}
+                onSuccess={() => onPinSuccess?.(msg.id, msg.sourceOrderId, msg.name, msg.side, msg.quantity)}
+                onError={(message) => onPinError?.(message)}
               />
+              {msg.time && (
+                <span className="text-[9px] text-foreground-disabled">{msg.time}</span>
+              )}
+            </div>
+          )
+        }
+        if (msg.type === 'exchange-pin') {
+          return (
+            <div key={msg.id} className="flex flex-col gap-1 animate-bubble-in">
+              <ChatExchangePinBubble
+                onClose={() => onPinClose?.(msg.id, msg.sourceExchangeId)}
+                onSubmit={(pinData) => onPinSuccess?.(msg.id, msg.sourceExchangeId, {
+                  ...pinData,
+                  fromCurrency: msg.fromCurrency,
+                  toCurrency: msg.toCurrency,
+                  requestAmount: msg.requestAmount,
+                })}
+                onError={(message) => onPinError?.(message)}
+              />
+              {msg.time && (
+                <span className="text-[9px] text-foreground-disabled">{msg.time}</span>
+              )}
             </div>
           )
         }
@@ -245,7 +394,12 @@ function ChatMessages({ messages, isTyping, bottomRef, onRetry, onOrderAction, o
         if (msg.type === 'exchange') {
           return (
             <div key={msg.id} className="flex flex-col gap-1">
-              <ChatExchangeCard krwBalance={msg.krwBalance} usdBalance={msg.usdBalance} />
+              <ChatExchangeCard
+                krwBalance={msg.krwBalance}
+                usdBalance={msg.usdBalance}
+                isPending={Boolean(msg.isPending)}
+                onSubmit={(payload) => onOrderAction?.(msg.id, payload)}
+              />
               {msg.time && (
                 <span className="text-[9px] text-foreground-disabled">{msg.time}</span>
               )}
@@ -403,9 +557,11 @@ export default function ChatPanel() {
   const { isPinCached, verifyAndCachePin } = usePinAuth();
   const { isAuthenticated, isRestoring } = useAuthStore();
   const [messages, setMessages] = useState(loadMessages);
+  const [toasts, setToasts] = useState([]);
   const [isTyping, setIsTyping] = useState(false);
   const bottomRef = useRef(null);
   const lastFailedTextRef = useRef(null);
+  const toastTimersRef = useRef(new Map());
   // 복원 완료 후 isAuthenticated의 이전 값 추적 (null = 복원 전)
   const prevIsAuthRef = useRef(null);
 
@@ -441,6 +597,147 @@ export default function ChatPanel() {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, isTyping]);
 
+  useEffect(() => () => {
+    toastTimersRef.current.forEach((timerId) => {
+      window.clearTimeout(timerId);
+    });
+    toastTimersRef.current.clear();
+  }, []);
+
+  const dismissToast = useCallback((toastId) => {
+    const timerId = toastTimersRef.current.get(toastId);
+    if (timerId) {
+      window.clearTimeout(timerId);
+      toastTimersRef.current.delete(toastId);
+    }
+    setToasts((prev) => prev.filter((toast) => toast.id !== toastId));
+  }, []);
+
+  const pushToast = useCallback((toast, duration = 3200) => {
+    const toastId = Date.now() + Math.random();
+    const nextToast = {
+      id: toastId,
+      ...toast,
+    };
+
+    setToasts((prev) => [...prev, nextToast]);
+
+    const timerId = window.setTimeout(() => {
+      dismissToast(toastId);
+    }, duration);
+    toastTimersRef.current.set(toastId, timerId);
+  }, [dismissToast]);
+
+  const pushOrderToast = useCallback((stockName, side, quantity) => {
+    pushToast({
+      type: "order-success",
+      title: "주문 접수 완료",
+      name: stockName,
+      side,
+      quantity,
+    });
+  }, [pushToast]);
+
+  const pushErrorToast = useCallback((message, title = "주문 처리 실패") => {
+    pushToast({
+      type: "error",
+      title,
+      message,
+    }, 3600);
+  }, [pushToast]);
+
+  const pushExchangeToast = useCallback((result) => {
+    pushToast({
+      type: "exchange-success",
+      title: "환전 완료",
+      message: `${formatExchangeAmount(result.fromCurrency, result.requestAmount)}를 ${formatExchangeAmount(result.toCurrency, result.receiveAmount)}로 환전했습니다.`,
+    });
+  }, [pushToast]);
+
+  const appendOrderCardMessage = useCallback(async (data) => {
+    const searchResults = await marketApi.searchStocks(data.stock_code).catch(() => []);
+    const info =
+      searchResults.find((item) => item.stockCode === data.stock_code) ??
+      searchResults[0] ??
+      null;
+    const marketType = data.market_type ?? info?.marketType ?? null;
+    const exchangeCode = info?.exchangeCode ?? null;
+
+    if (!marketType) {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now(),
+          role: "ai",
+          text: "종목 정보를 찾지 못해 주문 카드를 열지 못했습니다. 잠시 후 다시 시도해 주세요.",
+          time: getTimestamp(),
+        },
+      ]);
+      return;
+    }
+
+    const priceData = await (
+      isForeignMarketType(marketType)
+        ? foreignMarketApi.getCurrentPrice(
+            data.stock_code,
+            getExchcd(exchangeCode ?? (marketType === "NYSE" ? "NYS" : marketType === "AMEX" ? "AMS" : "NAS")),
+          )
+        : marketApi.getCurrentPrice(data.stock_code)
+    ).catch(() => null);
+
+    const normalizedPrice = normalizeOrderCardPriceData(marketType, priceData);
+    const stock = {
+      name: info?.stockName ?? data.stock_code,
+      stockCode: data.stock_code,
+      marketType,
+      exchangeCode,
+      price: normalizedPrice.price,
+      changeRate: normalizedPrice.changeRate,
+    };
+
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: Date.now(),
+        type: "order",
+        stock,
+        requestKeyBase: buildClientOrderSeed(),
+        time: getTimestamp(),
+      },
+    ]);
+  }, []);
+
+  const appendExchangeCardMessage = useCallback(async () => {
+    try {
+      const summary = await balanceApi.getBalanceSummary();
+      const cashList = summary?.cashBalances ?? [];
+      const krw = cashList.find((balance) => balance.currencyCode === "KRW");
+      const usd = cashList.find((balance) => balance.currencyCode === "USD");
+
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now(),
+          type: "exchange",
+          krwBalance: Number(krw?.availableAmount ?? 0),
+          usdBalance: Number(usd?.availableAmount ?? usd?.totalAmount ?? 0),
+          isPending: false,
+          time: getTimestamp(),
+        },
+      ]);
+    } catch {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now(),
+          role: "ai",
+          text: "환전 카드를 준비하지 못했습니다. 잠시 후 다시 시도해 주세요.",
+          time: getTimestamp(),
+        },
+      ]);
+    }
+  }, []);
+
   const handleSend = useCallback(async (text) => {
     const userMsg = {
       id: Date.now(),
@@ -462,39 +759,9 @@ export default function ChatPanel() {
       ]);
 
       if (data.type === "order" && data.stock_code) {
-        // 종목 검색 + 현재가 병렬 조회
-        const [searchResults, priceData] = await Promise.all([
-          marketApi.searchStocks(data.stock_code),
-          marketApi.getCurrentPrice(data.stock_code),
-        ]);
-        const info = searchResults?.[0];
-        const stock = {
-          name: info?.stockName ?? data.stock_code,
-          stockCode: data.stock_code,
-          marketType: info?.marketType ?? "KOSPI",
-          price: priceData?.currentPrice ?? 0,
-          changeRate: priceData?.changeRate ?? 0,
-        };
-        setMessages((prev) => [
-          ...prev,
-          { id: Date.now(), type: "order", stock, time: getTimestamp() },
-        ]);
+        await appendOrderCardMessage(data);
       } else if (data.type === "exchange") {
-        // 잔고 조회 후 환전 카드를 채팅 메시지로 추가
-        const summary = await balanceApi.getBalanceSummary();
-        const cashList = summary?.cashBalances ?? [];
-        const krw = cashList.find((b) => b.currencyCode === "KRW");
-        const usd = cashList.find((b) => b.currencyCode === "USD");
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: Date.now(),
-            type: "exchange",
-            krwBalance: Number(krw?.availableAmount ?? 0),
-            usdBalance: Number(usd?.totalAmount ?? 0),
-            time: getTimestamp(),
-          },
-        ]);
+        await appendExchangeCardMessage();
       }
     } catch {
       lastFailedTextRef.current = text;
@@ -511,7 +778,7 @@ export default function ChatPanel() {
     } finally {
       setIsTyping(false);
     }
-  }, []);
+  }, [appendExchangeCardMessage, appendOrderCardMessage]);
 
   const handleRetry = useCallback(() => {
     const text = lastFailedTextRef.current;
@@ -520,60 +787,221 @@ export default function ChatPanel() {
     handleSend(text);
   }, [handleSend]);
 
-  function handleOrderAction(stock, side, quantity) {
+  const handlePinClose = useCallback((messageId, sourceOrderId) => {
+    setMessages((prev) => prev
+      .filter((message) => (
+        message.id !== messageId
+        && !(message.type === 'pin' && message.sourceOrderId === sourceOrderId)
+      ))
+      .map((message) => {
+        if (message.id !== sourceOrderId) {
+          return message;
+        }
+
+        return {
+          ...message,
+          pendingPin: false,
+        };
+      }));
+  }, []);
+
+  const handlePinSuccess = useCallback((messageId, sourceOrderId, stockName, side, quantity) => {
+    setMessages((prev) => prev
+      .filter((message) => (
+        message.id !== messageId
+        && !(message.type === 'pin' && message.sourceOrderId === sourceOrderId)
+      ))
+      .map((message) => {
+        if (message.id !== sourceOrderId) {
+          return message;
+        }
+
+        return {
+          ...message,
+          pendingPin: false,
+        };
+      }));
+    pushOrderToast(stockName, side, quantity);
+  }, [pushOrderToast]);
+
+  const handlePinError = useCallback((message) => {
+    pushErrorToast(message, '계좌 비밀번호 확인');
+  }, [pushErrorToast]);
+
+  const applyExchangeResultToMessage = useCallback((sourceExchangeId, result) => {
+    const nextKrwBalance = result.fromCurrency === 'KRW'
+      ? Number(result.fromBalanceAfter)
+      : Number(result.toBalanceAfter);
+    const nextUsdBalance = result.fromCurrency === 'USD'
+      ? Number(result.fromBalanceAfter)
+      : Number(result.toBalanceAfter);
+
+    setMessages((prev) => prev.map((message) => {
+      if (message.id !== sourceExchangeId || message.type !== 'exchange') {
+        return message;
+      }
+
+      return {
+        ...message,
+        krwBalance: Number.isFinite(nextKrwBalance) ? nextKrwBalance : message.krwBalance,
+        usdBalance: Number.isFinite(nextUsdBalance) ? nextUsdBalance : message.usdBalance,
+        isPending: false,
+      };
+    }));
+  }, []);
+
+  const setExchangePending = useCallback((sourceExchangeId, isPending) => {
+    setMessages((prev) => prev.map((message) => {
+      if (message.id !== sourceExchangeId || message.type !== 'exchange') {
+        return message;
+      }
+
+      return {
+        ...message,
+        isPending,
+      };
+    }));
+  }, []);
+
+  const runExchangeFlow = useCallback(async (sourceExchangeId, payload, options = {}) => {
+    const startedAt = Date.now();
+    let pinVerified = false;
+    setExchangePending(sourceExchangeId, true);
+
+    try {
+      if (options.pin) {
+        await verifyAndCachePin(options.pin, options.rememberPin);
+        pinVerified = true;
+      }
+
+      const result = await exchangeApi.exchange(payload.fromCurrency, payload.toCurrency, payload.requestAmount);
+      queryClient.invalidateQueries({ queryKey: ['balance'] });
+      queryClient.invalidateQueries({ queryKey: ['portfolio'] });
+      await waitForMinimumDelay(startedAt);
+      applyExchangeResultToMessage(sourceExchangeId, result);
+      pushExchangeToast(result);
+    } catch (err) {
+      await waitForMinimumDelay(startedAt);
+      setExchangePending(sourceExchangeId, false);
+      if (options.pin && !pinVerified) {
+        pushErrorToast(err?.message ?? '비밀번호가 올바르지 않습니다.', '계좌 비밀번호 확인');
+      } else {
+        pushErrorToast(err?.message ?? '환전을 실행하지 못했습니다.', '환전 실패');
+      }
+      throw err;
+    } finally {
+      setExchangePending(sourceExchangeId, false);
+    }
+  }, [applyExchangeResultToMessage, pushErrorToast, pushExchangeToast, queryClient, setExchangePending, verifyAndCachePin]);
+
+  const handleExchangePinSuccess = useCallback(async (messageId, sourceExchangeId, payload) => {
+    setMessages((prev) => prev
+      .filter((message) => (
+        message.id !== messageId
+        && !(message.type === 'exchange-pin' && message.sourceExchangeId === sourceExchangeId)
+      )));
+    await runExchangeFlow(sourceExchangeId, payload, {
+      pin: payload.pin,
+      rememberPin: payload.rememberPin,
+    });
+  }, [runExchangeFlow]);
+
+  async function handleOrderAction(messageId, stock, side, quantity, requestKeyBase) {
+    const idempotencyKey = buildOrderIdempotencyKey(requestKeyBase, side, quantity);
+
     if (isPinCached()) {
-      // PIN 캐시 있으면 바로 PIN 버블 없이 주문 — ChatPinBubble과 동일한 로직
-      orderApi.placeOrder({
-        stockCode: stock.stockCode,
-        marketType: stock.marketType,
-        orderSide: ORDER_SIDE[side],
-        orderKind: ORDER_KIND.market,
-        orderChannel: 'CHAT',
-        orderQuantity: quantity,
-      }).then(() => {
+      try {
+        await orderApi.placeOrder({
+          stockCode: stock.stockCode,
+          marketType: stock.marketType,
+          orderSide: ORDER_SIDE[side],
+          orderKind: ORDER_KIND.market,
+          orderChannel: 'CHAT',
+          orderQuantity: quantity,
+          idempotencyKey,
+        });
         queryClient.invalidateQueries({ queryKey: ['balance'] });
         queryClient.invalidateQueries({ queryKey: ['orders'] });
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: Date.now(),
-            role: 'ai',
-            text: `**${stock.name}** ${side === 'buy' ? '매수' : '매도'} ${quantity}주 주문이 접수되었습니다.`,
-            time: getTimestamp(),
-          },
-        ]);
-      }).catch((err) => {
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: Date.now(),
-            role: 'ai',
-            text: `주문 접수에 실패했습니다. ${err?.message ?? ''}`.trim(),
-            time: getTimestamp(),
-            isError: true,
-          },
-        ]);
-      });
+        pushOrderToast(stock.name, side, quantity);
+      } catch (err) {
+        pushErrorToast(err?.message ?? '주문 접수에 실패했습니다.');
+        throw err;
+      }
     } else {
-      setMessages((prev) => [
+      setMessages((prev) => {
+        const alreadyOpen = prev.some(
+          (message) => message.type === 'pin' && message.sourceOrderId === messageId
+        );
+
+        if (alreadyOpen) {
+          return prev;
+        }
+
+        return [
+          ...prev.map((message) => {
+            if (message.id !== messageId) {
+              return message;
+            }
+
+            return {
+              ...message,
+              pendingPin: true,
+            };
+          }),
+          {
+            id: Date.now(),
+            type: 'pin',
+            sourceOrderId: messageId,
+            stockCode: stock.stockCode,
+            marketType: stock.marketType,
+            name: stock.name,
+            side,
+            quantity,
+            idempotencyKey,
+            time: getTimestamp(),
+          },
+        ];
+      });
+    }
+  }
+
+  async function handleExchangeAction(messageId, payload) {
+    if (isPinCached()) {
+      await runExchangeFlow(messageId, payload);
+      return;
+    }
+
+    setMessages((prev) => {
+      const alreadyOpen = prev.some(
+        (message) => message.type === 'exchange-pin' && message.sourceExchangeId === messageId
+      );
+
+      if (alreadyOpen) {
+        return prev;
+      }
+
+      return [
         ...prev,
         {
           id: Date.now(),
-          type: 'pin',
-          stockCode: stock.stockCode,
-          marketType: stock.marketType,
-          name: stock.name,
-          side,
-          quantity,
+          type: 'exchange-pin',
+          sourceExchangeId: messageId,
+          fromCurrency: payload.fromCurrency,
+          toCurrency: payload.toCurrency,
+          requestAmount: payload.requestAmount,
           time: getTimestamp(),
         },
-      ]);
-    }
+      ];
+    });
   }
 
   function handleOrderDetail(stock) {
     navigate(`/invest/${stock.stockCode}`, {
-      state: { stockName: stock.name, marketType: stock.marketType },
+      state: buildInvestNavigationState({
+        stockName: stock.name,
+        marketType: stock.marketType,
+        exchangeCode: stock.exchangeCode,
+      }),
     });
   }
 
@@ -587,9 +1015,23 @@ export default function ChatPanel() {
             isTyping={isTyping}
             bottomRef={bottomRef}
             onRetry={handleRetry}
-            onOrderAction={handleOrderAction}
+            onOrderAction={(...args) => {
+              if (args.length === 2 && typeof args[1] === 'object' && args[1]?.fromCurrency) {
+                return handleExchangeAction(args[0], args[1]);
+              }
+              return handleOrderAction(...args);
+            }}
             onOrderDetail={handleOrderDetail}
+            onPinClose={handlePinClose}
+            onPinSuccess={(...args) => {
+              if (args.length === 3 && args[2]?.fromCurrency) {
+                return handleExchangePinSuccess(args[0], args[1], args[2]);
+              }
+              return handlePinSuccess(...args);
+            }}
+            onPinError={handlePinError}
           />
+          <ChatToastStack toasts={toasts} onClose={dismissToast} />
           <ChatInput onSend={handleSend} />
         </>
       ) : (

--- a/src/components/layout/ChatPinBubble.jsx
+++ b/src/components/layout/ChatPinBubble.jsx
@@ -1,0 +1,125 @@
+import { useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { orderApi, ORDER_SIDE, ORDER_KIND } from '@/api/order'
+import usePinAuth from '@/hooks/usePinAuth'
+import AccountPinKeypad from '@/components/signup/AccountPinKeypad'
+
+/**
+ * 채팅창 PIN 입력 버블
+ * 매수/매도 확인 후 PIN 검증 → 주문 실행까지 self-contained
+ */
+export default function ChatPinBubble({ stockCode, marketType, name, side, quantity }) {
+  const queryClient = useQueryClient()
+  const { verifyAndCachePin } = usePinAuth()
+
+  const [pin, setPin] = useState('')
+  const [error, setError] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [rememberPin, setRememberPin] = useState(true)
+  const [done, setDone] = useState(false)
+
+  const isBuy = side === 'buy'
+  const tone = isBuy ? 'text-up' : 'text-down'
+  const dotColor = isBuy ? 'bg-up' : 'bg-down'
+
+  async function handlePinDone() {
+    if (pin.length !== 4) { setError('4자리를 입력해주세요.'); return }
+    setSubmitting(true)
+    setError('')
+    try {
+      await verifyAndCachePin(pin, rememberPin)
+      await orderApi.placeOrder({
+        stockCode,
+        marketType,
+        orderSide: ORDER_SIDE[side],
+        orderKind: ORDER_KIND.market,
+        orderChannel: 'CHAT',
+        orderQuantity: quantity,
+      })
+      queryClient.invalidateQueries({ queryKey: ['balance'] })
+      queryClient.invalidateQueries({ queryKey: ['orders'] })
+      setDone(true)
+    } catch (err) {
+      setError(err?.message ?? '비밀번호가 올바르지 않습니다.')
+      setPin('')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  // ── 완료 상태 ─────────────────────────────────────────────────
+  if (done) {
+    return (
+      <div className="bg-surface-muted rounded-[0_16px_16px_16px] px-3.5 py-2.5 max-w-[85%]">
+        <p className={`text-[11px] font-bold uppercase tracking-wide mb-1 ${tone}`}>
+          주문 접수 완료
+        </p>
+        <p className="text-[13px] text-foreground">
+          <span className="font-bold">{name}</span> {isBuy ? '매수' : '매도'} {quantity}주 주문이 접수되었습니다.
+        </p>
+      </div>
+    )
+  }
+
+  // ── PIN 입력 상태 ─────────────────────────────────────────────
+  return (
+    <div className="bg-surface-muted rounded-[0_16px_16px_16px] px-3 py-3 w-[240px] flex flex-col gap-2">
+      {/* PIN 도트 */}
+      <div className="flex justify-center gap-2 py-1">
+        {Array.from({ length: 4 }, (_, i) => (
+          <div
+            key={i}
+            className={`w-2.5 h-2.5 rounded-full transition-colors ${
+              i < pin.length ? dotColor : 'bg-stroke-input'
+            }`}
+          />
+        ))}
+      </div>
+
+      {/* 에러 */}
+      {error && (
+        <p className="text-center text-[10px] text-down">{error}</p>
+      )}
+
+      {/* 키패드 */}
+      <div className="sol-pin-keypad-compact">
+        <AccountPinKeypad
+          isOpen
+          variant="desktop"
+          value={pin}
+          onChange={setPin}
+          onDone={handlePinDone}
+          onClose={() => setPin('')}
+        />
+      </div>
+
+      {/* 30분 기억 */}
+      <label
+        className={`flex cursor-pointer items-center justify-between rounded-[10px] border px-2 py-1.5 transition-colors ${
+          rememberPin
+            ? 'border-primary-border bg-primary-light'
+            : 'border-stroke-input bg-surface hover:bg-surface-subtle'
+        }`}
+      >
+        <input
+          type="checkbox"
+          checked={rememberPin}
+          onChange={(e) => setRememberPin(e.target.checked)}
+          className="sr-only"
+        />
+        <span className={`text-[9px] font-semibold ${rememberPin ? 'text-primary' : 'text-foreground-secondary'}`}>
+          30분간 비밀번호 기억하기
+        </span>
+        <span
+          className={`flex h-4 w-4 items-center justify-center rounded-[6px] border-[1.5px] text-[10px] font-black transition-colors ${
+            rememberPin
+              ? 'border-primary bg-primary text-white'
+              : 'border-stroke-input bg-surface text-transparent'
+          }`}
+        >
+          ✓
+        </span>
+      </label>
+    </div>
+  )
+}

--- a/src/components/signup/AccountPinKeypad.jsx
+++ b/src/components/signup/AccountPinKeypad.jsx
@@ -74,6 +74,8 @@ export default function AccountPinKeypad({
   onDone,
   onClose,
   variant = 'both',
+  disabled = false,
+  showDecoyOverlay = true,
 }) {
   const shellRef = useRef(null)
   const flashTimeoutRef = useRef(null)
@@ -110,6 +112,10 @@ export default function AccountPinKeypad({
   }
 
   function handleKeyPress(button) {
+    if (disabled) {
+      return
+    }
+
     if (/^\d$/.test(button)) {
       onChange(`${value}${button}`.slice(0, 4))
       reshuffleInteractiveKeys()
@@ -171,7 +177,7 @@ export default function AccountPinKeypad({
             data-pin-interactive="true"
           >
             {keyboard}
-            <DecoyCursorOverlay active containerRef={shellRef} count={4} />
+            {showDecoyOverlay && <DecoyCursorOverlay active containerRef={shellRef} count={4} />}
           </div>
         </div>
       )}

--- a/src/hooks/usePinAuth.js
+++ b/src/hooks/usePinAuth.js
@@ -17,7 +17,7 @@ function clearPin() {
   sessionStorage.removeItem(STORAGE_KEY)
 }
 
-async function verifyAndCachePin(pin, remember = true) {
+async function verifyAndCachePin(pin, remember = false) {
   await fetchWithAuth('/api/accounts/verify-pin', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/src/index.css
+++ b/src/index.css
@@ -119,6 +119,7 @@
   --shadow-modal:         0 20px 50px rgba(0,0,0,.22);
   --shadow-focus-ring:    0 0 0 3px rgba(0,70,255,.08);
   --shadow-delete-btn:    0 2px 6px rgba(0,0,0,.22);
+  --shadow-toast:         0 8px 20px rgba(15,23,42,0.08);
 
   /* ── Summary Card ── */
   --background-summary-card: linear-gradient(135deg, var(--color-primary-light) 0%, var(--color-primary-dim) 100%);


### PR DESCRIPTION
## 연관된 이슈

> 없음

## 작업 내용

채팅 패널에서 AI가 제안한 주문·환전을 PIN 인증 후 즉시 실행하는 기능을 추가했습니다.

### 주요 변경 사항

**신규 컴포넌트**
- `ChatExchangePinBubble` — 환전 전용 PIN 입력 말풍선

**ChatPanel**
- 환전 PIN 플로우 통합 (`exchange-pin` 메시지 타입)
- 주문/환전 결과 토스트 스택(`ChatToastStack`) 추가
- 주문 멱등성 키(`buildOrderIdempotencyKey`) 처리
- 해외 주식 시장 타입 분기 처리 (`isForeignMarketType`)
- 세션 복원 시 `pin` / `pin-result` / `exchange-pin` 타입 메시지 필터링

**기존 컴포넌트 개선**
- `ChatOrderCard` / `ChatExchangeCard` PIN 연동 안정화
- `ChatPinBubble` 리팩토링
- `rememberPin` 기본값 `true` → `false` 변경 (InvestOrderSection 포함)

### 스크린샷 (선택)

## 체크리스트

- [x] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항(선택)

> `rememberPin` 기본값 변경이 기존 InvestOrderSection UX에 영향을 주지 않는지 확인 부탁드립니다.