### PR TITLE
fix(widget): 위젯 UI 폴리시 및 EditPanel 정합화, stock-chart 과호출 최적화

### DIFF
--- a/src/components/layout/AppHeader.jsx
+++ b/src/components/layout/AppHeader.jsx
@@ -1,30 +1,74 @@
+import { useState } from 'react'
 import { Activity, LayoutGrid } from 'lucide-react'
 import { useNavigate, useLocation } from 'react-router-dom'
-import NavTabs from './NavTabs'
+import NavTabs, { NavConfirmModal } from './NavTabs'
 import useAuthStore from '@/store/useAuthStore'
 import { useMyAccount } from '@/api/account'
 import useRightPanelStore from '@/store/useRightPanelStore'
 import useEditModeStore from '@/store/useEditModeStore'
-import useWidgetStore from '@/store/useWidgetStore'
+import useWidgetStore, { hasUnsavedChanges } from '@/store/useWidgetStore'
 import { useDashboardSave } from '@/hooks/useDashboardSync'
 import NotificationCenter from '@/components/ui/NotificationCenter'
 import { FontSizeButton, ThemeButton } from './DisplaySettingsButtons'
 
 function Logo() {
   const navigate = useNavigate()
+  const { isEditMode, exitEditMode, saveLayout } = useEditModeStore()
+  const { restoreSnapshot, clearSnapshot } = useWidgetStore()
+  const unsaved = useWidgetStore(hasUnsavedChanges)
+  const { mutate: saveDashboard, isPending } = useDashboardSave()
+  const [showConfirm, setShowConfirm] = useState(false)
+
+  function handleClick() {
+    if (!isEditMode) {
+      navigate('/')
+      return
+    }
+    if (!unsaved) {
+      exitEditMode()
+      navigate('/')
+      return
+    }
+    setShowConfirm(true)
+  }
+
   return (
-    <button
-      onClick={() => navigate('/')}
-      aria-label="홈으로 이동"
-      className="flex items-center gap-2 mr-2 shrink-0"
-    >
-      <div className="w-7 h-7 rounded-[9px] bg-primary flex items-center justify-center shadow-brand-glow">
-        <Activity className="w-3.5 h-3.5 text-white" strokeWidth={2.5} />
-      </div>
-      <span className="text-[15px] font-bold tracking-tight text-foreground">
-        SOL <span className="text-primary">Lite</span>
-      </span>
-    </button>
+    <>
+      <button
+        onClick={handleClick}
+        aria-label="홈으로 이동"
+        className="flex items-center gap-2 mr-2 shrink-0"
+      >
+        <div className="w-7 h-7 rounded-[9px] bg-primary flex items-center justify-center shadow-brand-glow">
+          <Activity className="w-3.5 h-3.5 text-white" strokeWidth={2.5} />
+        </div>
+        <span className="text-[15px] font-bold tracking-tight text-foreground">
+          SOL <span className="text-primary">Lite</span>
+        </span>
+      </button>
+      {showConfirm && (
+        <NavConfirmModal
+          isPending={isPending}
+          onSave={() => {
+            clearSnapshot()
+            saveDashboard(undefined, {
+              onSuccess: () => {
+                saveLayout()
+                navigate('/')
+                setShowConfirm(false)
+              },
+            })
+          }}
+          onDiscard={() => {
+            restoreSnapshot()
+            exitEditMode()
+            navigate('/')
+            setShowConfirm(false)
+          }}
+          onCancel={() => setShowConfirm(false)}
+        />
+      )}
+    </>
   )
 }
 

--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -270,37 +270,13 @@ export function PreviewContent({ type }) {
       return (
         <div className="flex flex-col h-full">
           <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">환율</span>
-          <div className="flex-1 flex flex-col justify-center min-h-0">
+          <div className="flex-1 flex flex-col items-center justify-center min-h-0 text-center">
             <div className="text-[8px] text-foreground-disabled">USD / KRW</div>
             <div className="text-[15px] font-extrabold text-foreground leading-tight">1,378.50</div>
             <div className="text-[9px] font-semibold text-down mt-0.5">▼ −2.30 (−0.17%)</div>
           </div>
         </div>
       )
-
-    /* 환율 — 복합 2×1 */
-    case 'exchange-wide': {
-      const EX_WIDE = [
-        { pair: 'USD / KRW', rate: '1,378.50', chg: '▼ −2.30 (−0.17%)', up: false, flex: '1.2', pr: 'pr-3', pl: '', rateSize: 'text-[13px]' },
-        { pair: 'JPY / KRW', rate: '9.18',     chg: '▲ +0.05 (+0.54%)', up: true,  flex: '1',   pr: '',    pl: 'pl-3', rateSize: 'text-[11px]' },
-      ]
-      return (
-        <div className="flex flex-col h-full gap-1">
-          <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">환율</span>
-          <div className="flex flex-1 min-h-0 divide-x divide-stroke">
-            {EX_WIDE.map(({ pair, rate, chg, up, flex, pr, pl, rateSize }) => (
-              <div key={pair} className={`flex flex-col justify-center ${pr} ${pl}`} style={{ flex }}>
-                <div className="text-center">
-                  <div className="text-[8px] text-foreground-disabled">{pair}</div>
-                  <div className={`${rateSize} font-extrabold text-foreground leading-tight`}>{rate}</div>
-                  <span className={`text-[8px] ${up ? 'text-up' : 'text-down'}`}>{chg}</span>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )
-    }
 
     /* 오늘의 시황 — 헤드라인 1×1 */
     case 'market-sm':
@@ -728,31 +704,6 @@ export function PreviewContent({ type }) {
           </div>
         </div>
       )
-
-    /* 환율 — 3통화 3×1 */
-    case 'exchange-3x1': {
-      const EX_3X1 = [
-        { pair: 'USD / KRW', rate: '1,378.50', chg: '▼ −2.30', up: false, flex: '1.2', pr: 'pr-3', pl: '',    rateSize: 'text-[13px]' },
-        { pair: 'JPY / KRW', rate: '9.18',     chg: '▲ +0.05', up: true,  flex: '1',   pr: 'pr-2', pl: 'pl-2', rateSize: 'text-[11px]' },
-        { pair: 'EUR / KRW', rate: '1,502.30', chg: '▼ −3.20', up: false, flex: '1',   pr: '',    pl: 'pl-2', rateSize: 'text-[11px]' },
-      ]
-      return (
-        <div className="flex flex-col h-full gap-1">
-          <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">환율</span>
-          <div className="flex flex-1 min-h-0 divide-x divide-stroke">
-            {EX_3X1.map(({ pair, rate, chg, up, flex, pr, pl, rateSize }) => (
-              <div key={pair} className={`flex flex-col justify-center ${pr} ${pl}`} style={{ flex }}>
-                <div className="text-center">
-                  <div className="text-[8px] text-foreground-disabled">{pair}</div>
-                  <div className={`${rateSize} font-extrabold text-foreground leading-tight`}>{rate}</div>
-                  <span className={`text-[8px] ${up ? 'text-up' : 'text-down'}`}>{chg}</span>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )
-    }
 
     /* 환율 — 대형 (구 2×2, 미사용) */
     case 'exchange-2x2':

--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -48,25 +48,28 @@ export function PreviewContent({ type }) {
     /* 계좌 잔고 — 와이드 2×1 */
     case 'balance-lg':
       return (
-        <div className="flex flex-col h-full gap-1.5">
-          <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">계좌 잔고</span>
-          <div className="shrink-0">
-            <div className="text-[9px] text-foreground-disabled">총 평가자산</div>
-            <div className="text-[18px] font-extrabold text-foreground leading-tight">84,320,000</div>
-            <div className="text-[10px] text-up font-semibold">▲ +2,152,000 (+2.61%)</div>
-          </div>
-          {/* <div className="h-px bg-stroke-subtle shrink-0" /> */}
-          <div className="flex gap-2 flex-1 items-end">
-            {[
-              { label: '투자원금', val: '82,168,000', color: 'text-foreground' },
-              { label: '평가손익', val: '+2,152,000', color: 'text-up' },
-              { label: '주문가능', val: '74,780,000', color: 'text-foreground' },
-            ].map(({ label, val, color }) => (
-              <div key={label} className="flex-1 min-w-0">
-                <div className="text-[9px] text-foreground-disabled">{label}</div>
-                <div className={`text-[12px] font-semibold truncate ${color}`}>{val}</div>
-              </div>
-            ))}
+        <div className="flex flex-col h-full">
+          <span className="text-[9px] font-semibold text-foreground-disabled shrink-0 mb-1">계좌 잔고</span>
+          <div className="flex flex-1 min-h-0 gap-3">
+            {/* 좌: 총 평가자산 */}
+            <div className="flex flex-col justify-end flex-1 min-w-0">
+              <div className="text-[8px] text-foreground-disabled">총 평가자산</div>
+              <div className="text-[15px] font-extrabold text-foreground leading-tight">84,320,000</div>
+              <div className="text-[9px] text-up font-semibold mt-0.5">▲ +2,152,000 (+2.61%)</div>
+            </div>
+            {/* 우: 3항목 세로 배치 */}
+            <div className="flex flex-col justify-end gap-1 border-l border-stroke pl-3 w-[42%] shrink-0">
+              {[
+                { label: '투자원금', val: '82,168,000', color: 'text-foreground' },
+                { label: '평가손익', val: '+2,152,000', color: 'text-up' },
+                { label: '주문가능', val: '74,780,000', color: 'text-foreground' },
+              ].map(({ label, val, color }) => (
+                <div key={label} className="min-w-0">
+                  <div className="text-[7px] text-foreground-disabled">{label}</div>
+                  <div className={`text-[9px] font-semibold truncate ${color}`}>{val}</div>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
       )
@@ -481,32 +484,36 @@ export function PreviewContent({ type }) {
       return (
         <div className="flex flex-col h-full">
           <span className="text-[9px] font-semibold text-foreground-disabled shrink-0 mb-1">계좌 잔고</span>
-          <div className="flex flex-1 min-h-0 gap-3">
-            <div className="flex flex-col flex-1 min-w-0">
-              <div className="flex-1 flex flex-col justify-center">
+          <div className="flex flex-col flex-1 min-h-0 gap-2">
+            {/* 상: 금액 정보 */}
+            <div className="flex flex-col shrink-0 gap-1">
+              <div>
                 <div className="text-[8px] text-foreground-disabled">총 평가자산</div>
                 <div className="text-[15px] font-extrabold text-foreground leading-none mt-0.5">84,320,000</div>
-                <div className="text-[9px] text-up font-semibold mt-0.5">▲ +2,152,000원 (+2.61%)</div>
+                <div className="text-[8px] text-up font-semibold mt-0.5">▲ +2,152,000 (+2.61%)</div>
               </div>
-              <div className="flex gap-3 shrink-0">
-                <div>
-                  <div className="text-[8px] text-foreground-disabled">투자원금</div>
-                  <div className="text-[10px] font-semibold text-foreground">82,168,000</div>
-                </div>
-                <div>
-                  <div className="text-[8px] text-foreground-disabled">주문가능</div>
-                  <div className="text-[10px] font-semibold text-foreground">74,780,000</div>
-                </div>
+              <div className="grid grid-cols-3">
+                {[
+                  { label: '투자원금', val: '82,168,000' },
+                  { label: '평가손익', val: '+2,152,000' },
+                  { label: '주문가능', val: '74,780,000' },
+                ].map(({ label, val }) => (
+                  <div key={label} className="min-w-0">
+                    <div className="text-[7px] text-foreground-disabled">{label}</div>
+                    <div className="text-[9px] font-semibold text-foreground truncate">{val}</div>
+                  </div>
+                ))}
               </div>
             </div>
-            <div className="flex flex-col flex-1 min-w-0 pl-3 border-l border-stroke">
-              <div className="text-[8px] text-foreground-disabled shrink-0">수익 추이 (30일)</div>
+            {/* 하: 수익 추이 */}
+            <div className="flex flex-col flex-1 min-h-0 border-t border-stroke pt-1">
+              <div className="text-[8px] text-foreground-disabled shrink-0">수익 추이 (7일)</div>
               <div className="flex-1 min-h-0 my-1">
                 <svg viewBox="0 0 100 30" preserveAspectRatio="none" style={{ width: '100%', height: '100%', display: 'block' }}>
                   <polyline points="0,27 12,23 24,25 36,18 50,14 62,10 74,7 86,4 100,1" fill="none" stroke="var(--color-up)" strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
                 </svg>
               </div>
-              <div className="text-[8px] text-foreground-disabled text-right shrink-0">최고 +5.2%</div>
+              <div className="text-[8px] text-up text-right shrink-0">+2.61%</div>
             </div>
           </div>
         </div>

--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -468,31 +468,31 @@ export function PreviewContent({ type }) {
         { d: 22, trades: null },
       ]
       return (
-        <div className="flex flex-col h-full gap-1">
-          <div className="flex items-center justify-between shrink-0">
-            <span className="text-[9px] font-bold text-foreground">2026년 3월</span>
-            <span className="text-[8px] text-foreground-disabled">3.16 ~ 3.22</span>
+        <div className="flex flex-col h-full">
+          <div className="flex items-center justify-between mb-2 shrink-0">
+            <span className="text-[9px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">거래내역</span>
+            <span className="text-[8px] text-foreground-disabled">2026년 3월</span>
           </div>
-          <div className="grid grid-cols-7 gap-0.5 shrink-0">
-            {wDays.map((d) => (
-              <div key={d} className="text-center text-[7px] font-semibold text-foreground-disabled">{d}</div>
+          <div className="grid grid-cols-7 gap-0.5 shrink-0 mb-1">
+            {wDays.map((d, i) => (
+              <div key={d} className={cn('text-[7px] font-semibold text-center', i === 0 ? 'text-up' : i === 6 ? 'text-down' : 'text-foreground-disabled')}>{d}</div>
             ))}
           </div>
           <div className="grid grid-cols-7 gap-0.5 flex-1">
-            {weekCells.map(({ d, trades }, i) => (
-              <div
-                key={i}
-                className="flex flex-col items-start justify-start rounded p-1 bg-background/50"
-              >
-                <span className="text-[8px] leading-none mb-1 text-foreground">{d}</span>
-                {trades && trades.map((tr, j) => (
-                  <div key={j} className="flex items-center gap-0.5 w-full mb-0.5">
-                    <div className={cn('w-0.5 rounded-full shrink-0 self-stretch', tr.buy ? 'bg-up' : 'bg-down')} />
-                    <span className="text-[7px] leading-snug truncate text-foreground">{tr.s}</span>
-                  </div>
-                ))}
-              </div>
-            ))}
+            {weekCells.map(({ d, trades }, i) => {
+              const dateColor = i === 0 ? 'text-up' : i === 6 ? 'text-down' : 'text-foreground'
+              return (
+                <div key={i} className="flex flex-col items-start rounded-lg p-1 overflow-hidden">
+                  <span className={`text-[8px] leading-none mb-1 shrink-0 w-full text-center ${dateColor}`}>{d}</span>
+                  {trades && trades.map((tr, j) => (
+                    <div key={j} className="flex items-center gap-0.5 w-full mb-0.5 shrink-0">
+                      <div className={cn('w-0.5 rounded-full shrink-0 self-stretch', tr.buy ? 'bg-up' : 'bg-down')} />
+                      <span className="text-[7px] leading-snug truncate text-foreground">{tr.s}</span>
+                    </div>
+                  ))}
+                </div>
+              )
+            })}
           </div>
         </div>
       )
@@ -538,25 +538,27 @@ export function PreviewContent({ type }) {
         25: [{ s: '포스코', t: false }],
       }
       return (
-        <div className="flex flex-col h-full gap-1">
-          <div className="flex items-center justify-between shrink-0">
-            <span className="text-[9px] font-bold text-foreground">2026년 3월</span>
-            <span className="text-[8px] text-foreground-disabled">거래내역</span>
+        <div className="flex flex-col h-full">
+          <div className="flex items-center justify-between mb-2 shrink-0">
+            <span className="text-[9px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">거래내역</span>
+            <span className="text-[8px] text-foreground-disabled">2026년 3월</span>
           </div>
-          <div className="grid grid-cols-7 gap-0.5 shrink-0">
-            {days.map((d) => (
-              <div key={d} className="text-center text-[7px] font-semibold text-foreground-disabled">{d}</div>
+          <div className="grid grid-cols-7 gap-0.5 shrink-0 mb-1">
+            {days.map((d, i) => (
+              <div key={d} className={cn('text-[7px] font-semibold text-center', i === 0 ? 'text-up' : i === 6 ? 'text-down' : 'text-foreground-disabled')}>{d}</div>
             ))}
           </div>
           <div className="grid grid-cols-7 gap-0.5 flex-1">
             {cells.map((d, i) => {
               const trades = d ? tradeMap[d] : null
+              const col = i % 7
+              const dateColor = col === 0 ? 'text-up' : col === 6 ? 'text-down' : 'text-foreground'
               return (
                 <div
                   key={i}
-                  className="flex flex-col items-start justify-start rounded p-0.5"
+                  className="flex flex-col items-center rounded p-0.5"
                 >
-                  <span className={`text-[8px] leading-none mb-px ${d ? 'text-foreground' : ''}`}>
+                  <span className={`text-[8px] leading-none mb-px ${d ? dateColor : 'invisible'}`}>
                     {d ?? ''}
                   </span>
                   {trades && trades.slice(0, 2).map((tr, j) => (
@@ -966,48 +968,61 @@ export function PreviewContent({ type }) {
         25: [{ s: '포스코', t: false }],
       }
       const trades = [
-        { name: '삼성전자', type: '매수' }, { name: 'SK하이닉스', type: '매도' },
-        { name: 'LG에너지', type: '매수' }, { name: 'NAVER',      type: '매도' },
-        { name: '현대차',   type: '매수' },
+        { name: '삼성전자',   type: '매수', qty: '10주', price: '75,400', date: '3.18' },
+        { name: 'SK하이닉스', type: '매도', qty: '5주',  price: '182,000', date: '3.17' },
+        { name: 'LG에너지',   type: '매수', qty: '3주',  price: '412,000', date: '3.16' },
+        { name: 'NAVER',      type: '매도', qty: '2주',  price: '215,500', date: '3.15' },
+        { name: '현대차',     type: '매수', qty: '7주',  price: '221,500', date: '3.14' },
       ]
       return (
         <div className="flex flex-col h-full">
-          <div className="flex items-center justify-between shrink-0 mb-1">
-            <span className="text-[9px] font-bold text-foreground">2026년 3월</span>
+          <div className="flex items-center justify-between mb-2 shrink-0">
+            <span className="text-[9px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">거래내역</span>
+            <span className="text-[8px] text-foreground-disabled">2026년 3월</span>
           </div>
           <div className="flex flex-1 min-h-0 gap-2">
-          <div className="flex flex-col flex-1 min-h-0">
-            <div className="grid grid-cols-7 gap-0.5 shrink-0">
-              {days.map((d) => (
-                <div key={d} className="text-center text-[6px] font-semibold text-foreground-disabled">{d}</div>
-              ))}
-            </div>
-            <div className="grid grid-cols-7 gap-0.5 flex-1">
-              {cells.map((d, i) => {
-                const ts = d ? tradeMap[d] : null
-                return (
-                  <div key={i} className="flex flex-col items-start rounded p-0.5">
-                    <span className={`text-[7px] leading-none mb-px ${d ? 'text-foreground' : ''}`}>{d ?? ''}</span>
-                    {ts && ts.slice(0, 2).map((tr, j) => (
-                      <div key={j} className="flex items-center gap-px w-full">
-                        <div className={`w-0.5 rounded-full shrink-0 self-stretch ${tr.t ? 'bg-up' : 'bg-down'}`} />
-                        <span className="text-[6px] leading-snug truncate text-foreground">{tr.s}</span>
-                      </div>
-                    ))}
-                  </div>
-                )
-              })}
-            </div>
-          </div>
-          <div className="flex flex-col border-l border-stroke pl-2 shrink-0 gap-1">
-            <span className="text-[7px] font-semibold text-foreground-disabled shrink-0">거래 내역</span>
-            {trades.map(({ name, type }, i) => (
-              <div key={i} className="flex items-center gap-1">
-                <span className={`text-[6px] font-semibold px-1 py-px rounded shrink-0 ${type === '매수' ? 'text-up bg-up/10' : 'text-down bg-down/10'}`}>{type}</span>
-                <span className="text-[8px] text-foreground truncate">{name}</span>
+            <div className="flex flex-col flex-1 min-h-0">
+              <div className="grid grid-cols-7 gap-0.5 shrink-0 mb-1">
+                {days.map((d, i) => (
+                  <div key={d} className={cn('text-[6px] font-semibold text-center', i === 0 ? 'text-up' : i === 6 ? 'text-down' : 'text-foreground-disabled')}>{d}</div>
+                ))}
               </div>
-            ))}
-          </div>
+              <div className="grid grid-cols-7 gap-0.5 flex-1">
+                {cells.map((d, i) => {
+                  const ts = d ? tradeMap[d] : null
+                  const col = i % 7
+                  const dateColor = col === 0 ? 'text-up' : col === 6 ? 'text-down' : 'text-foreground'
+                  return (
+                    <div key={i} className="flex flex-col items-center rounded p-0.5">
+                      <span className={`text-[7px] leading-none mb-px w-full text-center ${d ? dateColor : 'invisible'}`}>{d ?? ''}</span>
+                      {ts && ts.slice(0, 2).map((tr, j) => (
+                        <div key={j} className="flex items-center gap-px w-full">
+                          <div className={`w-0.5 rounded-full shrink-0 self-stretch ${tr.t ? 'bg-up' : 'bg-down'}`} />
+                          <span className="text-[6px] leading-snug truncate text-foreground">{tr.s}</span>
+                        </div>
+                      ))}
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+            <div className="flex flex-col min-h-0 border-l border-stroke pl-2 shrink-0 w-[40%]">
+              <span className="text-[7px] font-semibold text-foreground-disabled mb-1 shrink-0">거래 내역</span>
+              <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-1">
+                {trades.map(({ name, type, qty, price, date }, i) => (
+                  <div key={i} className="flex items-center justify-between gap-1">
+                    <div className="flex items-center gap-1 min-w-0">
+                      <span className={`text-[6px] font-semibold px-1 py-px rounded shrink-0 ${type === '매수' ? 'text-up bg-up/10' : 'text-down bg-down/10'}`}>{type}</span>
+                      <span className="text-[8px] text-foreground truncate">{name}</span>
+                    </div>
+                    <div className="flex flex-col items-end shrink-0">
+                      <span className="text-[7px] font-semibold text-foreground">{price}</span>
+                      <span className="text-[6px] text-foreground-disabled">{qty} · {date}</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
           </div>
         </div>
       )

--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -1,4 +1,4 @@
-import { ChevronLeft } from 'lucide-react'
+import { ChevronDown, ChevronLeft } from 'lucide-react'
 import { useDraggable } from '@dnd-kit/core'
 import { cn } from '@/lib/cn'
 import useGridStore from '@/store/useGridStore'
@@ -26,6 +26,80 @@ function calcAspectRatio(colSpan, rowSpan, cw, ch) {
   const w = colSpan * cw + (colSpan - 1) * GRID_GAP
   const h = rowSpan * ch + (rowSpan - 1) * GRID_GAP
   return w / h
+}
+
+/* ── 캔들차트 미리보기 ───────────────────────────────────
+   [cx, high_y, body_top, body_bot, low_y, isUp]
+   SVG y: 값이 작을수록 화면 위(=고가), 클수록 아래(=저가)
+─────────────────────────────────────────────────────── */
+function buildPreviewCandles(count = 78) {
+  const candles = []
+  const minY = 5
+  const maxY = 38
+  const clamp = (v) => Math.max(minY, Math.min(maxY, v))
+  const anchors = [
+    [0.00, 31.5], // 시작
+    [0.14, 29.8], // 완만한 초반 상승
+    [0.30, 24.2], // 가속 상승
+    [0.48, 19.4], // 강한 상승
+    [0.66, 16.8], // 고점권
+    [0.82, 20.4], // 눌림
+    [1.00, 17.2], // 상승 재개 후 마감
+  ]
+  const yAt = (t) => {
+    for (let i = 0; i < anchors.length - 1; i += 1) {
+      const [x1, y1] = anchors[i]
+      const [x2, y2] = anchors[i + 1]
+      if (t <= x2) {
+        const p = (t - x1) / (x2 - x1)
+        return y1 + (y2 - y1) * p
+      }
+    }
+    return anchors[anchors.length - 1][1]
+  }
+
+  for (let i = 0; i < count; i += 1) {
+    const t = i / (count - 1)
+    const cx = 2 + t * 96
+    const base = yAt(t)
+    const wave = Math.sin(i * 0.48) * 0.85 + Math.sin(i * 0.16) * 0.45
+    const mid = clamp(base + wave)
+    const prevMid = i === 0 ? mid + 0.3 : (candles[i - 1][2] + candles[i - 1][3]) / 2
+    // 몸통 길이를 다양화해서 실제 캔들 느낌 강화
+    const body = 0.45 + ((i * 5) % 8) * 0.2
+    // 윗꼬리/아랫꼬리 길이를 분리해 비대칭 + 가변 길이로 생성
+    const wickUp = 0.25 + ((i * 7) % 6) * 0.22
+    const wickDown = 0.2 + ((i * 11) % 7) * 0.18
+    const isUp = mid <= prevMid
+    const bodyTop = clamp(mid - body)
+    const bodyBottom = clamp(mid + body)
+    const highY = clamp(bodyTop - wickUp)
+    const lowY = clamp(bodyBottom + wickDown)
+    candles.push([cx, highY, bodyTop, bodyBottom, lowY, isUp])
+  }
+  return candles
+}
+
+const PREVIEW_CANDLES = buildPreviewCandles(65)
+
+function MiniCandleChart({ className = '' }) {
+  const lastBodyBottom = PREVIEW_CANDLES[PREVIEW_CANDLES.length - 1][3]
+  return (
+    <div className={cn('h-full w-full rounded-lg bg-white p-1', className)}>
+      <svg viewBox="0 0 100 42" preserveAspectRatio="none" style={{ width: '100%', height: '100%', display: 'block' }}>
+        <line x1="0" y1={lastBodyBottom} x2="100" y2={lastBodyBottom} stroke="var(--color-up)" strokeWidth="0.7" strokeDasharray="1.5 1.5" vectorEffect="non-scaling-stroke" />
+        {PREVIEW_CANDLES.map(([cx, ht, bt, bb, lb, isUp]) => {
+          const color = isUp ? 'var(--color-up)' : 'var(--color-down)'
+          return (
+            <g key={cx}>
+              <line x1={cx} y1={ht} x2={cx} y2={lb} stroke={color} strokeWidth="0.8" vectorEffect="non-scaling-stroke" />
+              <rect x={cx - 0.45} y={bt} width={0.9} height={Math.max(bb - bt, 0.6)} fill={color} rx="0" />
+            </g>
+          )
+        })}
+      </svg>
+    </div>
+  )
 }
 
 /* ── 위젯별 미리보기 콘텐츠 ─────────────────────────────── */
@@ -58,17 +132,19 @@ export function PreviewContent({ type }) {
               <div className="text-[9px] text-up font-semibold mt-0.5">▲ +2,152,000 (+2.61%)</div>
             </div>
             {/* 우: 3항목 세로 배치 */}
-            <div className="flex flex-col justify-end gap-1 border-l border-stroke pl-3 w-[42%] shrink-0">
-              {[
-                { label: '투자원금', val: '82,168,000', color: 'text-foreground' },
-                { label: '평가손익', val: '+2,152,000', color: 'text-up' },
-                { label: '주문가능', val: '74,780,000', color: 'text-foreground' },
-              ].map(({ label, val, color }) => (
-                <div key={label} className="min-w-0">
-                  <div className="text-[7px] text-foreground-disabled">{label}</div>
-                  <div className={`text-[9px] font-semibold truncate ${color}`}>{val}</div>
-                </div>
-              ))}
+            <div className="flex flex-col justify-end w-[42%] shrink-0">
+              <div className="flex flex-col gap-1 border-l border-stroke pl-3">
+                {[
+                  { label: '투자원금', val: '82,168,000', color: 'text-foreground' },
+                  { label: '평가손익', val: '+2,152,000', color: 'text-up' },
+                  { label: '주문가능', val: '74,780,000', color: 'text-foreground' },
+                ].map(({ label, val, color }) => (
+                  <div key={label} className="min-w-0">
+                    <div className="text-[7px] text-foreground-disabled">{label}</div>
+                    <div className={`text-[9px] font-semibold truncate ${color}`}>{val}</div>
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
         </div>
@@ -110,9 +186,7 @@ export function PreviewContent({ type }) {
             </div>
           </div>
           <div className="flex-1 min-h-0">
-            <svg viewBox="0 0 100 30" preserveAspectRatio="none" style={{ width: '100%', height: '100%', display: 'block' }}>
-              <polyline points="0,28 8,24 16,26 24,20 32,22 40,16 48,18 56,12 64,14 72,8 80,10 88,5 100,2" fill="none" stroke="var(--color-up)" strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
-            </svg>
+            <MiniCandleChart />
           </div>
         </div>
       )
@@ -121,10 +195,13 @@ export function PreviewContent({ type }) {
     case 'ranking-wide':
       return (
         <div className="flex flex-col h-full gap-1.5">
-          <div className="flex gap-1.5 shrink-0">
-            {['거래대금', '상승률', '거래량'].map((tab, i) => (
+          <div className="flex items-center justify-between shrink-0">
+            <span className="text-[9px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">실시간 순위</span>
+            <div className="flex gap-1.5 justify-end">
+            {['거래금', '급상승', '거래량'].map((tab, i) => (
               <span key={tab} className={`text-[9px] font-semibold px-1.5 py-0.5 rounded-full ${i === 0 ? 'bg-primary-light text-primary' : 'text-foreground-disabled'}`}>{tab}</span>
             ))}
+            </div>
           </div>
           <div className="flex flex-col gap-1.5">
             {[
@@ -150,10 +227,13 @@ export function PreviewContent({ type }) {
     case 'ranking-lg':
       return (
         <div className="flex flex-col h-full gap-1.5">
-          <div className="flex gap-1.5 shrink-0">
-            {['거래대금', '상승률', '거래량'].map((tab, i) => (
+          <div className="flex items-center justify-between shrink-0">
+            <span className="text-[9px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">실시간 순위</span>
+            <div className="flex gap-1.5 justify-end">
+            {['거래금', '급상승', '거래량'].map((tab, i) => (
               <span key={tab} className={`text-[9px] font-semibold px-1.5 py-0.5 rounded-full ${i === 0 ? 'bg-primary-light text-primary' : 'text-foreground-disabled'}`}>{tab}</span>
             ))}
+            </div>
           </div>
           <div className="flex flex-col gap-1.5">
             {[
@@ -284,30 +364,44 @@ export function PreviewContent({ type }) {
     /* 오늘의 시황 — 헤드라인 1×1 */
     case 'market-sm':
       return (
-        <div className="flex flex-col h-full gap-2">
-          <span className="text-[9px] font-semibold text-foreground-disabled">오늘의 시황</span>
-          <p className="text-[10px] text-foreground-secondary leading-snug">
-            美 CPI 예상치 하회…<br />나스닥 1% 이상 상승.<br />반도체 섹터 강세.
-          </p>
+        <div className="flex flex-col h-full">
+          <div className="flex items-center justify-between mb-1 shrink-0">
+            <span className="text-[9px] font-semibold text-foreground-disabled uppercase tracking-[.04em]">오늘의 시황</span>
+            <div className="flex gap-1">
+              <span className="px-1.5 py-px text-[7px] font-semibold rounded bg-primary text-white">국내</span>
+              <span className="px-1.5 py-px text-[7px] font-semibold rounded text-foreground-disabled">해외</span>
+            </div>
+          </div>
+          <div className="flex flex-col">
+            {['美 CPI 예상치 하회… 나스닥 1% 상승', '外人 순매수 4,200억 · 반도체↑', '원달러 1,378원 소폭 하락'].map((title, i) => (
+              <div key={i} className="flex items-start gap-1.5 py-1 border-b border-stroke last:border-b-0">
+                <span className="text-[8px] font-bold text-primary shrink-0">{i + 1}</span>
+                <p className="text-[8px] text-foreground leading-snug line-clamp-2">{title}</p>
+              </div>
+            ))}
+          </div>
         </div>
       )
 
     /* 오늘의 시황 — 상세 2×1 */
     case 'market-wide':
       return (
-        <div className="flex flex-col h-full gap-1.5">
-          <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">오늘의 시황</span>
-          <div className="flex flex-col gap-1.5">
+        <div className="flex flex-col h-full">
+          <div className="flex items-center justify-between mb-1 shrink-0">
+            <span className="text-[9px] font-semibold text-foreground-disabled uppercase tracking-[.04em]">오늘의 시황</span>
+            <div className="flex gap-1">
+              <span className="px-1.5 py-px text-[7px] font-semibold rounded bg-primary text-white">국내</span>
+              <span className="px-1.5 py-px text-[7px] font-semibold rounded text-foreground-disabled">해외</span>
+            </div>
+          </div>
+          <div className="flex flex-col">
             {[
               { title: '美 CPI 예상치 하회… 나스닥 1% 상승', desc: '긴축 우려 완화. AI 관련주 반등.' },
               { title: '外人 순매수 4,200억 · 반도체↑',      desc: '삼성·SK하이닉스 강세.' },
             ].map(({ title, desc }, i) => (
-              <div
-                key={i}
-                className={`px-1.5 py-1 rounded border-l-2 ${i === 0 ? 'bg-primary-light border-primary' : 'bg-surface-subtle border-stroke'}`}
-              >
-                <p className="text-[9px] font-bold text-foreground leading-snug">{title}</p>
-                <p className="text-[8px] text-foreground-disabled leading-snug mt-0.5">{desc}</p>
+              <div key={i} className="flex flex-col gap-0.5 py-1.5 border-b border-stroke last:border-b-0 pl-1.5 border-l-2 border-l-transparent">
+                <p className="text-[9px] font-semibold text-foreground leading-snug">{title}</p>
+                <p className="text-[8px] text-foreground-disabled leading-snug">{desc}</p>
               </div>
             ))}
           </div>
@@ -567,9 +661,7 @@ export function PreviewContent({ type }) {
             </div>
           </div>
           <div className="flex-1 min-h-0 overflow-hidden">
-            <svg viewBox="0 0 100 30" preserveAspectRatio="none" style={{ width: '100%', height: '100%', display: 'block' }}>
-              <polyline points="0,28 6,25 12,26 20,21 28,23 36,17 44,19 52,13 60,15 68,9 76,11 84,5 92,7 100,3" fill="none" stroke="var(--color-up)" strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
-            </svg>
+            <MiniCandleChart />
           </div>
           <div className="flex justify-between shrink-0">
             {[
@@ -692,9 +784,7 @@ export function PreviewContent({ type }) {
             ))}
           </div>
           <div className="flex-1 min-h-0 overflow-hidden">
-            <svg viewBox="0 0 100 30" preserveAspectRatio="none" style={{ width: '100%', height: '100%', display: 'block' }}>
-              <polyline points="0,27 10,24 20,25 30,19 40,21 50,15 60,17 70,10 80,12 90,6 100,3" fill="none" stroke="var(--color-up)" strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
-            </svg>
+            <MiniCandleChart />
           </div>
           <div className="flex justify-between shrink-0">
             {[
@@ -746,36 +836,57 @@ export function PreviewContent({ type }) {
     /* 종목별 뉴스 — 헤드라인 1×1 */
     case 'stock-news-sm':
       return (
-        <div className="flex flex-col h-full gap-2">
-          <div className="flex items-center justify-between shrink-0">
-            <span className="text-[9px] font-semibold text-foreground-disabled">종목별 뉴스</span>
-            <span className="text-[8px] font-semibold text-primary bg-primary-light px-1.5 py-px rounded">삼성전자</span>
+        <div className="flex flex-col h-full">
+          <div className="flex items-center justify-between mb-1 shrink-0">
+            <span className="text-[9px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 뉴스</span>
+            <span className="flex items-center gap-0.5 text-[8px] font-semibold text-primary shrink-0">
+              삼성전자
+              <ChevronDown size={9} />
+            </span>
           </div>
-          <p className="text-[10px] text-foreground-secondary leading-snug">
-            HBM 공급 본격화…<br />엔비디아향 납품 재개.<br />외국인 순매수 지속.
-          </p>
+          <div className="flex-1 flex flex-col overflow-hidden">
+            {[
+              'HBM 공급 본격화 — 엔비디아향 납품 재개',
+              '외국인 6거래일 연속 순매수',
+              '파운드리 2나노 시범 생산 개시',
+            ].map((title, i) => (
+              <div key={i} className="flex items-start gap-1.5 py-1 border-b border-stroke last:border-b-0 pl-2 border-l-2 border-l-transparent">
+                <span className="text-[8px] font-bold text-primary mt-[1px] shrink-0">{i + 1}</span>
+                <p className="text-[9px] text-foreground leading-snug line-clamp-2">{title}</p>
+              </div>
+            ))}
+          </div>
         </div>
       )
 
     /* 종목별 뉴스 — 상세 2×1 */
     case 'stock-news-wide':
       return (
-        <div className="flex flex-col h-full gap-1.5">
-          <div className="flex items-center justify-between shrink-0">
-            <span className="text-[9px] font-semibold text-foreground-disabled">종목별 뉴스</span>
-            <span className="text-[8px] font-semibold text-primary bg-primary-light px-1.5 py-px rounded">삼성전자</span>
+        <div className="flex flex-col h-full">
+          <div className="flex items-center justify-between mb-1 shrink-0">
+            <span className="text-[9px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 뉴스</span>
+            <span className="flex items-center gap-0.5 text-[8px] font-semibold text-primary shrink-0">
+              삼성전자
+              <ChevronDown size={9} />
+            </span>
           </div>
-          <div className="flex flex-col gap-1.5">
+          <div className="flex-1 min-h-0 overflow-y-auto">
             {[
-              { title: 'HBM 공급 본격화 — 엔비디아향 납품 재개', desc: 'AI 서버 수요 확대 수혜 기대.' },
-              { title: '외국인 6거래일 연속 순매수',               desc: '누적 순매수 1.2조원.' },
-            ].map(({ title, desc }, i) => (
+              { title: 'HBM 공급 본격화 — 엔비디아향 납품 재개', source: '연합뉴스', at: '1시간 전' },
+              { title: '외국인 6거래일 연속 순매수', source: '매일경제', at: '2시간 전' },
+            ].map(({ title, source, at }, i) => (
               <div
                 key={i}
-                className={`px-1.5 py-1 rounded border-l-2 ${i === 0 ? 'bg-primary-light border-primary' : 'bg-surface-subtle border-stroke'}`}
+                className="flex gap-2 py-2 border-b border-stroke last:border-b-0 pl-2 border-l-2 border-l-transparent"
               >
-                <p className="text-[9px] font-bold text-foreground leading-snug">{title}</p>
-                <p className="text-[8px] text-foreground-disabled leading-snug mt-0.5">{desc}</p>
+                <div className="flex-1 min-w-0">
+                  <p className="text-[9px] font-semibold text-foreground leading-snug line-clamp-2">{title}</p>
+                  <div className="flex items-center gap-1.5 mt-0.5">
+                    <span className="text-[8px] text-foreground-disabled">{source}</span>
+                    <span className="text-[8px] text-stroke">·</span>
+                    <span className="text-[8px] text-foreground-disabled">{at}</span>
+                  </div>
+                </div>
               </div>
             ))}
           </div>
@@ -785,23 +896,32 @@ export function PreviewContent({ type }) {
     /* 종목별 뉴스 — 대형 2×2 */
     case 'stock-news-2x2':
       return (
-        <div className="flex flex-col h-full gap-1.5">
-          <div className="flex items-center justify-between shrink-0">
-            <span className="text-[9px] font-semibold text-foreground-disabled">종목별 뉴스</span>
-            <span className="text-[8px] font-semibold text-primary bg-primary-light px-1.5 py-px rounded">삼성전자</span>
+        <div className="flex flex-col h-full">
+          <div className="flex items-center justify-between mb-1 shrink-0">
+            <span className="text-[9px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 뉴스</span>
+            <span className="flex items-center gap-0.5 text-[8px] font-semibold text-primary shrink-0">
+              삼성전자
+              <ChevronDown size={9} />
+            </span>
           </div>
-          <div className="flex flex-col gap-1.5">
+          <div className="flex-1 min-h-0 overflow-y-auto">
             {[
-              { title: 'HBM 공급 본격화 — 엔비디아향 납품 재개', desc: 'AI 서버 수요 확대 수혜 기대.' },
-              { title: '외국인 6거래일 연속 순매수',               desc: '누적 순매수 1.2조원.' },
-              { title: '파운드리 2나노 시범 생산 개시',            desc: 'TSMC와 경쟁 본격화.' },
-            ].map(({ title, desc }, i) => (
+              { title: 'HBM 공급 본격화 — 엔비디아향 납품 재개', source: '연합뉴스', at: '1시간 전' },
+              { title: '외국인 6거래일 연속 순매수', source: '매일경제', at: '2시간 전' },
+              { title: '파운드리 2나노 시범 생산 개시', source: '한국경제', at: '4시간 전' },
+            ].map(({ title, source, at }, i) => (
               <div
                 key={i}
-                className={`px-1.5 py-1 rounded border-l-2 ${i === 0 ? 'bg-primary-light border-primary' : 'bg-surface-subtle border-stroke'}`}
+                className="flex gap-2 py-2 border-b border-stroke last:border-b-0 pl-2 border-l-2 border-l-transparent"
               >
-                <p className="text-[9px] font-bold text-foreground leading-snug">{title}</p>
-                <p className="text-[8px] text-foreground-disabled leading-snug mt-0.5">{desc}</p>
+                <div className="flex-1 min-w-0">
+                  <p className="text-[9px] font-semibold text-foreground leading-snug line-clamp-2">{title}</p>
+                  <div className="flex items-center gap-1.5 mt-0.5">
+                    <span className="text-[8px] text-foreground-disabled">{source}</span>
+                    <span className="text-[8px] text-stroke">·</span>
+                    <span className="text-[8px] text-foreground-disabled">{at}</span>
+                  </div>
+                </div>
               </div>
             ))}
           </div>
@@ -811,20 +931,24 @@ export function PreviewContent({ type }) {
     /* 오늘의 시황 — 대형 2×2 */
     case 'market-2x2':
       return (
-        <div className="flex flex-col h-full gap-1.5">
-          <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">오늘의 시황</span>
-          <div className="flex flex-col gap-1.5">
+        <div className="flex flex-col h-full">
+          <div className="flex items-center justify-between mb-1 shrink-0">
+            <span className="text-[9px] font-semibold text-foreground-disabled uppercase tracking-[.04em]">오늘의 시황</span>
+            <div className="flex gap-1">
+              <span className="px-1.5 py-px text-[7px] font-semibold rounded bg-primary text-white">국내</span>
+              <span className="px-1.5 py-px text-[7px] font-semibold rounded text-foreground-disabled">해외</span>
+            </div>
+          </div>
+          <div className="flex flex-col flex-1 min-h-0 overflow-y-auto">
             {[
               { title: '美 CPI 예상치 하회… 나스닥 1% 상승', desc: '인플레이션 둔화. AI 관련주 반등.' },
               { title: '外人 순매수 4,200억 · 반도체↑',      desc: '삼성·SK하이닉스 강세.' },
               { title: '원달러 1,378원 소폭 하락',            desc: '금리 인하 기대감 반영.' },
+              { title: '美 연준 의사록 공개… 금리 동결 시사', desc: '시장 안도감 회복.' },
             ].map(({ title, desc }, i) => (
-              <div
-                key={i}
-                className={`px-1.5 py-1 rounded border-l-2 ${i === 0 ? 'bg-primary-light border-primary' : 'bg-surface-subtle border-stroke'}`}
-              >
-                <p className="text-[9px] font-bold text-foreground leading-snug">{title}</p>
-                <p className="text-[8px] text-foreground-disabled leading-snug mt-0.5">{desc}</p>
+              <div key={i} className="flex flex-col gap-0.5 py-1.5 border-b border-stroke last:border-b-0 pl-1.5 border-l-2 border-l-transparent">
+                <p className="text-[9px] font-semibold text-foreground leading-snug">{title}</p>
+                <p className="text-[8px] text-foreground-disabled leading-snug">{desc}</p>
               </div>
             ))}
           </div>

--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -86,7 +86,7 @@ function MiniCandleChart({ className = '' }) {
   const lastBodyBottom = PREVIEW_CANDLES[PREVIEW_CANDLES.length - 1][3]
   return (
     <div className={cn('h-full w-full rounded-lg bg-white p-1', className)}>
-      <svg viewBox="0 0 100 42" preserveAspectRatio="none" style={{ width: '100%', height: '100%', display: 'block' }}>
+      <svg viewBox="0 0 100 42" preserveAspectRatio="none" className="w-full h-full block">
         <line x1="0" y1={lastBodyBottom} x2="100" y2={lastBodyBottom} stroke="var(--color-up)" strokeWidth="0.7" strokeDasharray="1.5 1.5" vectorEffect="non-scaling-stroke" />
         {PREVIEW_CANDLES.map(([cx, ht, bt, bb, lb, isUp]) => {
           const color = isUp ? 'var(--color-up)' : 'var(--color-down)'
@@ -605,7 +605,7 @@ export function PreviewContent({ type }) {
             <div className="flex flex-col flex-1 min-h-0 border-t border-stroke pt-1">
               <div className="text-[8px] text-foreground-disabled shrink-0">수익 추이 (7일)</div>
               <div className="flex-1 min-h-0 my-1">
-                <svg viewBox="0 0 100 30" preserveAspectRatio="none" style={{ width: '100%', height: '100%', display: 'block' }}>
+                <svg viewBox="0 0 100 30" preserveAspectRatio="none" className="w-full h-full block">
                   <polyline points="0,27 12,23 24,25 36,18 50,14 62,10 74,7 86,4 100,1" fill="none" stroke="var(--color-up)" strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
                 </svg>
               </div>
@@ -638,7 +638,7 @@ export function PreviewContent({ type }) {
             ))}
           </div>
           <div className="flex-1 min-h-0 bg-background rounded-lg overflow-hidden">
-            <svg viewBox="0 0 100 30" preserveAspectRatio="none" style={{ width: '100%', height: '100%', display: 'block' }}>
+            <svg viewBox="0 0 100 30" preserveAspectRatio="none" className="w-full h-full block">
               <polyline points="0,27 10,22 20,24 30,18 40,20 50,13 60,15 70,8 80,10 90,5 100,2" fill="none" stroke="var(--color-up)" strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
             </svg>
           </div>

--- a/src/components/layout/NavTabs.jsx
+++ b/src/components/layout/NavTabs.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { X } from 'lucide-react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { cn } from '@/lib/cn'
 import { LAST_INVEST_PATH_KEY, LAST_INVEST_STATE_KEY } from '@/features/invest/navigation'
@@ -24,7 +25,7 @@ function resolveNavigatePath(path) {
 }
 
 /* 편집 모드 탭 이동 확인 모달 */
-function NavConfirmModal({ isPending, onSave, onDiscard, onCancel }) {
+export function NavConfirmModal({ isPending, onSave, onDiscard, onCancel }) {
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
@@ -34,7 +35,15 @@ function NavConfirmModal({ isPending, onSave, onDiscard, onCancel }) {
         className="bg-surface rounded-2xl shadow-xl w-[320px] p-6"
         onClick={(e) => e.stopPropagation()}
       >
-        <h3 className="text-[14px] font-bold text-foreground mb-1">편집 중인 내용이 있습니다</h3>
+        <div className="flex items-start justify-between mb-1">
+          <h3 className="text-[14px] font-bold text-foreground">편집 중인 내용이 있습니다</h3>
+          <button
+            onClick={onCancel}
+            className="w-6 h-6 rounded-full flex items-center justify-center text-foreground-tertiary hover:text-foreground hover:bg-surface-muted transition-colors -mt-0.5 -mr-1"
+          >
+            <X className="w-3.5 h-3.5" />
+          </button>
+        </div>
         <p className="text-[12px] text-foreground-secondary mb-5">저장하지 않으면 변경사항이 사라집니다.</p>
         <div className="flex gap-2">
           <button

--- a/src/components/layout/NavTabs.jsx
+++ b/src/components/layout/NavTabs.jsx
@@ -38,6 +38,7 @@ export function NavConfirmModal({ isPending, onSave, onDiscard, onCancel }) {
         <div className="flex items-start justify-between mb-1">
           <h3 className="text-[14px] font-bold text-foreground">편집 중인 내용이 있습니다</h3>
           <button
+            aria-label="닫기"
             onClick={onCancel}
             className="w-6 h-6 rounded-full flex items-center justify-center text-foreground-tertiary hover:text-foreground hover:bg-surface-muted transition-colors -mt-0.5 -mr-1"
           >

--- a/src/components/layout/PageEditModal.jsx
+++ b/src/components/layout/PageEditModal.jsx
@@ -135,37 +135,53 @@ export default function PageEditModal({ onClose }) {
   const activePages = stagedPages.filter((p) => !p._deleted)
   const isAtLimit   = activePages.length >= MAX_PAGES
 
+  /* staged 상태를 즉시 스토어에 반영 — 헤더 완료·저장 버튼이 최신 페이지를 읽을 수 있도록 */
+  function syncToStore(newStaged, currentId) {
+    const finalPages = newStaged
+      .filter((p) => !p._deleted)
+      .map(({ _deleted: _, ...rest }) => rest)
+    applyPageChanges(finalPages, currentId)
+  }
+
   function handleAddPage() {
     const newId = crypto.randomUUID()
     const nextIndex = activePages.length + 1
-    setStagedPages((prev) => [
-      ...prev,
+    const newStaged = [
+      ...stagedPages,
       { id: newId, name: `대시보드 ${nextIndex}`, widgets: [] },
-    ])
+    ]
+    setStagedPages(newStaged)
+    syncToStore(newStaged, stagedCurrentId)
   }
 
   function handleDeletePage(pageId) {
     if (activePages.length <= 1) return
-    setStagedPages((prev) => prev.map((p) => p.id === pageId ? { ...p, _deleted: true } : p))
-    // 현재 페이지 삭제 시 인접 활성 페이지로 이동
+    const newStaged = stagedPages.map((p) => p.id === pageId ? { ...p, _deleted: true } : p)
+    let newCurrentId = stagedCurrentId
     if (pageId === stagedCurrentId) {
       const remaining = activePages.filter((p) => p.id !== pageId)
       const deletedIndex = activePages.findIndex((p) => p.id === pageId)
-      const fallback = remaining[deletedIndex] ?? remaining[deletedIndex - 1]
-      setStagedCurrentId(fallback.id)
+      newCurrentId = (remaining[deletedIndex] ?? remaining[deletedIndex - 1]).id
+      setStagedCurrentId(newCurrentId)
     }
+    setStagedPages(newStaged)
+    syncToStore(newStaged, newCurrentId)
   }
 
   function handleRestorePage(pageId) {
-    setStagedPages((prev) => prev.map((p) => p.id === pageId ? { ...p, _deleted: false } : p))
+    const newStaged = stagedPages.map((p) => p.id === pageId ? { ...p, _deleted: false } : p)
+    setStagedPages(newStaged)
+    syncToStore(newStaged, stagedCurrentId)
   }
 
-  /* 페이지 카드 클릭 or backdrop 클릭 — _deleted 제외 후 store에 반영하고 모달 닫기 */
+  /* 페이지 카드 클릭 or backdrop 클릭 — 스토어는 이미 동기화된 상태이므로 모달만 닫기 */
   function handleClose(targetPageId = stagedCurrentId) {
-    const finalPages = stagedPages
-      .filter((p) => !p._deleted)
-      .map(({ _deleted: _, ...rest }) => rest)
-    applyPageChanges(finalPages, targetPageId)
+    if (targetPageId !== stagedCurrentId) {
+      const finalPages = stagedPages
+        .filter((p) => !p._deleted)
+        .map(({ _deleted: _, ...rest }) => rest)
+      applyPageChanges(finalPages, targetPageId)
+    }
     onClose()
   }
 

--- a/src/components/layout/PageEditModal.jsx
+++ b/src/components/layout/PageEditModal.jsx
@@ -124,6 +124,8 @@ function AddPageSlot({ onClick }) {
   )
 }
 
+const MAX_PAGES = 5
+
 export default function PageEditModal({ onClose }) {
   const { pages, currentPageId, applyPageChanges } = useWidgetStore()
 
@@ -131,6 +133,7 @@ export default function PageEditModal({ onClose }) {
   const [stagedCurrentId, setStagedCurrentId] = useState(currentPageId)
 
   const activePages = stagedPages.filter((p) => !p._deleted)
+  const isAtLimit   = activePages.length >= MAX_PAGES
 
   function handleAddPage() {
     const newId = crypto.randomUUID()
@@ -197,7 +200,18 @@ export default function PageEditModal({ onClose }) {
               onNavigate={() => handleClose(page.id)}
             />
           ))}
-          <AddPageSlot onClick={handleAddPage} />
+          {isAtLimit ? (
+            <div className="w-[148px] shrink-0">
+              <div className="w-full h-[148px] rounded-[14px] border border-stroke-input bg-surface-subtle flex flex-col items-center justify-center gap-2">
+                <span className="text-[11px] text-foreground-disabled font-medium text-center px-3">최대 {MAX_PAGES}개까지<br />추가할 수 있어요</span>
+              </div>
+              <div className="mt-2.5 px-0.5">
+                <span className="text-[11px] text-foreground-disabled">페이지 추가 불가</span>
+              </div>
+            </div>
+          ) : (
+            <AddPageSlot onClick={handleAddPage} />
+          )}
         </div>
       </div>
     </div>

--- a/src/components/layout/PageEditModal.jsx
+++ b/src/components/layout/PageEditModal.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
-import { Trash2, Plus, RotateCcw } from 'lucide-react'
+import { createPortal } from 'react-dom'
+import { Trash2, Plus, RotateCcw, X } from 'lucide-react'
 import useWidgetStore from '@/store/useWidgetStore'
 import { cn } from '@/lib/cn'
 import { PreviewContent } from '@/components/layout/EditPanel/WidgetSizeList'
@@ -185,7 +186,7 @@ export default function PageEditModal({ onClose }) {
     onClose()
   }
 
-  return (
+  return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center p-6">
       {/* 백드롭 */}
       <div
@@ -196,11 +197,20 @@ export default function PageEditModal({ onClose }) {
       {/* 모달 카드 */}
       <div className="relative bg-surface rounded-[20px] p-7 w-[760px] max-w-full border border-stroke shadow-modal animate-modal-in">
         {/* 헤더 */}
-        <div className="mb-6">
-          <h2 className="text-base font-extrabold text-foreground">페이지 편집</h2>
-          <p className="text-[11px] text-foreground-disabled mt-0.5">
-            대시보드 페이지를 추가하거나 삭제하세요
-          </p>
+        <div className="flex items-start justify-between mb-6">
+          <div>
+            <h2 className="text-base font-extrabold text-foreground">페이지 편집</h2>
+            <p className="text-[11px] text-foreground-disabled mt-0.5">
+              대시보드 페이지를 추가하거나 삭제하세요
+            </p>
+          </div>
+          <button
+            aria-label="닫기"
+            onClick={() => handleClose()}
+            className="w-7 h-7 rounded-full border border-stroke-input bg-surface-muted flex items-center justify-center text-foreground-tertiary hover:text-foreground transition-colors"
+          >
+            <X className="w-3.5 h-3.5" />
+          </button>
         </div>
 
         {/* 페이지 썸네일 목록 */}
@@ -230,6 +240,7 @@ export default function PageEditModal({ onClose }) {
           )}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   )
 }

--- a/src/components/ui/MiniChart.jsx
+++ b/src/components/ui/MiniChart.jsx
@@ -167,14 +167,19 @@ export default function MiniChart({ candleData, liveCandle, isIntraday = false, 
   }, [candleData, isIntraday, tickOffset, isForceFit, theme])
 
   // STOMP 실시간 캔들 업데이트 — 차트 재생성 없이 마지막 봉만 갱신
-  // isIntraday: 새 버킷이 79슬롯 밖으로 나가면 최신 캔들이 보이도록 scrollToRealTime
+  // 정규장(09:00~15:30) 중에는 고정 79슬롯 범위 안에 자연 표시 — scrollToRealTime 불필요
+  // 15:30 이후 새 봉이 슬롯 밖으로 나갈 때만 scrollToRealTime 호출
   useEffect(() => {
     if (!seriesRef.current || !liveCandle) return
     seriesRef.current.update(liveCandle)
     if (isIntraday && chartRef.current) {
-      chartRef.current.timeScale().scrollToRealTime()
+      const d = new Date((liveCandle.time + tickOffset) * 1000)
+      const kstMinutes = d.getUTCHours() * 60 + d.getUTCMinutes()
+      if (kstMinutes > 15 * 60 + 30) {
+        chartRef.current.timeScale().scrollToRealTime()
+      }
     }
-  }, [liveCandle, isIntraday])
+  }, [liveCandle, isIntraday, tickOffset])
 
   return <div ref={ref} className={className} />
 }

--- a/src/components/widgets/BalanceWidget.jsx
+++ b/src/components/widgets/BalanceWidget.jsx
@@ -66,7 +66,7 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
 
       {variant === 'balance-lg' ? (
         <div className="flex flex-1 gap-3 min-h-0">
-          <div className="flex flex-col justify-center flex-1 min-w-0">
+          <div className="flex flex-col justify-end flex-1 min-w-0">
             <div className="text-widget-11 text-foreground-disabled">총 평가자산</div>
             <div className="text-widget-18 font-bold leading-tight tracking-tight text-foreground mt-0.5">
               {BALANCE.total}
@@ -76,44 +76,48 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
               : <div className={`text-widget-11 font-semibold mt-0.5 ${BALANCE.isProfit ? 'text-up' : 'text-down'}`}>{BALANCE.isProfit ? '▲' : '▼'} {BALANCE.profit} ({BALANCE.profitRate})</div>
             }
           </div>
-          <div className="flex flex-col justify-center gap-1 shrink-0 border-l border-stroke pl-3">
+          <div className="flex flex-col justify-end gap-1 min-w-0 w-[42%] shrink-0 border-l border-stroke pl-3">
             {[
               { label: '투자원금', val: BALANCE.invested, color: 'text-foreground' },
               { label: '평가손익', val: BALANCE.profit,   color: BALANCE.isProfit ? 'text-up' : 'text-down' },
               { label: '주문가능', val: BALANCE.available, color: 'text-foreground' },
             ].map(({ label, val, color }) => (
-              <div key={label}>
+              <div key={label} className="min-w-0">
                 <div className="text-widget-7 text-foreground-disabled">{label}</div>
-                <div className={`text-widget-10 font-semibold ${color}`}>{val}</div>
+                <div className={`text-widget-10 font-semibold truncate ${color}`}>{val}</div>
               </div>
             ))}
           </div>
         </div>
       ) : variant === 'balance-3x1' ? (
-        <div className="flex flex-1 gap-4 min-h-0">
-          <div className="flex flex-col flex-1 min-w-0">
-            <div className="flex-1 flex flex-col justify-center">
-              <div className="text-widget-9 text-foreground-disabled">총 평가자산</div>
+        <div className="flex flex-col flex-1 min-h-0 gap-3">
+          {/* 상: 금액 정보 */}
+          <div className="flex flex-col shrink-0 gap-1.5">
+            <div>
+              <div className="text-widget-10 text-foreground-disabled">총 평가자산</div>
               <div className="text-widget-22 font-bold leading-tight tracking-tight text-foreground mt-0.5">
                 {BALANCE.total}
               </div>
               {BALANCE.isLoading
                 ? <div className="text-widget-10 text-foreground-disabled mt-0.5">-</div>
-                : <div className={`text-widget-9 font-semibold mt-0.5 ${BALANCE.isProfit ? 'text-up' : 'text-down'}`}>{BALANCE.isProfit ? '▲' : '▼'} {BALANCE.profit} ({BALANCE.profitRate})</div>
+                : <div className={`text-widget-11 font-semibold mt-0.5 ${BALANCE.isProfit ? 'text-up' : 'text-down'}`}>{BALANCE.isProfit ? '▲' : '▼'} {BALANCE.profit} ({BALANCE.profitRate})</div>
               }
             </div>
-            <div className="flex gap-6 shrink-0">
-              <div>
-                <div className="text-widget-7 text-foreground-disabled">투자원금</div>
-                <div className="text-widget-10 font-semibold text-foreground">{BALANCE.invested}</div>
-              </div>
-              <div>
-                <div className="text-widget-7 text-foreground-disabled">주문가능</div>
-                <div className="text-widget-10 font-semibold text-foreground">{BALANCE.available}</div>
-              </div>
+            <div className="grid grid-cols-3">
+              {[
+                { label: '투자원금', val: BALANCE.invested, color: 'text-foreground' },
+                { label: '평가손익', val: BALANCE.profit,   color: BALANCE.isProfit ? 'text-up' : 'text-down' },
+                { label: '주문가능', val: BALANCE.available, color: 'text-foreground' },
+              ].map(({ label, val, color }) => (
+                <div key={label} className="min-w-0">
+                  <div className="text-widget-7 text-foreground-disabled">{label}</div>
+                  <div className={`text-widget-10 font-semibold truncate ${color}`}>{val}</div>
+                </div>
+              ))}
             </div>
           </div>
-          <div className="flex flex-col flex-1 min-w-0 pl-4 border-l border-stroke">
+          {/* 하: 수익 추이 */}
+          <div className="flex flex-col flex-1 min-h-0 border-t border-stroke pt-2">
             <div className="text-widget-9 text-foreground-disabled shrink-0">수익 추이 (7일)</div>
             <div className="flex-1 min-h-0 relative my-2">
               {BALANCE.flowPoints.length > 1 ? (() => {
@@ -140,11 +144,7 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
                       const x = i * W
                       const y = 10 + (1 - (r - min) / range) * 80
                       return (
-                        <circle
-                          key={i}
-                          cx={x}
-                          cy={y}
-                          r="3"
+                        <circle key={i} cx={x} cy={y} r="3"
                           fill={r >= 0 ? 'var(--color-up)' : 'var(--color-down)'}
                           vectorEffect="non-scaling-stroke"
                         />
@@ -153,7 +153,7 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
                   </svg>
                 )
               })() : (
-                <div className="absolute inset-0 flex items-center justify-center text-widget-8 text-foreground-disabled">데이터 없음</div>
+                <div className="absolute inset-0 flex items-center justify-center text-widget-9 text-foreground-disabled">데이터 없음</div>
               )}
             </div>
             {BALANCE.flowPoints.length > 0 && (

--- a/src/components/widgets/BalanceWidget.jsx
+++ b/src/components/widgets/BalanceWidget.jsx
@@ -76,17 +76,19 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
               : <div className={`text-widget-11 font-semibold mt-0.5 ${BALANCE.isProfit ? 'text-up' : 'text-down'}`}>{BALANCE.isProfit ? '▲' : '▼'} {BALANCE.profit} ({BALANCE.profitRate})</div>
             }
           </div>
-          <div className="flex flex-col justify-end gap-1 min-w-0 w-[42%] shrink-0 border-l border-stroke pl-3">
-            {[
-              { label: '투자원금', val: BALANCE.invested, color: 'text-foreground' },
-              { label: '평가손익', val: BALANCE.profit,   color: BALANCE.isProfit ? 'text-up' : 'text-down' },
-              { label: '주문가능', val: BALANCE.available, color: 'text-foreground' },
-            ].map(({ label, val, color }) => (
-              <div key={label} className="min-w-0">
-                <div className="text-widget-7 text-foreground-disabled">{label}</div>
-                <div className={`text-widget-10 font-semibold truncate ${color}`}>{val}</div>
-              </div>
-            ))}
+          <div className="flex flex-col justify-end min-w-0 w-[42%] shrink-0">
+            <div className="flex flex-col gap-1 border-l border-stroke pl-3">
+              {[
+                { label: '투자원금', val: BALANCE.invested, color: 'text-foreground' },
+                { label: '평가손익', val: BALANCE.profit,   color: BALANCE.isProfit ? 'text-up' : 'text-down' },
+                { label: '주문가능', val: BALANCE.available, color: 'text-foreground' },
+              ].map(({ label, val, color }) => (
+                <div key={label} className="min-w-0">
+                  <div className="text-widget-7 text-foreground-disabled">{label}</div>
+                  <div className={`text-widget-10 font-semibold truncate ${color}`}>{val}</div>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
       ) : variant === 'balance-3x1' ? (

--- a/src/components/widgets/ExchangeWidget.jsx
+++ b/src/components/widgets/ExchangeWidget.jsx
@@ -17,10 +17,8 @@ const ALL_CURRENCIES = [
 ]
 
 const DEFAULT_CURRENCIES = {
-  'exchange-sm':   ['USD'],
-  'exchange-wide': ['USD', 'JPY'],
-  'exchange-3x1':  ['USD', 'JPY', 'EUR'],
-  'exchange-2x2':  ['USD', 'JPY', 'EUR'],
+  'exchange-sm':  ['USD'],
+  'exchange-2x2': ['USD', 'JPY', 'EUR'],
 }
 
 const LIVE_BY_CODE = { USD: 0, JPY: 1, EUR: 2 }
@@ -98,92 +96,6 @@ export default function ExchangeWidget({ instanceId, variant = 'exchange-sm', co
     </button>
   )
 
-  if (variant === 'exchange-3x1') {
-    const flexValues = ['1.2', '1', '1']
-    const paddings   = [{ pr: 'pr-3', pl: '' }, { pr: 'pr-2.5', pl: 'pl-2.5' }, { pr: '', pl: 'pl-2.5' }]
-    const rateSize   = ['text-widget-20', 'text-widget-16', 'text-widget-16']
-    return (
-      <>
-        <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-          <div className="flex items-center justify-between mb-1 shrink-0">
-            <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
-            {settingsBtn}
-          </div>
-          <div className="flex flex-1 min-h-0 divide-x divide-stroke">
-            {currencies.map(({ code, pair, live }, i) => {
-              const isUp = (live?.change ?? 0) > 0
-              const { pr, pl } = paddings[i] ?? { pr: '', pl: 'pl-2.5' }
-              return (
-                <div
-                  key={pair}
-                  className={`relative flex flex-col justify-center ${pr} ${pl} cursor-pointer group [flex:var(--flex-val)]`}
-                  style={{ '--flex-val': flexValues[i] ?? '1' }}
-                  onClick={(e) => handleCurrencyClick(e, code)}
-                >
-                  <div className="text-center">
-                    <div className="text-widget-9 text-foreground-disabled">{pair}</div>
-                    <div className={`${rateSize[i] ?? 'text-widget-16'} font-bold text-foreground leading-tight`}>{formatRate(live?.rate)}</div>
-                    {live?.change != null && (
-                      <div className={`text-widget-9 ${isUp ? 'text-up' : 'text-down'}`}>
-                        {isUp ? '▲' : '▼'} {Math.abs(live.change)}
-                      </div>
-                    )}
-                  </div>
-                  <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary opacity-0 group-hover:opacity-100 transition-opacity" />
-                </div>
-              )
-            })}
-          </div>
-          {!isAuthenticated && <LockedOverlay message="환율 정보를 보려면" />}
-        </WidgetCard>
-        {configModal}
-      </>
-    )
-  }
-
-  if (variant === 'exchange-wide') {
-    return (
-      <>
-        <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-          <div className="flex items-center justify-between mb-1 shrink-0">
-            <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
-            {settingsBtn}
-          </div>
-          <div className="flex flex-1 min-h-0 divide-x divide-stroke">
-            {currencies.map(({ code, pair, live }, i) => {
-              const isUp = (live?.change ?? 0) > 0
-              const rateSize = i === 0 ? 'text-widget-20' : 'text-widget-16'
-              const pr = i === 0 ? 'pr-3' : ''
-              const pl = i > 0 ? 'pl-3' : ''
-              const flex = i === 0 ? '1.2' : '1'
-              return (
-                <div
-                  key={pair}
-                  className={`relative flex flex-col justify-center ${pr} ${pl} cursor-pointer group [flex:var(--flex-val)]`}
-                  style={{ '--flex-val': flex }}
-                  onClick={(e) => handleCurrencyClick(e, code)}
-                >
-                  <div className="text-center">
-                    <div className="text-widget-9 text-foreground-disabled">{pair}</div>
-                    <div className={`${rateSize} font-bold text-foreground leading-tight`}>{formatRate(live?.rate)}</div>
-                    {live?.change != null && (
-                      <div className={`text-widget-9 ${isUp ? 'text-up' : 'text-down'}`}>
-                        {isUp ? '▲' : '▼'} {Math.abs(live.change)}
-                      </div>
-                    )}
-                  </div>
-                  <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary opacity-0 group-hover:opacity-100 transition-opacity" />
-                </div>
-              )
-            })}
-          </div>
-          {!isRestoring && !isAuthenticated && <LockedOverlay message="환율 정보를 보려면" />}
-        </WidgetCard>
-        {configModal}
-      </>
-    )
-  }
-
   if (variant === 'exchange-2x2') {
     const primary = currencies[0]
     const rest    = currencies.slice(1)
@@ -254,7 +166,7 @@ export default function ExchangeWidget({ instanceId, variant = 'exchange-sm', co
         <div className="flex items-center justify-between shrink-0">
           <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">환율</span>
         </div>
-        <div className="flex-1 flex flex-col justify-center min-h-0">
+        <div className="flex-1 flex flex-col items-center justify-center min-h-0 text-center">
           <div className="text-widget-9 text-foreground-disabled">USD / KRW</div>
           <RateDisplay live={smLive} rateClassName="text-widget-18" />
         </div>

--- a/src/components/widgets/MarketOverviewWidget.jsx
+++ b/src/components/widgets/MarketOverviewWidget.jsx
@@ -73,11 +73,12 @@ export default function MarketOverviewWidget({ variant = 'market-sm', colSpan = 
           type="button"
           onClick={(e) => { e.stopPropagation(); setTab(t.key) }}
           className={cn(
-            'px-1.5 py-px text-widget-9 font-semibold rounded transition-colors',
+            'px-1.5 py-px font-semibold rounded transition-colors',
             tab === t.key
               ? 'bg-primary text-white'
               : 'text-foreground-disabled hover:text-foreground-secondary',
           )}
+          style={{ fontSize: 'var(--text-widget-9)' }}
         >
           {t.label}
         </button>

--- a/src/components/widgets/MarketOverviewWidget.jsx
+++ b/src/components/widgets/MarketOverviewWidget.jsx
@@ -73,12 +73,11 @@ export default function MarketOverviewWidget({ variant = 'market-sm', colSpan = 
           type="button"
           onClick={(e) => { e.stopPropagation(); setTab(t.key) }}
           className={cn(
-            'px-1.5 py-px font-semibold rounded transition-colors',
+            'px-1.5 py-px text-widget-9 font-semibold rounded transition-colors',
             tab === t.key
               ? 'bg-primary text-white'
               : 'text-foreground-disabled hover:text-foreground-secondary',
           )}
-          style={{ fontSize: 'var(--text-widget-9)' }}
         >
           {t.label}
         </button>

--- a/src/components/widgets/MarketOverviewWidget.jsx
+++ b/src/components/widgets/MarketOverviewWidget.jsx
@@ -5,8 +5,8 @@ import useWidgetDetailStore from '@/store/useWidgetDetailStore'
 import { cn } from '@/lib/cn'
 
 const TABS = [
-  { key: 'kr', label: '한국' },
-  { key: 'us', label: '미국' },
+  { key: 'kr', label: '국내' },
+  { key: 'us', label: '해외' },
 ]
 
 function NewsCard({ item, showSummary = false, onClickNews }) {
@@ -73,11 +73,12 @@ export default function MarketOverviewWidget({ variant = 'market-sm', colSpan = 
           type="button"
           onClick={(e) => { e.stopPropagation(); setTab(t.key) }}
           className={cn(
-            'px-2 py-0.5 text-widget-9 font-semibold rounded-md transition-colors',
+            'px-1.5 py-px font-semibold rounded transition-colors',
             tab === t.key
               ? 'bg-primary text-white'
               : 'text-foreground-disabled hover:text-foreground-secondary',
           )}
+          style={{ fontSize: 'var(--text-widget-9)' }}
         >
           {t.label}
         </button>

--- a/src/components/widgets/PortfolioWidget.jsx
+++ b/src/components/widgets/PortfolioWidget.jsx
@@ -98,7 +98,7 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
   const returnRateStr = portfolio.returnRate != null
     ? `${portfolio.returnRate >= 0 ? '+' : ''}${portfolio.returnRate.toFixed(1)}%`
     : '-'
-  const returnRateColor = (portfolio.returnRate ?? 0) >= 0 ? 'text-up' : 'text-down'
+  const returnRateColor = portfolio.returnRate == null ? 'text-foreground-disabled' : portfolio.returnRate >= 0 ? 'text-up' : 'text-down'
 
   return (
     <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={() => open({ widgetTypeId: 'balance', config: {} })}>
@@ -106,10 +106,16 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
         <>
           <div className="flex items-center justify-between mb-1 shrink-0">
             <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 비중</span>
-            <span className={`text-widget-10 font-semibold ${returnRateColor}`}>{returnRateStr}</span>
+            {portfolio.returnRate != null && (
+              <span className={`text-widget-10 font-semibold ${returnRateColor}`}>{returnRateStr}</span>
+            )}
           </div>
           <div className="flex flex-col gap-1 flex-1 min-h-0 overflow-hidden">
-            {portfolio.items.map((item) => (
+            {portfolio.isLoading || portfolio.items.length === 0 ? (
+              <div className="flex-1 flex items-center justify-center text-widget-9 text-foreground-disabled">
+                {portfolio.isLoading ? '불러오는 중...' : '보유 종목 없음'}
+              </div>
+            ) : portfolio.items.map((item) => (
               <ItemBar key={item.name} item={item} barHeight="h-[3px]" />
             ))}
           </div>
@@ -119,46 +125,60 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
           <div className="flex items-center justify-between mb-1 shrink-0">
             <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 비중</span>
           </div>
-          <div className="flex flex-col flex-1 gap-3 min-h-0">
-            <div className="flex items-center gap-3 shrink-0">
-              <div
-                className="w-16 h-16 rounded-full shrink-0"
-                style={{ background: `conic-gradient(${conicStops})` }}
-              />
-              <div>
-                <div className="text-widget-9 text-foreground-disabled">총 수익률</div>
-                <div className={`text-widget-22 font-bold leading-tight ${returnRateColor}`}>{returnRateStr}</div>
-                <div className="text-widget-9 text-foreground-disabled mt-0.5">+4,280,000원</div>
+          {portfolio.isLoading || portfolio.items.length === 0 ? (
+            <div className="flex-1 flex items-center justify-center text-widget-9 text-foreground-disabled">
+              {portfolio.isLoading ? '불러오는 중...' : '보유 종목 없음'}
+            </div>
+          ) : (
+            <div className="flex flex-col flex-1 gap-3 min-h-0">
+              <div className="flex items-center gap-3 shrink-0">
+                <div
+                  className="w-16 h-16 rounded-full shrink-0"
+                  style={{ background: `conic-gradient(${conicStops})` }}
+                />
+                <div>
+                  <div className="text-widget-9 text-foreground-disabled">총 수익률</div>
+                  <div className={`text-widget-22 font-bold leading-tight ${returnRateColor}`}>{returnRateStr}</div>
+                  <div className="text-widget-9 text-foreground-disabled mt-0.5">+4,280,000원</div>
+                </div>
+              </div>
+              <div className="flex flex-col gap-1.5 flex-1 min-h-0 overflow-hidden">
+                {portfolio.items.map((item) => (
+                  <ItemBar key={item.name} item={item} barHeight="h-[4px]" />
+                ))}
               </div>
             </div>
-            <div className="flex flex-col gap-1.5 flex-1 min-h-0 overflow-hidden">
-              {portfolio.items.map((item) => (
-                <ItemBar key={item.name} item={item} barHeight="h-[4px]" />
-              ))}
-            </div>
-          </div>
+          )}
         </>
       ) : (
         /* portfolio-sm (default) */
         <>
           <div className="flex items-center justify-between mb-1 shrink-0">
             <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 비중</span>
-            <span className={`text-widget-10 font-semibold ${returnRateColor}`}>{returnRateStr}</span>
+            {portfolio.returnRate != null && (
+              <span className={`text-widget-10 font-semibold ${returnRateColor}`}>{returnRateStr}</span>
+            )}
           </div>
-          <div className="flex items-center gap-2.5 flex-1 min-h-0">
-            <div
-              className="w-14 h-14 rounded-full shrink-0"
-              style={{ background: `conic-gradient(${conicStops})` }}
-            />
-            <div className="flex flex-col gap-1 min-w-0 flex-1">
-              {portfolio.items.map((item) => (
-                <div key={item.name} className="flex items-center gap-1 min-w-0">
-                  <div className="w-1.5 h-1.5 rounded-full shrink-0" style={{ background: item.color }} />
-                  <span className="text-widget-10 text-foreground-secondary tracking-tight truncate">{item.name}</span>
-                </div>
-              ))}
+          {portfolio.isLoading || portfolio.items.length === 0 ? (
+            <div className="flex-1 flex items-center justify-center text-widget-9 text-foreground-disabled">
+              {portfolio.isLoading ? '불러오는 중...' : '보유 종목 없음'}
             </div>
-          </div>
+          ) : (
+            <div className="flex items-center gap-2.5 flex-1 min-h-0">
+              <div
+                className="w-14 h-14 rounded-full shrink-0"
+                style={{ background: `conic-gradient(${conicStops})` }}
+              />
+              <div className="flex flex-col gap-1 min-w-0 flex-1">
+                {portfolio.items.map((item) => (
+                  <div key={item.name} className="flex items-center gap-1 min-w-0">
+                    <div className="w-1.5 h-1.5 rounded-full shrink-0" style={{ background: item.color }} />
+                    <span className="text-widget-10 text-foreground-secondary tracking-tight truncate">{item.name}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
         </>
       )}
 

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { Settings2 } from 'lucide-react'
 import StockAvatar from '@/components/ui/StockAvatar'
 import PriceChange from '@/components/ui/PriceChange'
@@ -155,46 +155,6 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
   const priceData = isOverseas && priceRaw
     ? { currentPrice: priceRaw.price, changeRate: priceRaw.rate, changeAmount: priceRaw.diff }
     : priceRaw
-
-  const queryClient = useQueryClient()
-
-  useEffect(() => {
-    if (!stockCode) return
-    const end = formatApiDate(new Date())
-    Object.values(PERIOD_CONFIG).forEach((cfg) => {
-      const effectiveCfgType = isOverseas ? (cfg.overseasType ?? cfg.type) : cfg.type
-      if (effectiveCfgType === 'minute') {
-        if (isOverseas) {
-          queryClient.prefetchQuery({
-            queryKey: ['foreign', 'minuteChart', stockCode, exchcd, cfg.nmin],
-            queryFn:  () => foreignMarketApi.getMinuteChart(stockCode, exchcd, { nmin: cfg.nmin }),
-            staleTime: 60_000,
-          })
-        } else {
-          queryClient.prefetchQuery({
-            queryKey: ['stock', 'minute-chart', stockCode, cfg.ncnt],
-            queryFn:  () => marketApi.getMinuteChart(stockCode, { ncnt: cfg.ncnt }),
-            staleTime: 60_000,
-          })
-        }
-      } else {
-        const start = formatApiDate(new Date(Date.now() - cfg.days * 24 * 60 * 60 * 1000))
-        if (isOverseas) {
-          queryClient.prefetchQuery({
-            queryKey: ['foreign', 'chart', cfg.foreignPeriod, stockCode, exchcd, start, end],
-            queryFn:  () => foreignMarketApi.getChart(stockCode, exchcd, { period: cfg.foreignPeriod, startDate: start, endDate: end }),
-            staleTime: 5 * 60 * 1000,
-          })
-        } else {
-          queryClient.prefetchQuery({
-            queryKey: ['stock', 'chart', cfg.period, stockCode, start, end],
-            queryFn:  () => marketApi.getChart(stockCode, { period: cfg.period, startDate: start, endDate: end }),
-            staleTime: 5 * 60 * 1000,
-          })
-        }
-      }
-    })
-  }, [stockCode, exchcd, isOverseas, queryClient])
 
   const periodCfg    = PERIOD_CONFIG[activePeriod]
   const effectiveType = isOverseas ? (periodCfg.overseasType ?? periodCfg.type) : periodCfg.type

--- a/src/components/widgets/StockChartWidget.jsx
+++ b/src/components/widgets/StockChartWidget.jsx
@@ -412,8 +412,8 @@ export default function StockChartWidget({ instanceId, variant = 'stock-sm', col
               { label: '거래량', val: stock.volume },
             ].map(({ label, val }) => (
               <div key={label} className="text-center">
-                <div className="text-widget-8 text-foreground-disabled">{label}</div>
-                <div className="text-widget-10 font-semibold text-foreground">{val}</div>
+                <div className="text-widget-9 text-foreground-disabled">{label}</div>
+                <div className="text-widget-11 font-semibold text-foreground">{val}</div>
               </div>
             ))}
           </div>

--- a/src/components/widgets/StockSelectModal.jsx
+++ b/src/components/widgets/StockSelectModal.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
 import { useQuery } from '@tanstack/react-query'
 import { X, Search } from 'lucide-react'
 import { marketApi } from '@/api/market'
@@ -19,7 +20,7 @@ export default function StockSelectModal({ currentCode, currentName, onSave, onC
     staleTime: 30_000,
   })
 
-  return (
+  return createPortal(
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
       onClick={onClose}
@@ -78,6 +79,7 @@ export default function StockSelectModal({ currentCode, currentName, onSave, onC
           ))}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   )
 }

--- a/src/components/widgets/TradeHistoryWidget.jsx
+++ b/src/components/widgets/TradeHistoryWidget.jsx
@@ -104,17 +104,19 @@ export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1
           {/* 좌: 캘린더 */}
           <div className="flex flex-col flex-1 min-h-0 min-w-0">
             <div className="grid grid-cols-7 gap-0.5 shrink-0 mb-1">
-              {WEEK_DAYS.map((d) => (
-                <div key={d} className="text-center text-[8px] font-semibold text-foreground-disabled">{d}</div>
+              {WEEK_DAYS.map((d, i) => (
+                <div key={d} className={cn('text-[8px] font-semibold text-center', i === 0 ? 'text-up' : i === 6 ? 'text-down' : 'text-foreground-disabled')}>{d}</div>
               ))}
             </div>
             <div className="grid grid-cols-7 gap-0.5 flex-1 min-h-0">
               {monthCells.map((d, i) => {
                 const k = d ? dateKey(new Date(year, month, d)) : null
                 const trades = k ? (tradeMap[k] ?? null) : null
+                const col = i % 7
+                const dateColor = col === 0 ? 'text-up' : col === 6 ? 'text-down' : 'text-foreground'
                 return (
-                  <div key={i} className="flex flex-col items-start rounded p-0.5">
-                    <span className={`text-widget-9 leading-none mb-px ${d ? 'text-foreground' : 'invisible'}`}>
+                  <div key={i} className="flex flex-col items-center rounded p-0.5">
+                    <span className={`text-widget-9 leading-none mb-px w-full text-center ${d ? dateColor : 'invisible'}`}>
                       {d ?? '0'}
                     </span>
                     {trades && trades.slice(0, 2).map((tr, j) => (
@@ -170,17 +172,18 @@ export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1
           <span className="text-widget-9 text-foreground-disabled">{monthLabel}</span>
         </div>
         <div className="grid grid-cols-7 gap-0.5 shrink-0 mb-1">
-          {WEEK_DAYS.map((d) => (
-            <div key={d} className="text-center text-[8px] font-semibold text-foreground-disabled">{d}</div>
+          {WEEK_DAYS.map((d, i) => (
+            <div key={d} className={cn('text-[8px] font-semibold text-center', i === 0 ? 'text-up' : i === 6 ? 'text-down' : 'text-foreground-disabled')}>{d}</div>
           ))}
         </div>
         <div className="grid grid-cols-7 gap-0.5 flex-1 min-h-0">
           {weekCells.map(({ d, key }, i) => {
             const trades = tradeMap[key] ?? null
             const visible = trades ? trades.slice(0, 5) : null
+            const dateColor = i === 0 ? 'text-up' : i === 6 ? 'text-down' : 'text-foreground'
             return (
               <div key={i} className="flex flex-col items-start rounded-lg p-1 overflow-hidden">
-                <span className="text-widget-9 leading-none mb-1 text-foreground shrink-0">{d}</span>
+                <span className={`text-widget-9 leading-none mb-1 shrink-0 w-full text-center ${dateColor}`}>{d}</span>
                 {visible && visible.map((tr, j) => (
                   <div key={j} className="flex items-center gap-0.5 w-full mb-0.5 shrink-0">
                     <div className={cn('w-0.5 rounded-full shrink-0 self-stretch', tr.buy ? 'bg-up' : 'bg-down')} />
@@ -205,17 +208,19 @@ export default function TradeHistoryWidget({ variant = 'trade-list', colSpan = 1
           <span className="text-widget-9 text-foreground-disabled">{monthLabel}</span>
         </div>
         <div className="grid grid-cols-7 gap-0.5 shrink-0 mb-1">
-          {WEEK_DAYS.map((d) => (
-            <div key={d} className="text-center text-[8px] font-semibold text-foreground-disabled">{d}</div>
+          {WEEK_DAYS.map((d, i) => (
+            <div key={d} className={cn('text-[8px] font-semibold text-center', i === 0 ? 'text-up' : i === 6 ? 'text-down' : 'text-foreground-disabled')}>{d}</div>
           ))}
         </div>
         <div className="grid grid-cols-7 gap-0.5 flex-1 min-h-0">
           {monthCells.map((d, i) => {
             const k = d ? `${year}-${String(month + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}` : null
             const trades = k ? (tradeMap[k] ?? null) : null
+            const col = i % 7
+            const dateColor = col === 0 ? 'text-up' : col === 6 ? 'text-down' : 'text-foreground'
             return (
-              <div key={i} className="flex flex-col items-start rounded p-0.5">
-                <span className={`text-widget-9 leading-none mb-px ${d ? 'text-foreground' : 'invisible'}`}>
+              <div key={i} className="flex flex-col items-center rounded p-0.5">
+                <span className={`text-widget-9 leading-none mb-px ${d ? dateColor : 'invisible'}`}>
                   {d ?? '0'}
                 </span>
                 {trades && trades.slice(0, 2).map((tr, j) => (

--- a/src/components/widgets/WatchlistEditModal.jsx
+++ b/src/components/widgets/WatchlistEditModal.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
 import { useQuery } from '@tanstack/react-query'
 import { X, Search, Heart } from 'lucide-react'
 import { marketApi } from '@/api/market'
@@ -46,9 +47,9 @@ export default function WatchlistEditModal({ items, onAdd, onRemove, onClose }) 
 
   const localSet = new Map(localItems.map((i) => [i.stockCode, i.isWatched]))
 
-  return (
+  return createPortal(
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      className="fixed inset-0 z-[1200] flex items-center justify-center bg-black/40"
       onClick={onClose}
     >
       <div
@@ -131,6 +132,7 @@ export default function WatchlistEditModal({ items, onAdd, onRemove, onClose }) 
           })}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -186,7 +186,7 @@
    Widget Font Scale Overrides
 ───────────────────────────────────────────── */
 [data-font-size="md"] {
-  --text-widget-6:  5px;
+  --text-widget-6:  7px;
   --text-widget-7:  8px;
   --text-widget-9:  10px;
   --text-widget-10: 11px;
@@ -202,7 +202,7 @@
   --text-widget-22: 24px;
 }
 [data-font-size="lg"] {
-  --text-widget-6:  7px;
+  --text-widget-6:  8px;
   --text-widget-7:  9px;
   --text-widget-9:  11px;
   --text-widget-10: 12px;

--- a/src/mocks/widgets.js
+++ b/src/mocks/widgets.js
@@ -64,11 +64,9 @@ export const WIDGET_TYPES = [
     id: 'exchange',
     name: '환율',
     category: '기타',
-    description: 'USD · JPY · EUR 실시간 환율',
+    description: 'USD 실시간 환율',
     variants: [
-      { id: 'exchange-sm',   label: '단일',  colSpan: 1, rowSpan: 1, preview: 'exchange-sm' },
-      { id: 'exchange-wide', label: '복합',  colSpan: 2, rowSpan: 1, preview: 'exchange-wide' },
-      { id: 'exchange-3x1',  label: '3통화', colSpan: 3, rowSpan: 1, preview: 'exchange-3x1' },
+      { id: 'exchange-sm', label: '단일', colSpan: 1, rowSpan: 1, preview: 'exchange-sm' },
     ],
   },
   {

--- a/src/mocks/widgets.js
+++ b/src/mocks/widgets.js
@@ -13,7 +13,7 @@ export const WIDGET_TYPES = [
     variants: [
       { id: 'balance-sm',  label: '소형',  colSpan: 1, rowSpan: 1, preview: 'balance-sm' },
       { id: 'balance-lg',  label: '와이드', colSpan: 2, rowSpan: 1, preview: 'balance-lg' },
-      { id: 'balance-3x1', label: '확장형', colSpan: 3, rowSpan: 1, preview: 'balance-3x1' },
+      { id: 'balance-3x1', label: '차트형', colSpan: 2, rowSpan: 2, preview: 'balance-3x1' },
     ],
   },
   {

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useCallback, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { Pencil, LayoutTemplate, X, ChevronRight, LayoutGrid, Plus } from 'lucide-react'
 import { useDashboardSave } from '@/hooks/useDashboardSync'
 import { useDroppable } from '@dnd-kit/core'
@@ -37,7 +38,7 @@ function PresetThumbnail({ widgets }) {
 }
 
 function PresetPickerModal({ onSelect, onClose }) {
-  return (
+  return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center p-6">
       <div className="absolute inset-0 bg-black/50 backdrop-blur-[6px]" onClick={onClose} />
 
@@ -77,7 +78,8 @@ function PresetPickerModal({ onSelect, onClose }) {
           ))}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   )
 }
 

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -106,6 +106,14 @@ export default function HomePage() {
   const { applyPageChanges } = useWidgetStore()
   const { mutate: saveDashboard } = useDashboardSave()
 
+  // 편집 모드 종료(완료·저장 또는 취소) 시 열려있는 모달 닫기
+  useEffect(() => {
+    if (!isEditMode) {
+      setIsPageEditOpen(false)
+      setIsPresetPickerOpen(false)
+    }
+  }, [isEditMode])
+
   function handleApplyPreset(preset) {
     const newId      = crypto.randomUUID()
     const newWidgets = preset.widgets.map((w) => ({ ...w, instanceId: crypto.randomUUID() }))


### PR DESCRIPTION
Closes #120

## 변경 요약
위젯 실 UI와 EditPanel 미리보기 간의 불일치, 모달 레이어 충돌, 일부 위젯 표시/상태 반영 이슈를 함께 정리했습니다.

## 주요 변경 사항

### 1) 위젯 UI 폴리시 개선
- 거래내역 위젯
  - 달력 요일/날짜 정렬 및 주말 색상 반영
  - EditPanel 미리보기 구조를 실 위젯과 정합화
- 실시간 순위 위젯
  - 탭(거래대금/급상승/거래량) 버튼 스케일 반영(소/중/대 폰트 설정 대응)
- 시황/종목 뉴스 위젯
  - 국내/해외 토글 라벨 및 사이징 보정
- 주가/차트 위젯
  - 장중 차트 좌우 흔들림 수정
  - 일부 수치 타이포 미세 조정
- 계좌 잔고 위젯
  - 레이아웃/정렬 개선

### 2) EditPanel 미리보기 정합화
- 주가/차트 미리보기를 캔들 형태로 개선
  - 캔들 개수/밀도 조정, 상승 흐름, 꼬리/몸통 형태 보정
  - 배경/라인 스타일 정리
- 종목별 뉴스, 실시간 순위, 거래내역 미리보기 UI를 실 위젯 구조에 가깝게 개선

### 3) 모달/레이어 및 편집 UX
- 관심종목 편집 모달
  - Portal 렌더링 + z-index 조정으로 Dashboard/EditPanel 위 레이어 보장
- 페이지 편집 모달
  - 완료/저장 시 변경 반영 보강
  - 최대 5개 제한 안내 추가
- 헤더
  - 로고 클릭 시 위젯 편집 모드 이탈 확인 모달 적용

### 4) StockChartWidget API 과호출 방지
- 페이지 로드 시 `1일/1주/1달/3달` 전 기간 prefetch 하던 로직 제거
- 현재 활성 탭(`activePeriod`) 데이터만 요청하도록 변경
- 목적: LS 증권 API 호출량 감소 및 호출 제한(차단) 리스크 완화
- 기대 효과
  - 초기 진입 시 불필요한 차트 API 호출 감소
  - 탭 전환 시점에 필요한 데이터만 fetch
  - 서버/클라이언트 모두 네트워크 부담 완화
 
### 5) 기타
- 환율 위젯 2x1·3x1 variant 제거, 1x1 정렬 개선
- 포트폴리오 위젯 빈 상태 처리 추가

## 확인 항목
- [ ] 편집 모드에서 각 위젯 미리보기와 실제 위젯 UI 구조가 유사한지
- [ ] 관심종목 편집 모달 오픈 시 EditPanel/Dashboard drag 상호작용이 차단되는지
- [ ] 소/중/대 폰트 설정 전환 시 탭/토글 크기 반영이 자연스러운지