### PR TITLE
feat(home): SectorSelectModal 연동 및 프리셋 적용 플로우 서버 기반으로 전환

### DIFF
--- a/src/api/dashboard.js
+++ b/src/api/dashboard.js
@@ -10,4 +10,10 @@ export const dashboardApi = {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     }),
+  applyPreset: (payload) =>
+    fetchWithAuth(`${BASE}/presets/apply`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }),
 }

--- a/src/components/layout/SectorSelectModal.jsx
+++ b/src/components/layout/SectorSelectModal.jsx
@@ -17,14 +17,18 @@ const THEMES = [
   { code: 'ROBOT',            displayName: '로봇' },
 ]
 
+const ERROR_MESSAGES = {
+  PAGE_LIMIT_EXCEEDED: '대시보드 페이지 수 초과로 적용할 수 없습니다',
+}
+
 export default function SectorSelectModal({ preset, onClose }) {
-  const [loading, setLoading] = useState(false)
-  const [error, setError]     = useState(null)
+  const [loadingCode, setLoadingCode] = useState(null)
+  const [error, setError]             = useState(null)
   const { loadFromServer, switchPage } = useWidgetStore()
   const queryClient = useQueryClient()
 
   async function handleSelect(theme) {
-    setLoading(true)
+    setLoadingCode(theme.code)
     setError(null)
     try {
       const payload = {
@@ -40,25 +44,26 @@ export default function SectorSelectModal({ preset, onClose }) {
         })),
       }
       const response = await dashboardApi.applyPreset(payload)
+      if (!response?.length) throw new Error('UNKNOWN')
       queryClient.setQueryData(['dashboard', 'me'], response)
       loadFromServer(response)
       const newPage = response[response.length - 1]
       switchPage(String(newPage.dashboardId))
       onClose()
     } catch (e) {
-      setError(e?.message ?? '오류가 발생했습니다')
-      setLoading(false)
+      setError(ERROR_MESSAGES[e?.message] ?? '오류가 발생했습니다')
+      setLoadingCode(null)
     }
   }
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-6">
-      <div className="absolute inset-0 bg-black/50 backdrop-blur-[6px]" onClick={!loading ? onClose : undefined} />
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-[6px]" onClick={!loadingCode ? onClose : undefined} />
 
       <div className="relative bg-surface rounded-[20px] p-7 w-[560px] max-w-full border border-stroke shadow-modal animate-modal-in">
         <div className="flex items-start justify-between mb-1">
           <div>
-            <h2 className="text-base font-extrabold text-foreground">섹터 선택</h2>
+            <h2 className="text-xl font-extrabold text-foreground">섹터 선택</h2>
             <p className="text-[11px] text-foreground-disabled mt-0.5">
               선택한 섹터의 상위 종목이 차트 위젯에 자동으로 설정됩니다
             </p>
@@ -66,7 +71,7 @@ export default function SectorSelectModal({ preset, onClose }) {
           <button
             aria-label="닫기"
             onClick={onClose}
-            disabled={loading}
+            disabled={!!loadingCode}
             className="w-7 h-7 rounded-full border border-stroke-input bg-surface-muted flex items-center justify-center text-foreground-tertiary hover:text-foreground transition-colors disabled:opacity-40"
           >
             <X className="w-3.5 h-3.5" />
@@ -78,7 +83,7 @@ export default function SectorSelectModal({ preset, onClose }) {
         </p>
 
         {error && (
-          <p className="mb-3 text-[11px] text-red-400">{error}</p>
+          <p className="mb-3 text-[11px] text-danger">{error}</p>
         )}
 
         <div className="grid grid-cols-5 gap-2">
@@ -86,10 +91,10 @@ export default function SectorSelectModal({ preset, onClose }) {
             <button
               key={theme.code}
               onClick={() => handleSelect(theme)}
-              disabled={loading}
+              disabled={!!loadingCode}
               className="flex items-center justify-center h-10 rounded-xl border border-stroke bg-surface-muted text-[11px] font-semibold text-foreground hover:border-primary hover:text-primary hover:bg-primary-light transition-all duration-150 disabled:opacity-40 disabled:cursor-not-allowed"
             >
-              {loading ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : theme.displayName}
+              {loadingCode === theme.code ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : theme.displayName}
             </button>
           ))}
         </div>

--- a/src/components/layout/SectorSelectModal.jsx
+++ b/src/components/layout/SectorSelectModal.jsx
@@ -1,0 +1,99 @@
+import { useState } from 'react'
+import { X, Loader2 } from 'lucide-react'
+import { useQueryClient } from '@tanstack/react-query'
+import { dashboardApi } from '@/api/dashboard'
+import useWidgetStore from '@/store/useWidgetStore'
+
+const THEMES = [
+  { code: 'SEMICONDUCTOR',    displayName: '반도체' },
+  { code: 'BATTERY',          displayName: '2차전지/배터리' },
+  { code: 'AUTOMOTIVE',       displayName: '자동차/전장' },
+  { code: 'IT_PLATFORM',      displayName: 'IT 플랫폼' },
+  { code: 'ENERGY_CHEMICAL',  displayName: '에너지/화학' },
+  { code: 'FINANCE',          displayName: '금융' },
+  { code: 'SHIPBUILDING',     displayName: '조선' },
+  { code: 'DEFENSE',          displayName: '방산' },
+  { code: 'MANUFACTURING',    displayName: '인프라 & 산업재' },
+  { code: 'ROBOT',            displayName: '로봇' },
+]
+
+export default function SectorSelectModal({ preset, onClose }) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError]     = useState(null)
+  const { loadFromServer, switchPage } = useWidgetStore()
+  const queryClient = useQueryClient()
+
+  async function handleSelect(theme) {
+    setLoading(true)
+    setError(null)
+    try {
+      const payload = {
+        presetName: preset.name,
+        theme: theme.code,
+        widgets: preset.widgets.map((w) => ({
+          widgetType: w.widgetTypeId,
+          positionX:  w.gridCol,
+          positionY:  w.gridRow,
+          width:      w.colSpan,
+          height:     w.rowSpan,
+          configJson: JSON.stringify({ variantId: w.variantId }),
+        })),
+      }
+      const response = await dashboardApi.applyPreset(payload)
+      queryClient.setQueryData(['dashboard', 'me'], response)
+      loadFromServer(response)
+      const newPage = response[response.length - 1]
+      switchPage(String(newPage.dashboardId))
+      onClose()
+    } catch (e) {
+      setError(e?.message ?? '오류가 발생했습니다')
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-6">
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-[6px]" onClick={!loading ? onClose : undefined} />
+
+      <div className="relative bg-surface rounded-[20px] p-7 w-[560px] max-w-full border border-stroke shadow-modal animate-modal-in">
+        <div className="flex items-start justify-between mb-1">
+          <div>
+            <h2 className="text-base font-extrabold text-foreground">섹터 선택</h2>
+            <p className="text-[11px] text-foreground-disabled mt-0.5">
+              선택한 섹터의 상위 종목이 차트 위젯에 자동으로 설정됩니다
+            </p>
+          </div>
+          <button
+            aria-label="닫기"
+            onClick={onClose}
+            disabled={loading}
+            className="w-7 h-7 rounded-full border border-stroke-input bg-surface-muted flex items-center justify-center text-foreground-tertiary hover:text-foreground transition-colors disabled:opacity-40"
+          >
+            <X className="w-3.5 h-3.5" />
+          </button>
+        </div>
+
+        <p className="text-[11px] text-foreground-tertiary mb-4">
+          <span className="font-semibold text-foreground">{preset.name}</span> 프리셋
+        </p>
+
+        {error && (
+          <p className="mb-3 text-[11px] text-red-400">{error}</p>
+        )}
+
+        <div className="grid grid-cols-5 gap-2">
+          {THEMES.map((theme) => (
+            <button
+              key={theme.code}
+              onClick={() => handleSelect(theme)}
+              disabled={loading}
+              className="flex items-center justify-center h-10 rounded-xl border border-stroke bg-surface-muted text-[11px] font-semibold text-foreground hover:border-primary hover:text-primary hover:bg-primary-light transition-all duration-150 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {loading ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : theme.displayName}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useCallback, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Pencil, LayoutTemplate, X, ChevronRight, LayoutGrid, Plus } from 'lucide-react'
-import { useDashboardSave } from '@/hooks/useDashboardSync'
 import { useDroppable } from '@dnd-kit/core'
 import LiveDot from '@/components/ui/LiveDot'
 import useEditModeStore from '@/store/useEditModeStore'
@@ -15,6 +14,7 @@ import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry'
 import { GRID_COLS, GRID_ROWS, GRID_GAP, MIN_GRID_WIDTH, MIN_GRID_HEIGHT, MIN_CELL_WIDTH, MIN_CELL_HEIGHT, gridElementRef } from '@/lib/gridConstants'
 import { DASHBOARD_PRESETS } from '@/data/dashboardPresets'
 import { PreviewContent } from '@/components/layout/EditPanel/WidgetSizeList'
+import SectorSelectModal from '@/components/layout/SectorSelectModal'
 
 function PresetThumbnail({ widgets }) {
   return (
@@ -105,8 +105,7 @@ export default function HomePage() {
   const { isAuthenticated, isRestoring } = useAuthStore()
   const [isPageEditOpen, setIsPageEditOpen]         = useState(false)
   const [isPresetPickerOpen, setIsPresetPickerOpen] = useState(false)
-  const { applyPageChanges } = useWidgetStore()
-  const { mutate: saveDashboard } = useDashboardSave()
+  const [selectedPresetForSector, setSelectedPresetForSector] = useState(null)
 
   // 편집 모드 종료(완료·저장 또는 취소) 시 열려있는 모달 닫기
   useEffect(() => {
@@ -117,12 +116,8 @@ export default function HomePage() {
   }, [isEditMode])
 
   function handleApplyPreset(preset) {
-    const newId      = crypto.randomUUID()
-    const newWidgets = preset.widgets.map((w) => ({ ...w, instanceId: crypto.randomUUID() }))
-    const newPages   = [...pages, { id: newId, name: preset.name, widgets: newWidgets }]
-    applyPageChanges(newPages, newId)
+    setSelectedPresetForSector(preset)
     setIsPresetPickerOpen(false)
-    saveDashboard()
   }
 
   // 로드 완료 전에는 위젯 미표시 (새로고침 flash 방지)
@@ -318,6 +313,12 @@ export default function HomePage() {
       <PresetPickerModal
         onSelect={handleApplyPreset}
         onClose={() => setIsPresetPickerOpen(false)}
+      />
+    )}
+    {selectedPresetForSector && (
+      <SectorSelectModal
+        preset={selectedPresetForSector}
+        onClose={() => setSelectedPresetForSector(null)}
       />
     )}
     </>


### PR DESCRIPTION
## 연관된 이슈
* Closes #122 

## 작업 내용
- 프리셋 적용 API 연동 (`POST /api/dashboards/presets/apply`)
- `SectorSelectModal` 컴포넌트 구현 — 10개 테마 섹터 선택 UI
- 프리셋 적용 플로우 변경: 클라이언트 직접 페이지 생성 → 섹터 선택 후 서버 응답 기반 적용으로 교체
- `useDashboardSave` 훅 의존 제거, 서버 응답을 `queryClient`에 직접 반영

### 스크린샷 (선택)

## 체크리스트

- [x] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항 (선택)

> 현재 `SectorSelectModal`의 에러 처리는 `e?.message`를 그대로 노출하는 방식입니다.

> 백엔드에서 `PAGE_LIMIT_EXCEEDED` 에러 코드가 추가된 것으로 알고 있는데, 해당 케이스에 대한 사용자 친화적 메시지 처리가 필요한지 의견 부탁드립니다.
