### PR TITLE
feat(home): 대시보드 페이지 UX 개선

### DIFF
--- a/src/components/layout/PageEditModal.jsx
+++ b/src/components/layout/PageEditModal.jsx
@@ -40,6 +40,7 @@ function PageCard({ page, isActive, canDelete, onDelete, onRestore, onNavigate }
     <div className={cn('w-[148px] shrink-0', isDeleted && 'opacity-40')}>
       <div className="relative">
         <button
+          disabled={isDeleted || isActive}
           onClick={isDeleted || isActive ? undefined : onNavigate}
           aria-label={isDeleted || isActive ? undefined : `${page.name}으로 이동`}
           className={cn(
@@ -160,7 +161,7 @@ export default function PageEditModal({ onClose }) {
   function handleClose(targetPageId = stagedCurrentId) {
     const finalPages = stagedPages
       .filter((p) => !p._deleted)
-      .map(({ _deleted, ...rest }) => rest)
+      .map(({ _deleted: _, ...rest }) => rest)
     applyPageChanges(finalPages, targetPageId)
     onClose()
   }

--- a/src/components/layout/PageEditModal.jsx
+++ b/src/components/layout/PageEditModal.jsx
@@ -1,21 +1,8 @@
 import { useState } from 'react'
-import { X, Trash2, Plus } from 'lucide-react'
+import { Trash2, Plus, RotateCcw } from 'lucide-react'
 import useWidgetStore from '@/store/useWidgetStore'
 import { cn } from '@/lib/cn'
 import { PreviewContent } from '@/components/layout/EditPanel/WidgetSizeList'
-
-const WIDGET_LABELS = {
-  'balance':         '계좌잔고',
-  'index':           '주요지수',
-  'portfolio':       '포트폴리오',
-  'stock-chart':     '차트',
-  'ranking':         '순위',
-  'watchlist':       '관심종목',
-  'market-overview': '시황',
-  'stock-news':      '뉴스',
-  'exchange':        '환율',
-  'trade-history':   '거래내역',
-}
 
 /* 6×4 미니 그리드 썸네일 */
 function PageThumbnail({ widgets }) {
@@ -37,7 +24,6 @@ function PageThumbnail({ widgets }) {
             gridRow:    `${w.gridRow} / span ${w.rowSpan}`,
           }}
         >
-          {/* 실제 위젯 미리보기: 600% 크기로 렌더링 후 1/6 스케일 축소 */}
           <div className="absolute top-0 left-0 w-[600%] h-[600%] origin-top-left scale-[0.1667] pointer-events-none p-[14px_16px]">
             <PreviewContent type={w.variantId} />
           </div>
@@ -47,40 +33,64 @@ function PageThumbnail({ widgets }) {
   )
 }
 
-function PageCard({ page, isActive, canDelete, onDelete }) {
+function PageCard({ page, isActive, canDelete, onDelete, onRestore, onNavigate }) {
+  const isDeleted = !!page._deleted
+
   return (
-    <div className="w-[148px] shrink-0">
-      <div className={cn(
-        'rounded-[14px] overflow-hidden',
-        isActive
-          ? 'border-2 border-primary shadow-widget-hover'
-          : 'border border-stroke',
-      )}>
-        <PageThumbnail widgets={page.widgets} />
+    <div className={cn('w-[148px] shrink-0', isDeleted && 'opacity-40')}>
+      <div className="relative">
+        <button
+          onClick={isDeleted || isActive ? undefined : onNavigate}
+          aria-label={isDeleted || isActive ? undefined : `${page.name}으로 이동`}
+          className={cn(
+            'w-full rounded-[14px] overflow-hidden text-left',
+            isActive && !isDeleted
+              ? 'border-2 border-primary shadow-widget-hover cursor-default'
+              : isDeleted
+                ? 'border border-stroke cursor-default'
+                : 'border border-stroke hover:border-primary hover:shadow-widget-hover transition-all duration-150 cursor-pointer',
+          )}
+        >
+          <PageThumbnail widgets={page.widgets} />
+        </button>
+
+        {/* 삭제 상태 오버레이 — 되돌리기 버튼 */}
+        {isDeleted && (
+          <div className="absolute inset-0 flex items-center justify-center rounded-[14px]">
+            <button
+              onClick={onRestore}
+              aria-label={`${page.name} 되돌리기`}
+              className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-surface border border-stroke text-[11px] font-semibold text-foreground-secondary hover:border-primary hover:text-primary transition-colors shadow-modal"
+            >
+              <RotateCcw className="w-3 h-3" />
+              되돌리기
+            </button>
+          </div>
+        )}
       </div>
 
       <div className="flex items-center justify-between mt-2.5 px-0.5">
         <div className="flex items-center gap-1 min-w-0">
           <div className={cn(
             'w-1.5 h-1.5 rounded-full shrink-0',
-            isActive ? 'bg-primary' : 'bg-foreground-disabled',
+            isActive && !isDeleted ? 'bg-primary' : 'bg-foreground-disabled',
           )} />
           <span className={cn(
             'text-[11px] truncate',
-            isActive ? 'font-semibold text-primary' : 'font-medium text-foreground-secondary',
+            isActive && !isDeleted ? 'font-semibold text-primary' : 'font-medium text-foreground-secondary',
           )}>
             {page.name}
           </span>
-          {isActive && (
+          {isActive && !isDeleted && (
             <span className="text-[10px] text-foreground-disabled bg-surface-muted px-1.5 py-px rounded-full shrink-0">
               현재
             </span>
           )}
         </div>
 
-        {!isActive && canDelete && (
+        {!isDeleted && canDelete && (
           <button
-            onClick={onDelete}
+            onClick={(e) => { e.stopPropagation(); onDelete() }}
             aria-label={`${page.name} 삭제`}
             className="flex items-center gap-0.5 px-2 py-0.5 rounded-lg border border-danger/20 bg-danger/5 text-danger text-[10px] font-semibold hover:opacity-80 transition-opacity shrink-0"
           >
@@ -116,12 +126,14 @@ function AddPageSlot({ onClick }) {
 export default function PageEditModal({ onClose }) {
   const { pages, currentPageId, applyPageChanges } = useWidgetStore()
 
-  const [stagedPages, setStagedPages] = useState(() => pages.map((p) => ({ ...p })))
-  const [stagedCurrentId] = useState(currentPageId)
+  const [stagedPages, setStagedPages]         = useState(() => pages.map((p) => ({ ...p })))
+  const [stagedCurrentId, setStagedCurrentId] = useState(currentPageId)
+
+  const activePages = stagedPages.filter((p) => !p._deleted)
 
   function handleAddPage() {
     const newId = crypto.randomUUID()
-    const nextIndex = stagedPages.length + 1
+    const nextIndex = activePages.length + 1
     setStagedPages((prev) => [
       ...prev,
       { id: newId, name: `대시보드 ${nextIndex}`, widgets: [] },
@@ -129,15 +141,27 @@ export default function PageEditModal({ onClose }) {
   }
 
   function handleDeletePage(pageId) {
-    if (stagedPages.length <= 1) return
-    setStagedPages((prev) => prev.filter((p) => p.id !== pageId))
+    if (activePages.length <= 1) return
+    setStagedPages((prev) => prev.map((p) => p.id === pageId ? { ...p, _deleted: true } : p))
+    // 현재 페이지 삭제 시 인접 활성 페이지로 이동
+    if (pageId === stagedCurrentId) {
+      const remaining = activePages.filter((p) => p.id !== pageId)
+      const deletedIndex = activePages.findIndex((p) => p.id === pageId)
+      const fallback = remaining[deletedIndex] ?? remaining[deletedIndex - 1]
+      setStagedCurrentId(fallback.id)
+    }
   }
 
-  function handleSave() {
-    const targetId = stagedPages.find((p) => p.id === stagedCurrentId)
-      ? stagedCurrentId
-      : stagedPages[0].id
-    applyPageChanges(stagedPages, targetId)
+  function handleRestorePage(pageId) {
+    setStagedPages((prev) => prev.map((p) => p.id === pageId ? { ...p, _deleted: false } : p))
+  }
+
+  /* 페이지 카드 클릭 or backdrop 클릭 — _deleted 제외 후 store에 반영하고 모달 닫기 */
+  function handleClose(targetPageId = stagedCurrentId) {
+    const finalPages = stagedPages
+      .filter((p) => !p._deleted)
+      .map(({ _deleted, ...rest }) => rest)
+    applyPageChanges(finalPages, targetPageId)
     onClose()
   }
 
@@ -146,26 +170,17 @@ export default function PageEditModal({ onClose }) {
       {/* 백드롭 */}
       <div
         className="absolute inset-0 bg-black/50 backdrop-blur-[6px]"
-        onClick={onClose}
+        onClick={() => handleClose()}
       />
 
       {/* 모달 카드 */}
       <div className="relative bg-surface rounded-[20px] p-7 w-[760px] max-w-full border border-stroke shadow-modal animate-modal-in">
         {/* 헤더 */}
-        <div className="flex items-start justify-between mb-6">
-          <div>
-            <h2 className="text-base font-extrabold text-foreground">페이지 편집</h2>
-            <p className="text-[11px] text-foreground-disabled mt-0.5">
-              대시보드 페이지를 추가하거나 삭제하세요
-            </p>
-          </div>
-          <button
-            onClick={onClose}
-            aria-label="닫기"
-            className="w-7 h-7 rounded-full border border-stroke-input bg-surface-muted flex items-center justify-center text-foreground-tertiary hover:text-foreground transition-colors"
-          >
-            <X className="w-3.5 h-3.5" />
-          </button>
+        <div className="mb-6">
+          <h2 className="text-base font-extrabold text-foreground">페이지 편집</h2>
+          <p className="text-[11px] text-foreground-disabled mt-0.5">
+            대시보드 페이지를 추가하거나 삭제하세요
+          </p>
         </div>
 
         {/* 페이지 썸네일 목록 */}
@@ -175,27 +190,13 @@ export default function PageEditModal({ onClose }) {
               key={page.id}
               page={page}
               isActive={page.id === stagedCurrentId}
-              canDelete={stagedPages.length > 1}
+              canDelete={activePages.length > 1}
               onDelete={() => handleDeletePage(page.id)}
+              onRestore={() => handleRestorePage(page.id)}
+              onNavigate={() => handleClose(page.id)}
             />
           ))}
           <AddPageSlot onClick={handleAddPage} />
-        </div>
-
-        {/* 하단 버튼 */}
-        <div className="flex justify-end gap-2 mt-6 pt-5 border-t border-stroke-subtle">
-          <button
-            onClick={onClose}
-            className="px-5 py-2.5 rounded-[10px] border border-stroke-input bg-surface text-foreground-secondary text-[12px] font-semibold hover:border-stroke hover:text-foreground transition-colors"
-          >
-            취소
-          </button>
-          <button
-            onClick={handleSave}
-            className="px-5 py-2.5 rounded-[10px] bg-primary text-white text-[12px] font-bold shadow-primary-btn hover:bg-primary-hover transition-colors"
-          >
-            저장
-          </button>
         </div>
       </div>
     </div>

--- a/src/hooks/useDashboardSync.js
+++ b/src/hooks/useDashboardSync.js
@@ -14,14 +14,16 @@ import { toApiPayload } from '@/store/widgetApi'
  */
 export function useDashboardLoad() {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
+  const isRestoring = useAuthStore((s) => s.isRestoring)
   const isLoaded = useWidgetStore((s) => s.isLoaded)
   const loadFromServer = useWidgetStore((s) => s.loadFromServer)
   const resetLayout = useWidgetStore((s) => s.resetLayout)
 
   // 로그아웃 시 레이아웃 초기화 → 재로그인 시 서버에서 새로 불러올 수 있도록
+  // isRestoring 중에는 실행하지 않음 — auth 복원 전 sessionStorage가 삭제되는 것을 방지
   useEffect(() => {
-    if (!isAuthenticated) resetLayout()
-  }, [isAuthenticated, resetLayout])
+    if (!isAuthenticated && !isRestoring) resetLayout()
+  }, [isAuthenticated, isRestoring, resetLayout])
 
   const { data, isError } = useQuery({
     queryKey: ['dashboard', 'me'],

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -2,6 +2,8 @@ import { create } from 'zustand'
 import { GRID_COLS, GRID_ROWS } from '@/lib/gridConstants'
 import { fromApiResponse } from './widgetApi'
 
+const STORAGE_KEY_CURRENT_PAGE = 'dashboard:currentPageId'
+
 /* ── 충돌 판정 ──────────────────────────────────────────────
    모든 좌표는 1-indexed (CSS grid와 동일).
 ──────────────────────────────────────────────────────────── */
@@ -224,7 +226,9 @@ const useWidgetStore = create((set) => ({
         const emptyPage = { id: 'page-1', name: '대시보드 1', widgets: [] }
         return { pages: [emptyPage], currentPageId: 'page-1', widgets: [], isLoaded: true }
       }
-      const currentPage = pages[0]
+      const savedPageId = sessionStorage.getItem(STORAGE_KEY_CURRENT_PAGE)
+      const restoredPage = savedPageId ? pages.find((p) => p.id === savedPageId) : null
+      const currentPage = restoredPage ?? pages[0]
       return {
         pages,
         currentPageId: currentPage.id,
@@ -235,13 +239,15 @@ const useWidgetStore = create((set) => ({
 
   // 로그아웃 시 INITIAL 레이아웃으로 초기화.
   // isLoaded를 false로 되돌려 재로그인 시 서버에서 새로 불러올 수 있게 함.
-  resetLayout: () =>
+  resetLayout: () => {
+    sessionStorage.removeItem(STORAGE_KEY_CURRENT_PAGE)
     set({
       pages:         INITIAL_PAGES,
       currentPageId: 'page-1',
       widgets:       INITIAL_WIDGETS,
       isLoaded:      false,
-    }),
+    })
+  },
 
 
   // ── 페이지 전환 ─────────────────────────────────────────
@@ -249,6 +255,7 @@ const useWidgetStore = create((set) => ({
     set((state) => {
       const page = state.pages.find((p) => p.id === pageId)
       if (!page || page.id === state.currentPageId) return state
+      sessionStorage.setItem(STORAGE_KEY_CURRENT_PAGE, pageId)
       return { currentPageId: pageId, widgets: page.widgets }
     }),
 
@@ -262,6 +269,7 @@ const useWidgetStore = create((set) => ({
   applyPageChanges: (newPages, newCurrentId) =>
     set(() => {
       const currentPage = newPages.find((p) => p.id === newCurrentId) ?? newPages[0]
+      sessionStorage.setItem(STORAGE_KEY_CURRENT_PAGE, currentPage.id)
       return {
         pages: newPages,
         currentPageId: currentPage.id,

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -251,13 +251,14 @@ const useWidgetStore = create((set) => ({
 
 
   // ── 페이지 전환 ─────────────────────────────────────────
-  switchPage: (pageId) =>
+  switchPage: (pageId) => {
+    sessionStorage.setItem(STORAGE_KEY_CURRENT_PAGE, pageId)
     set((state) => {
       const page = state.pages.find((p) => p.id === pageId)
       if (!page || page.id === state.currentPageId) return state
-      sessionStorage.setItem(STORAGE_KEY_CURRENT_PAGE, pageId)
       return { currentPageId: pageId, widgets: page.widgets }
-    }),
+    })
+  },
 
   // ── 페이지 이름 변경 ─────────────────────────────────────
   renamePage: (pageId, name) =>
@@ -266,16 +267,15 @@ const useWidgetStore = create((set) => ({
     })),
 
   // ── 페이지 편집 모달에서 staged 변경사항 일괄 적용 ────────
-  applyPageChanges: (newPages, newCurrentId) =>
-    set(() => {
-      const currentPage = newPages.find((p) => p.id === newCurrentId) ?? newPages[0]
-      sessionStorage.setItem(STORAGE_KEY_CURRENT_PAGE, currentPage.id)
-      return {
-        pages: newPages,
-        currentPageId: currentPage.id,
-        widgets: currentPage.widgets,
-      }
-    }),
+  applyPageChanges: (newPages, newCurrentId) => {
+    const currentPage = newPages.find((p) => p.id === newCurrentId) ?? newPages[0]
+    sessionStorage.setItem(STORAGE_KEY_CURRENT_PAGE, currentPage.id)
+    set(() => ({
+      pages: newPages,
+      currentPageId: currentPage.id,
+      widgets: currentPage.widgets,
+    }))
+  },
 
   // ── 편집 모드 스냅샷 (전체 pages 스코프) ─────────────────
   // 편집 중 페이지 전환을 지원하기 위해 전체 pages와 진입 시점 pageId를 저장.


### PR DESCRIPTION
## 관련 이슈
closes #117

## 변경 내용

### 1. 새로고침 후 마지막 대시보드 페이지 복원
새로고침 또는 탭 이동 후 복귀 시 마지막으로 보고 있던 페이지로 자동 복원합니다.

- `sessionStorage`에 현재 페이지 ID 저장/복원
- `isRestoring` 중 `resetLayout` 차단 — auth 복원 전 sessionStorage가 삭제되는 버그 수정

### 2. 페이지 편집 모달 기능 개선

- 비활성 페이지 카드 클릭 시 해당 페이지로 이동 후 모달 닫기
- 현재 페이지도 삭제 가능 (활성 페이지 2개 이상일 때)
- 삭제 시 소프트 삭제 처리 — 반투명 오버레이 + 되돌리기 버튼으로 복원 가능
- backdrop 클릭 시 변경사항 store에 반영 후 모달 닫기
- X / 취소 / 저장 버튼 제거 — 페이지 편집 저장을 편집 모드 완료·저장으로 일원화

## QA 체크리스트

### 새로고침 복원
- [ ] 로그인 상태에서 2번째 페이지로 이동 후 새로고침 → 2번째 페이지로 복원
- [ ] 로그아웃 후 재로그인 → 첫 번째 페이지로 정상 로드

### 페이지 편집 모달
- [ ] 비활성 페이지 카드 클릭 → 해당 페이지로 이동 후 모달 닫힘
- [ ] 페이지 삭제 → 반투명 처리 + 되돌리기 버튼 표시
- [ ] 되돌리기 클릭 → 페이지 복원
- [ ] 현재 페이지 삭제 → 인접 페이지로 자동 전환
- [ ] backdrop 클릭 → 변경사항 유지한 채 모달 닫힘
- [ ] 활성 페이지 1개 남으면 삭제 버튼 비노출
- [ ] 편집 모드 완료·저장 → 페이지 추가/삭제 포함 API 저장 완료