### PR TITLE
feat(chat-widget): 위젯-채팅 양방향 매핑 규격 통일

### DIFF
--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -17,6 +17,8 @@ import useEditModeStore from '@/store/useEditModeStore'
 import useGridStore from '@/store/useGridStore'
 import useAuthStore from '@/store/useAuthStore'
 import usePendingWidgetStore from '@/store/usePendingWidgetStore'
+import usePendingQueryStore from '@/store/usePendingQueryStore'
+import { getWidgetDefaultQuery } from '@/config/widgetShortcuts'
 import { useDashboardLoad } from '@/hooks/useDashboardSync'
 import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry'
 import { GRID_GAP, GRID_COLS, GRID_ROWS, gridElementRef } from '@/lib/gridConstants'
@@ -50,6 +52,7 @@ export default function AppShell() {
   } = useWidgetStore()
   const { resyncWiggle } = useEditModeStore()
   const clearPending = usePendingWidgetStore((s) => s.clearPending)
+  const setPendingQuery = usePendingQueryStore((s) => s.setPendingQuery)
   const { cellWidth, cellHeight } = useGridStore()
   const pointerPos = useRef({ x: 0, y: 0 })
   const dragAnchor = useRef({ colOffset: 0, rowOffset: 0 })
@@ -176,7 +179,7 @@ export default function AppShell() {
     if (!over && active.data.current?.type === 'new-widget') clearPhantom()
   }
 
-  function handleDragEnd({ active }) {
+  function handleDragEnd({ active, over }) {
     window.removeEventListener('pointermove', onPointerMove)
     dragAnchor.current = { colOffset: 0, rowOffset: 0 }
     const savedPhantom = phantomWidget
@@ -198,6 +201,12 @@ export default function AppShell() {
         applyPushAsidePlan(savedPhantom.pushAsidePlan)
       } else {
         moveWidgetTo(savedPhantom.activeId, savedPhantom.gridCol, savedPhantom.gridRow)
+      }
+    } else if (type === 'widget-to-chat') {
+      if (over?.id === 'chat-dropzone') {
+        const { widgetTypeId, config } = active.data.current
+        const query = getWidgetDefaultQuery(widgetTypeId, config)
+        if (query) setPendingQuery(query)
       }
     }
   }
@@ -238,6 +247,18 @@ export default function AppShell() {
         overlayContent = (
           <div className="opacity-90 shadow-widget-edit cursor-grabbing" style={{ width: ow, height: oh }}>
             <Comp variant={variant.id} colSpan={variant.colSpan} rowSpan={variant.rowSpan} />
+          </div>
+        )
+      }
+    } else if (type === 'widget-to-chat') {
+      const w = widgets.find((w) => w.instanceId === activeDrag.data.instanceId)
+      const Comp = w ? WIDGET_REGISTRY[w.widgetTypeId] : null
+      if (Comp && w) {
+        const ow = w.colSpan * cellWidth + (w.colSpan - 1) * GRID_GAP
+        const oh = w.rowSpan * cellHeight + (w.rowSpan - 1) * GRID_GAP
+        overlayContent = (
+          <div className="opacity-90 shadow-widget-edit cursor-grabbing" style={{ width: ow, height: oh }}>
+            <Comp variant={w.variantId} colSpan={w.colSpan} rowSpan={w.rowSpan} config={w.config} />
           </div>
         )
       }

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -19,7 +19,7 @@ import useAuthStore from '@/store/useAuthStore'
 import usePendingWidgetStore from '@/store/usePendingWidgetStore'
 import usePendingQueryStore from '@/store/usePendingQueryStore'
 import { getWidgetDefaultQuery } from '@/config/widgetShortcuts'
-import { useDashboardLoad } from '@/hooks/useDashboardSync'
+import { useDashboardLoad, useDashboardSave } from '@/hooks/useDashboardSync'
 import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry'
 import { GRID_GAP, GRID_COLS, GRID_ROWS, gridElementRef } from '@/lib/gridConstants'
 
@@ -51,6 +51,7 @@ export default function AppShell() {
     setIsDraggingNewWidget,
   } = useWidgetStore()
   const { resyncWiggle } = useEditModeStore()
+  const { mutate: saveDashboard } = useDashboardSave()
   const clearPending = usePendingWidgetStore((s) => s.clearPending)
   const setPendingQuery = usePendingQueryStore((s) => s.setPendingQuery)
   const { cellWidth, cellHeight } = useGridStore()
@@ -191,9 +192,10 @@ export default function AppShell() {
     const type = active.data.current?.type
 
     if (type === 'new-widget' && savedPhantom) {
-      const { widgetTypeId, variant } = active.data.current
-      addWidgetAt(widgetTypeId, variant, savedPhantom.gridCol, savedPhantom.gridRow)
+      const { widgetTypeId, variant, widgetConfig } = active.data.current
+      addWidgetAt(widgetTypeId, variant, savedPhantom.gridCol, savedPhantom.gridRow, widgetConfig)
       clearPending()
+      saveDashboard()
     } else if (type === 'new-widget') {
       // 그리드 밖에 드롭 → pending 유지 (사용자가 다시 시도할 수 있도록)
     } else if (type === 'existing-widget' && savedPhantom?.activeId) {

--- a/src/components/layout/ChatPanel.jsx
+++ b/src/components/layout/ChatPanel.jsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
+import { useDroppable } from "@dnd-kit/core";
 import { MessageCircle, Send } from "lucide-react";
 import WIDGET_SHORTCUTS from "@/config/widgetShortcuts";
 import ReactMarkdown from "react-markdown";
@@ -20,6 +21,7 @@ import { balanceApi } from "@/api/balance";
 import { orderApi, ORDER_SIDE, ORDER_KIND } from "@/api/order";
 import { exchangeApi } from "@/api/exchange";
 import usePinAuth from "@/hooks/usePinAuth";
+import usePendingQueryStore from "@/store/usePendingQueryStore";
 import ChatPinBubble from "@/components/layout/ChatPinBubble";
 import ChatExchangePinBubble from "@/components/layout/ChatExchangePinBubble";
 import { isForeignMarketType } from "@/features/invest/formatters";
@@ -766,6 +768,9 @@ export default function ChatPanel() {
   // 복원 완료 후 isAuthenticated의 이전 값 추적 (null = 복원 전)
   const prevIsAuthRef = useRef(null);
 
+  const { pendingQuery, consumePendingQuery } = usePendingQueryStore();
+  const { setNodeRef: setDropRef, isOver } = useDroppable({ id: 'chat-dropzone' });
+
 
   // 메시지 변경 시 sessionStorage에 저장
   useEffect(() => {
@@ -1107,6 +1112,14 @@ export default function ChatPanel() {
     }
   }, [appendExchangeCardMessage, appendOrderCardMessage]);
 
+  // 대시보드 위젯 → 채팅 드롭 시 자동 질의 전송
+  useEffect(() => {
+    if (!pendingQuery || !isAuthenticated) return
+    const query = pendingQuery
+    consumePendingQuery()
+    handleSend(query)
+  }, [pendingQuery, isAuthenticated, consumePendingQuery, handleSend])
+
   const handleRetry = useCallback(() => {
     const text = lastFailedTextRef.current;
     if (!text) return;
@@ -1332,7 +1345,7 @@ export default function ChatPanel() {
   }
 
   return (
-    <>
+    <div ref={setDropRef} className={cn('flex flex-col h-full', isOver && 'ring-2 ring-primary ring-inset')}>
       <ChatHeader />
       {isRestoring || isAuthenticated ? (
         <>
@@ -1361,13 +1374,13 @@ export default function ChatPanel() {
               onChange={setDraft}
               onSend={handleSend}
               onSuggestionKeyDown={handleSuggestionKeyDown}
+              isDisabled={isTyping}
             />
           </div>
         </>
       ) : (
         <LoginPrompt />
       )}
-
-    </>
+    </div>
   );
 }

--- a/src/components/layout/ChatPanel.jsx
+++ b/src/components/layout/ChatPanel.jsx
@@ -31,6 +31,25 @@ import { cn } from "@/lib/cn";
 import { getStockLogoUrl } from "@/lib/stockLogo";
 
 const EXCHANGE_RESULT_DELAY_MS = 1400
+const INFO_FALLBACK_WIDGET_TYPES = ['portfolio', 'trade-history', 'market-overview', 'index', 'ranking', 'balance', 'exchange']
+
+function toInfoTypeFromWidgetType(widgetTypeId) {
+  if (widgetTypeId === 'trade-history') return 'trade_history'
+  if (widgetTypeId === 'market-overview') return 'market_overview'
+  if (widgetTypeId === 'exchange') return 'exchange_rate'
+  return widgetTypeId
+}
+
+function inferInfoTypeFromPrompt(prompt = '') {
+  const keyword = prompt.trim().toLowerCase()
+  if (!keyword) return null
+  const matched = WIDGET_SHORTCUTS.find((item) =>
+    INFO_FALLBACK_WIDGET_TYPES.includes(item.widgetTypeId) &&
+    item.keywords.some((k) => keyword.includes(k) || k.includes(keyword))
+  )
+  if (!matched) return null
+  return toInfoTypeFromWidgetType(matched.widgetTypeId)
+}
 
 function getTimestamp() {
   return new Date().toLocaleTimeString("ko-KR", {
@@ -1035,7 +1054,7 @@ export default function ChatPanel() {
       const data = await chatApi.sendMessage(text);
       lastFailedTextRef.current = null;
 
-      const INFO_CARD_TYPES = ['index', 'ranking', 'balance', 'exchange_rate', 'market_overview'];
+      const INFO_CARD_TYPES = ['index', 'ranking', 'balance', 'exchange_rate', 'market_overview', 'portfolio', 'trade_history', 'trade-history'];
       const NEWS_CARD_TYPES = ['stock_news'];
 
       if (data.type === "order" && data.stock_code) {
@@ -1079,12 +1098,13 @@ export default function ChatPanel() {
           },
         ]);
       } else if (data.reply && /━/.test(data.reply)) {
+        const inferredInfoType = inferInfoTypeFromPrompt(text)
         setMessages((prev) => [
           ...prev,
           {
             id: Date.now(),
             type: 'info_card',
-            infoType: 'market_overview',
+            infoType: inferredInfoType ?? 'market_overview',
             text: data.reply,
             time: getTimestamp(),
           },

--- a/src/components/layout/ChatPanel.jsx
+++ b/src/components/layout/ChatPanel.jsx
@@ -45,7 +45,7 @@ function inferInfoTypeFromPrompt(prompt = '') {
   if (!keyword) return null
   const matched = WIDGET_SHORTCUTS.find((item) =>
     INFO_FALLBACK_WIDGET_TYPES.includes(item.widgetTypeId) &&
-    item.keywords.some((k) => keyword.includes(k) || k.includes(keyword))
+    item.keywords.some((k) => keyword.includes(k))
   )
   if (!matched) return null
   return toInfoTypeFromWidgetType(matched.widgetTypeId)

--- a/src/components/layout/ChatPanel.jsx
+++ b/src/components/layout/ChatPanel.jsx
@@ -391,7 +391,7 @@ function ChatMessages({ messages, isTyping, bottomRef, onRetry, onOrderAction, o
                 <ChatWidgetAdder msgId={msg.id} widgetTypeId="stock-chart" />
               </div>
               {isThisPending ? (
-                <DraggableChatCard msgId={msg.id} widgetTypeId={pendingWidgetTypeId} variant={pendingVariant}>
+                <DraggableChatCard msgId={msg.id} widgetTypeId={pendingWidgetTypeId} variant={pendingVariant} widgetConfig={{ stockCode: msg.stock.stockCode, stockName: msg.stock.name, marketType: msg.stock.marketType, exchangeCode: msg.stock.exchangeCode }}>
                   <ChatOrderCard
                     {...msg.stock}
                     onBuy={(qty) => onOrderAction?.(msg.id, msg.stock, 'buy', qty, msg.requestKeyBase)}
@@ -491,7 +491,7 @@ function ChatMessages({ messages, isTyping, bottomRef, onRetry, onOrderAction, o
                 <ChatWidgetAdder msgId={msg.id} widgetTypeId="stock-chart" />
               </div>
               {isThisPending ? (
-                <DraggableChatCard msgId={msg.id} widgetTypeId={pendingWidgetTypeId} variant={pendingVariant}>
+                <DraggableChatCard msgId={msg.id} widgetTypeId={pendingWidgetTypeId} variant={pendingVariant} widgetConfig={{ stockCode: msg.stockCode, stockName: msg.stockName, marketType: msg.marketType, exchangeCode: msg.exchangeCode }}>
                   <ChatStockCard
                     stockCode={msg.stockCode}
                     stockName={msg.stockName}
@@ -525,7 +525,7 @@ function ChatMessages({ messages, isTyping, bottomRef, onRetry, onOrderAction, o
                   <ChatWidgetAdder msgId={msg.id} widgetTypeId="stock-news" />
                 </div>
                 {isThisPending ? (
-                  <DraggableChatCard msgId={msg.id} widgetTypeId={pendingWidgetTypeId} variant={pendingVariant}>
+                  <DraggableChatCard msgId={msg.id} widgetTypeId={pendingWidgetTypeId} variant={pendingVariant} widgetConfig={{ stockCode: msg.stockCode, stockName: msg.stockName }}>
                     <ChatNewsCard text={msg.text} stockCode={msg.stockCode} stockName={msg.stockName} />
                   </DraggableChatCard>
                 ) : (

--- a/src/components/layout/ChatWidgetAdder.jsx
+++ b/src/components/layout/ChatWidgetAdder.jsx
@@ -9,6 +9,9 @@ const INFOCARD_WIDGET_MAP = {
   index:            'index',
   ranking:          'ranking',
   market_overview:  'market-overview',
+  portfolio:        'portfolio',
+  trade_history:    'trade-history',
+  'trade-history':  'trade-history',
 }
 
 /** info_card infoType → widgetTypeId */

--- a/src/components/layout/DraggableChatCard.jsx
+++ b/src/components/layout/DraggableChatCard.jsx
@@ -5,10 +5,10 @@ import { CSS } from '@dnd-kit/utilities'
  * 채팅 카드에서 위젯 크기를 선택했을 때 카드 전체를 드래거블 + 흔들림 상태로 만드는 래퍼.
  * AppShell의 DndContext 안에서 동작하며, 드롭 시 new-widget 타입으로 처리된다.
  */
-export default function DraggableChatCard({ msgId, widgetTypeId, variant, children }) {
+export default function DraggableChatCard({ msgId, widgetTypeId, variant, widgetConfig, children }) {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
     id: `chat-widget-${msgId}`,
-    data: { type: 'new-widget', widgetTypeId, variant },
+    data: { type: 'new-widget', widgetTypeId, variant, widgetConfig },
   })
 
   const style = transform ? { transform: CSS.Translate.toString(transform) } : undefined

--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -394,13 +394,10 @@ export function PreviewContent({ type }) {
               <span className="px-1.5 py-px text-[7px] font-semibold rounded text-foreground-disabled">해외</span>
             </div>
           </div>
-          <div className="flex flex-col">
-            {['美 CPI 예상치 하회… 나스닥 1% 상승', '外人 순매수 4,200억 · 반도체↑', '원달러 1,378원 소폭 하락'].map((title, i) => (
-              <div key={i} className="flex items-start gap-1.5 py-1 border-b border-stroke last:border-b-0">
-                <span className="text-[8px] font-bold text-primary shrink-0">{i + 1}</span>
-                <p className="text-[8px] text-foreground leading-snug line-clamp-2">{title}</p>
-              </div>
-            ))}
+          <div className="flex items-start py-1.5 border-b border-stroke last:border-b-0">
+            <p className="text-[8px] text-foreground leading-snug line-clamp-6">
+              美 CPI 예상치 하회… 나스닥 1% 상승, 인플레이션 둔화 기대에 기술주 중심 매수세가 유입되며 반도체·소프트웨어 중심으로 상승 폭 확대
+            </p>
           </div>
         </div>
       )
@@ -959,23 +956,22 @@ export function PreviewContent({ type }) {
         <div className="flex flex-col h-full">
           <div className="flex items-center justify-between mb-1 shrink-0">
             <span className="text-[9px] font-semibold text-foreground-disabled uppercase tracking-[.04em]">오늘의 시황</span>
-            <div className="flex gap-1">
-              <span className="px-1.5 py-px text-[7px] font-semibold rounded bg-primary text-white">국내</span>
-              <span className="px-1.5 py-px text-[7px] font-semibold rounded text-foreground-disabled">해외</span>
-            </div>
           </div>
-          <div className="flex flex-col flex-1 min-h-0 overflow-y-auto">
-            {[
-              { title: '美 CPI 예상치 하회… 나스닥 1% 상승', desc: '인플레이션 둔화. AI 관련주 반등.' },
-              { title: '外人 순매수 4,200억 · 반도체↑',      desc: '삼성·SK하이닉스 강세.' },
-              { title: '원달러 1,378원 소폭 하락',            desc: '금리 인하 기대감 반영.' },
-              { title: '美 연준 의사록 공개… 금리 동결 시사', desc: '시장 안도감 회복.' },
-            ].map(({ title, desc }, i) => (
-              <div key={i} className="flex flex-col gap-0.5 py-1.5 border-b border-stroke last:border-b-0 pl-1.5 border-l-2 border-l-transparent">
-                <p className="text-[9px] font-semibold text-foreground leading-snug">{title}</p>
-                <p className="text-[8px] text-foreground-disabled leading-snug">{desc}</p>
+          <div className="flex flex-col flex-1 min-h-0 gap-2">
+            <div>
+              <div className="text-[8px] font-semibold text-foreground-disabled uppercase tracking-[.04em]">국내 시황</div>
+              <div className="mt-0.5 flex flex-col gap-0.5 py-1.5 border-b border-stroke pl-1.5 border-l-2 border-l-transparent">
+                <p className="text-[9px] font-semibold text-foreground leading-snug">外人 순매수 4,200억 · 반도체↑</p>
+                <p className="text-[8px] text-foreground-disabled leading-snug">삼성·SK하이닉스 강세, 코스피 상승 마감.</p>
               </div>
-            ))}
+            </div>
+            <div>
+              <div className="text-[8px] font-semibold text-foreground-disabled uppercase tracking-[.04em]">해외 시황</div>
+              <div className="mt-0.5 flex flex-col gap-0.5 py-1.5 border-b border-stroke pl-1.5 border-l-2 border-l-transparent">
+                <p className="text-[9px] font-semibold text-foreground leading-snug">美 CPI 예상치 하회… 나스닥 1% 상승</p>
+                <p className="text-[8px] text-foreground-disabled leading-snug">인플레이션 둔화 기대, 기술주 중심 반등.</p>
+              </div>
+            </div>
           </div>
         </div>
       )

--- a/src/components/widgets/MarketOverviewWidget.jsx
+++ b/src/components/widgets/MarketOverviewWidget.jsx
@@ -40,17 +40,15 @@ function NewsCard({ item, showSummary = false, onClickNews }) {
   )
 }
 
-function NewsListCompact({ items, onClickNews }) {
-  return items.map((item, i) => (
+function NewsSingleCompact({ item, onClickNews }) {
+  return (
     <div
-      key={item.newsId ?? i}
-      className="flex items-start gap-1.5 py-1 border-b border-stroke last:border-b-0 cursor-pointer pl-2 border-l-2 border-l-transparent hover:border-l-primary transition-colors"
+      className="flex items-start py-1.5 border-b border-stroke last:border-b-0 cursor-pointer pl-2 border-l-2 border-l-transparent hover:border-l-primary transition-colors"
       onClick={(e) => { e.stopPropagation(); onClickNews(item.newsId) }}
     >
-      <span className="text-widget-9 font-bold text-primary mt-[1px] shrink-0">{i + 1}</span>
-      <p className="text-widget-10 text-foreground leading-snug line-clamp-2">{item.title}</p>
+      <p className="text-widget-10 text-foreground leading-snug line-clamp-6">{item.title}</p>
     </div>
-  ))
+  )
 }
 
 export default function MarketOverviewWidget({ instanceId, variant = 'market-sm', colSpan = 1, rowSpan = 1, config = {}, onDelete }) {
@@ -72,8 +70,8 @@ export default function MarketOverviewWidget({ instanceId, variant = 'market-sm'
     openDetail({ widgetTypeId: 'market-overview', config: { tab } })
   }
 
-  function handleNewsClick(newsId) {
-    openDetail({ widgetTypeId: 'market-overview', config: { tab, newsId } })
+  function handleNewsClick(newsId, nextTab = tab) {
+    openDetail({ widgetTypeId: 'market-overview', config: { tab: nextTab, newsId } })
   }
 
   const tabBar = (
@@ -101,16 +99,38 @@ export default function MarketOverviewWidget({ instanceId, variant = 'market-sm'
   const loading = <div className="text-widget-10 text-foreground-disabled py-2">불러오는 중...</div>
 
   if (variant === 'market-2x2') {
+    const krTop = krNews[0] ?? null
+    const usTop = usNews[0] ?? null
+    const sectionTitleClass = 'text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase'
+    const sectionCardClass = 'flex flex-col gap-0.5 py-2 border-b border-stroke last:border-b-0 cursor-pointer pl-2 border-l-2 border-l-transparent hover:border-l-primary transition-colors'
     return (
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
         <div className="flex items-center justify-between mb-1 shrink-0">
           <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">오늘의 시황</span>
-          {tabBar}
         </div>
-        <div className="flex-1 min-h-0 overflow-y-auto">
-          {isLoading ? loading : !items.length ? empty : items.slice(0, 4).map((item, i) => (
-            <NewsCard key={item.newsId ?? i} item={item} showSummary onClickNews={handleNewsClick} />
-          ))}
+        <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-2">
+          <section>
+            <h4 className={sectionTitleClass}>국내 시황</h4>
+            <div className="mt-0.5">
+              {isLoading ? loading : !krTop ? empty : (
+                <div className={sectionCardClass} onClick={(e) => { e.stopPropagation(); handleNewsClick(krTop.newsId, 'kr') }}>
+                  <p className="text-widget-11 font-semibold text-foreground leading-snug line-clamp-2">{krTop.title}</p>
+                  {krTop.oneLineSummary && <p className="text-[9.5px] text-foreground-secondary leading-relaxed line-clamp-2">{krTop.oneLineSummary}</p>}
+                </div>
+              )}
+            </div>
+          </section>
+          <section>
+            <h4 className={sectionTitleClass}>해외 시황</h4>
+            <div className="mt-0.5">
+              {isLoading ? loading : !usTop ? empty : (
+                <div className={sectionCardClass} onClick={(e) => { e.stopPropagation(); handleNewsClick(usTop.newsId, 'us') }}>
+                  <p className="text-widget-11 font-semibold text-foreground leading-snug line-clamp-2">{usTop.title}</p>
+                  {usTop.oneLineSummary && <p className="text-[9.5px] text-foreground-secondary leading-relaxed line-clamp-2">{usTop.oneLineSummary}</p>}
+                </div>
+              )}
+            </div>
+          </section>
         </div>
       </WidgetCard>
     )
@@ -140,7 +160,7 @@ export default function MarketOverviewWidget({ instanceId, variant = 'market-sm'
         {tabBar}
       </div>
       <div className="flex-1 min-h-0 overflow-y-auto">
-        {isLoading ? loading : !items.length ? empty : <NewsListCompact items={items} onClickNews={handleNewsClick} />}
+        {isLoading ? loading : !items.length ? empty : <NewsSingleCompact item={items[0]} onClickNews={handleNewsClick} />}
       </div>
     </WidgetCard>
   )

--- a/src/components/widgets/MarketOverviewWidget.jsx
+++ b/src/components/widgets/MarketOverviewWidget.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import WidgetCard from './WidgetCard'
 import useLatestNews from '@/features/market/useLatestNews'
 import useWidgetDetailStore from '@/store/useWidgetDetailStore'
+import useWidgetStore from '@/store/useWidgetStore'
 import { cn } from '@/lib/cn'
 
 const TABS = [
@@ -51,11 +52,17 @@ function NewsListCompact({ items, onClickNews }) {
   ))
 }
 
-export default function MarketOverviewWidget({ variant = 'market-sm', colSpan = 1, rowSpan = 1, onDelete }) {
-  const [tab, setTab] = useState('kr')
+export default function MarketOverviewWidget({ instanceId, variant = 'market-sm', colSpan = 1, rowSpan = 1, config = {}, onDelete }) {
+  const [tab, setTab] = useState(() => config.tab ?? 'kr')
   const { krNews, usNews, isLoading } = useLatestNews(10)
   const items = tab === 'kr' ? krNews : usNews
   const openDetail = useWidgetDetailStore((s) => s.open)
+  const updateWidgetConfig = useWidgetStore((s) => s.updateWidgetConfig)
+
+  function handleTabChange(nextTab) {
+    setTab(nextTab)
+    if (instanceId) updateWidgetConfig(instanceId, { tab: nextTab })
+  }
 
   function handleWidgetClick() {
     openDetail({ widgetTypeId: 'market-overview', config: { tab } })
@@ -71,7 +78,7 @@ export default function MarketOverviewWidget({ variant = 'market-sm', colSpan = 
         <button
           key={t.key}
           type="button"
-          onClick={(e) => { e.stopPropagation(); setTab(t.key) }}
+          onClick={(e) => { e.stopPropagation(); handleTabChange(t.key) }}
           className={cn(
             'px-1.5 py-px font-semibold rounded transition-colors',
             tab === t.key

--- a/src/components/widgets/MarketOverviewWidget.jsx
+++ b/src/components/widgets/MarketOverviewWidget.jsx
@@ -5,6 +5,7 @@ import useWidgetDetailStore from '@/store/useWidgetDetailStore'
 import useWidgetStore from '@/store/useWidgetStore'
 import { cn } from '@/lib/cn'
 
+const STORAGE_KEY_ACTIVE_TAB = 'marketOverviewWidget.activeTab'
 const TABS = [
   { key: 'kr', label: '국내' },
   { key: 'us', label: '해외' },
@@ -53,7 +54,9 @@ function NewsListCompact({ items, onClickNews }) {
 }
 
 export default function MarketOverviewWidget({ instanceId, variant = 'market-sm', colSpan = 1, rowSpan = 1, config = {}, onDelete }) {
-  const [tab, setTab] = useState(() => config.tab ?? 'kr')
+  const [tab, setTab] = useState(
+    () => localStorage.getItem(STORAGE_KEY_ACTIVE_TAB) ?? config.tab ?? 'kr'
+  )
   const { krNews, usNews, isLoading } = useLatestNews(10)
   const items = tab === 'kr' ? krNews : usNews
   const openDetail = useWidgetDetailStore((s) => s.open)
@@ -61,6 +64,7 @@ export default function MarketOverviewWidget({ instanceId, variant = 'market-sm'
 
   function handleTabChange(nextTab) {
     setTab(nextTab)
+    localStorage.setItem(STORAGE_KEY_ACTIVE_TAB, nextTab)
     if (instanceId) updateWidgetConfig(instanceId, { tab: nextTab })
   }
 

--- a/src/components/widgets/SortableWidgetCard.jsx
+++ b/src/components/widgets/SortableWidgetCard.jsx
@@ -20,6 +20,7 @@ export default function SortableWidgetCard({
   gridRow,
   widgetTypeId,
   config = {},
+  canDragToChat = true,
   children,
 }) {
   const { isEditMode, widgetDragLockCount } = useEditModeStore()
@@ -44,7 +45,7 @@ export default function SortableWidgetCard({
     setNodeRef: setHandleRef,
   } = useDraggable({
     id: `wtc-handle-${instanceId}`,
-    disabled: isEditMode || isDragLocked,
+    disabled: isEditMode || isDragLocked || !canDragToChat,
     data: { type: 'widget-to-chat', instanceId, widgetTypeId, config },
   })
 
@@ -71,7 +72,7 @@ export default function SortableWidgetCard({
       {children}
 
       {/* 비편집모드 hover 핸들 — widget-to-chat drag 진입점 */}
-      {!isEditMode && (
+      {!isEditMode && canDragToChat && (
         <button
           ref={setHandleRef}
           aria-label="채팅으로 질문하기"

--- a/src/components/widgets/SortableWidgetCard.jsx
+++ b/src/components/widgets/SortableWidgetCard.jsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 import { useDraggable, useDroppable } from '@dnd-kit/core'
-import { GripVertical } from 'lucide-react'
+import { Grid2X2Plus } from 'lucide-react'
 import { cn } from '@/lib/cn'
 import useEditModeStore from '@/store/useEditModeStore'
 
@@ -84,7 +84,7 @@ export default function SortableWidgetCard({
           {...handleAttrs}
           {...handleListeners}
         >
-          <GripVertical size={13} />
+          <Grid2X2Plus size={13} />
         </button>
       )}
     </div>

--- a/src/components/widgets/SortableWidgetCard.jsx
+++ b/src/components/widgets/SortableWidgetCard.jsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 import { useDraggable, useDroppable } from '@dnd-kit/core'
+import { GripVertical } from 'lucide-react'
 import { cn } from '@/lib/cn'
 import useEditModeStore from '@/store/useEditModeStore'
 
@@ -7,13 +8,24 @@ import useEditModeStore from '@/store/useEditModeStore'
  * 대시보드 위젯을 dnd-kit draggable + droppable item으로 래핑.
  * - SortableContext/useSortable 미사용 → droppableRects 구독 루프 방지
  * - grid col-span / row-span 처리
- * - isEditMode일 때만 drag 활성화
+ * - isEditMode일 때만 카드 전체 drag 활성화 (existing-widget)
+ * - 비편집모드에서 hover 시 핸들 버튼만 drag 활성화 (widget-to-chat)
  * - isDragging 시 원본 자리 placeholder 유지 (opacity: 0)
  */
-export default function SortableWidgetCard({ instanceId, colSpan = 1, rowSpan = 1, gridCol, gridRow, children }) {
+export default function SortableWidgetCard({
+  instanceId,
+  colSpan = 1,
+  rowSpan = 1,
+  gridCol,
+  gridRow,
+  widgetTypeId,
+  config = {},
+  children,
+}) {
   const { isEditMode, widgetDragLockCount } = useEditModeStore()
   const isDragLocked = widgetDragLockCount > 0
 
+  // 편집모드 전용 — 카드 전체 draggable (existing-widget)
   const { attributes, listeners, setNodeRef: setDraggableRef, isDragging } = useDraggable({
     id: instanceId,
     disabled: !isEditMode || isDragLocked,
@@ -23,6 +35,17 @@ export default function SortableWidgetCard({ instanceId, colSpan = 1, rowSpan = 
   const { setNodeRef: setDroppableRef } = useDroppable({
     id: instanceId,
     data: { type: 'existing-widget', instanceId },
+  })
+
+  // 비편집모드 전용 — 핸들 버튼 draggable (widget-to-chat)
+  const {
+    attributes: handleAttrs,
+    listeners: handleListeners,
+    setNodeRef: setHandleRef,
+  } = useDraggable({
+    id: `wtc-handle-${instanceId}`,
+    disabled: isEditMode || isDragLocked,
+    data: { type: 'widget-to-chat', instanceId, widgetTypeId, config },
   })
 
   const setNodeRef = useCallback(
@@ -36,7 +59,7 @@ export default function SortableWidgetCard({ instanceId, colSpan = 1, rowSpan = 
   return (
     <div
       ref={setNodeRef}
-      className={cn('h-full', isEditMode && !isDragLocked && 'cursor-grab', isDragging && 'opacity-0')}
+      className={cn('relative h-full group', isEditMode && !isDragLocked && 'cursor-grab', isDragging && 'opacity-0')}
       style={
         gridCol && gridRow
           ? { gridColumn: `${gridCol} / span ${colSpan}`, gridRow: `${gridRow} / span ${rowSpan}` }
@@ -46,6 +69,24 @@ export default function SortableWidgetCard({ instanceId, colSpan = 1, rowSpan = 
       {...listeners}
     >
       {children}
+
+      {/* 비편집모드 hover 핸들 — widget-to-chat drag 진입점 */}
+      {!isEditMode && (
+        <button
+          ref={setHandleRef}
+          aria-label="채팅으로 질문하기"
+          className={cn(
+            'absolute top-2 right-2 z-10 p-1 rounded',
+            'opacity-0 group-hover:opacity-100 transition-opacity duration-150',
+            'bg-surface border border-stroke text-foreground-secondary',
+            'hover:text-primary cursor-grab active:cursor-grabbing',
+          )}
+          {...handleAttrs}
+          {...handleListeners}
+        >
+          <GripVertical size={13} />
+        </button>
+      )}
     </div>
   )
 }

--- a/src/components/widgets/StockNewsWidget.jsx
+++ b/src/components/widgets/StockNewsWidget.jsx
@@ -6,18 +6,19 @@ import useStockNews from '@/features/market/useStockNews'
 import useWidgetStore from '@/store/useWidgetStore'
 import useEditModeStore from '@/store/useEditModeStore'
 import useWidgetDetailStore from '@/store/useWidgetDetailStore'
+import { useDashboardSave } from '@/hooks/useDashboardSync'
 
 const DEFAULT_STOCK_NEWS_CODE = '055550'
 const DEFAULT_STOCK_NEWS_NAME = '신한지주'
 
-function StockChip({ name, onClick }) {
+function StockChip({ name, onClick, className = '' }) {
   return (
     <button
       onClick={onClick}
-      className="flex items-center gap-0.5 text-widget-9 font-semibold text-primary shrink-0 hover:opacity-70"
+      className={`flex items-center gap-0.5 text-widget-9 font-semibold text-primary min-w-0 shrink hover:opacity-70 ${className}`}
     >
-      {name ?? '종목 선택'}
-      <ChevronDown size={10} />
+      <span className="truncate">{name ?? '종목 선택'}</span>
+      <ChevronDown size={10} className="shrink-0" />
     </button>
   )
 }
@@ -66,6 +67,7 @@ function NewsListCompact({ items, onClickNews }) {
 export default function StockNewsWidget({ instanceId, variant = 'stock-news-sm', colSpan = 1, rowSpan = 1, config = {}, onDelete }) {
   const [showModal, setShowModal] = useState(false)
   const updateWidgetConfig = useWidgetStore((s) => s.updateWidgetConfig)
+  const { mutate: saveDashboard } = useDashboardSave()
   const { lockWidgetDrag, unlockWidgetDrag } = useEditModeStore()
   const openDetail = useWidgetDetailStore((s) => s.open)
 
@@ -83,6 +85,7 @@ export default function StockNewsWidget({ instanceId, variant = 'stock-news-sm',
 
   function handleStockSave({ stockCode: newCode, stockName: newName }) {
     updateWidgetConfig(instanceId, { stockCode: newCode, stockName: newName })
+    saveDashboard()
     setShowModal(false)
   }
 
@@ -98,6 +101,7 @@ export default function StockNewsWidget({ instanceId, variant = 'stock-news-sm',
   const chip = (
     <StockChip
       name={stockName}
+      className="max-w-[56%]"
       onClick={(e) => { e.stopPropagation(); setShowModal(true) }}
     />
   )
@@ -117,8 +121,8 @@ export default function StockNewsWidget({ instanceId, variant = 'stock-news-sm',
   if (variant === 'stock-news-2x2') {
     return (
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
-        <div className="flex items-center justify-between mb-1 shrink-0">
-          <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 뉴스</span>
+        <div className="flex items-center justify-between gap-1 mb-1 shrink-0 min-w-0">
+          <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase whitespace-nowrap shrink-0">종목별 뉴스</span>
           {chip}
         </div>
         <div className="flex-1 min-h-0 overflow-y-auto">
@@ -134,8 +138,8 @@ export default function StockNewsWidget({ instanceId, variant = 'stock-news-sm',
   if (variant === 'stock-news-wide') {
     return (
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
-        <div className="flex items-center justify-between mb-1 shrink-0">
-          <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 뉴스</span>
+        <div className="flex items-center justify-between gap-1 mb-1 shrink-0 min-w-0">
+          <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase whitespace-nowrap shrink-0">종목별 뉴스</span>
           {chip}
         </div>
         <div className="flex-1 min-h-0 overflow-y-auto">
@@ -151,8 +155,8 @@ export default function StockNewsWidget({ instanceId, variant = 'stock-news-sm',
   /* stock-news-sm */
   return (
     <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
-      <div className="flex items-center justify-between mb-1 shrink-0">
-        <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 뉴스</span>
+      <div className="flex items-center justify-between gap-1 mb-1 shrink-0 min-w-0">
+        <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase whitespace-nowrap shrink-0">종목별 뉴스</span>
         {chip}
       </div>
       <div className="flex-1 min-h-0 overflow-y-auto">

--- a/src/config/widgetShortcuts.js
+++ b/src/config/widgetShortcuts.js
@@ -83,5 +83,9 @@ export function getWidgetDefaultQuery(widgetTypeId, config = {}) {
     const name = config.stockName ?? null
     return name ? `${name} 주가 알려줘` : '주가 차트 보여줘'
   }
+  if (widgetTypeId === 'stock-news') {
+    const name = config.stockName ?? null
+    return name ? `${name} 종목 뉴스 알려줘` : '종목 뉴스 알려줘'
+  }
   return WIDGET_SHORTCUTS.find((s) => s.widgetTypeId === widgetTypeId)?.defaultQuery ?? null
 }

--- a/src/config/widgetShortcuts.js
+++ b/src/config/widgetShortcuts.js
@@ -78,14 +78,25 @@ const WIDGET_SHORTCUTS = [
 
 export default WIDGET_SHORTCUTS
 
+// StockChartWidget / StockNewsWidget의 폴백 로직과 동일하게 유지
+const STOCK_NAME_BY_ID = { shinhan: '신한지주', samsung: '삼성전자', skhynix: 'SK하이닉스' }
+const STOCK_NAME_BY_CODE = { '055550': '신한지주', '005930': '삼성전자', '000660': 'SK하이닉스' }
+const DEFAULT_STOCK_NAME = '신한지주'
+
+function resolveStockName(config = {}) {
+  const stockId = config.stockId ?? 'shinhan'
+  const stockCode = config.stockCode ?? null
+  return config.stockName ?? STOCK_NAME_BY_ID[stockId] ?? STOCK_NAME_BY_CODE[stockCode] ?? DEFAULT_STOCK_NAME
+}
+
 export function getWidgetDefaultQuery(widgetTypeId, config = {}) {
   if (widgetTypeId === 'stock-chart') {
-    const name = config.stockName ?? null
-    return name ? `${name} 주가 알려줘` : '주가 차트 보여줘'
+    const name = resolveStockName(config)
+    return `${name} 주가 알려줘`
   }
   if (widgetTypeId === 'stock-news') {
-    const name = config.stockName ?? null
-    return name ? `${name} 종목 뉴스 알려줘` : '종목 뉴스 알려줘'
+    const name = resolveStockName(config)
+    return `${name} 종목 뉴스 알려줘`
   }
   return WIDGET_SHORTCUTS.find((s) => s.widgetTypeId === widgetTypeId)?.defaultQuery ?? null
 }

--- a/src/config/widgetShortcuts.js
+++ b/src/config/widgetShortcuts.js
@@ -99,5 +99,8 @@ export function getWidgetDefaultQuery(widgetTypeId, config = {}) {
     const name = resolveStockName(config)
     return `${name} 종목 뉴스 알려줘`
   }
+  if (widgetTypeId === 'market-overview') {
+    return config.tab === 'us' ? '해외 시황 알려줘' : '국내 시황 알려줘'
+  }
   return WIDGET_SHORTCUTS.find((s) => s.widgetTypeId === widgetTypeId)?.defaultQuery ?? null
 }

--- a/src/config/widgetShortcuts.js
+++ b/src/config/widgetShortcuts.js
@@ -84,9 +84,10 @@ const STOCK_NAME_BY_CODE = { '055550': '신한지주', '005930': '삼성전자',
 const DEFAULT_STOCK_NAME = '신한지주'
 
 function resolveStockName(config = {}) {
-  const stockId = config.stockId ?? 'shinhan'
-  const stockCode = config.stockCode ?? null
-  return config.stockName ?? STOCK_NAME_BY_ID[stockId] ?? STOCK_NAME_BY_CODE[stockCode] ?? DEFAULT_STOCK_NAME
+  if (config.stockName) return config.stockName
+  if (config.stockId) return STOCK_NAME_BY_ID[config.stockId] ?? DEFAULT_STOCK_NAME
+  if (config.stockCode) return STOCK_NAME_BY_CODE[config.stockCode] ?? DEFAULT_STOCK_NAME
+  return STOCK_NAME_BY_ID['shinhan']
 }
 
 export function getWidgetDefaultQuery(widgetTypeId, config = {}) {

--- a/src/config/widgetShortcuts.js
+++ b/src/config/widgetShortcuts.js
@@ -16,6 +16,7 @@ const WIDGET_SHORTCUTS = [
     keywords: ['잔고', '계좌', '자산', '평가자산', '내계좌', '예수금', '투자자산', '계좌현황'],
     widgetTypeId: 'balance',
     Icon: Wallet,
+    defaultQuery: '내 계좌 잔고 알려줘',
   },
   {
     key: 'exchange',
@@ -23,6 +24,7 @@ const WIDGET_SHORTCUTS = [
     keywords: ['환율', '달러', '엔', '유로', 'usd', 'jpy', 'eur', '원달러', '환전', '외화', '파운드', '위안'],
     widgetTypeId: 'exchange',
     Icon: ArrowLeftRight,
+    defaultQuery: '현재 환율 알려줘',
   },
   {
     key: 'ranking',
@@ -30,6 +32,7 @@ const WIDGET_SHORTCUTS = [
     keywords: ['순위', '랭킹', '거래대금', '상승률', '거래량', '급등', '상한가', '인기종목', '하락률'],
     widgetTypeId: 'ranking',
     Icon: TrendingUp,
+    defaultQuery: '실시간 종목 순위 알려줘',
   },
   {
     key: 'index',
@@ -37,6 +40,7 @@ const WIDGET_SHORTCUTS = [
     keywords: ['지수', '코스피', '코스닥', '나스닥', 'kospi', 'kosdaq', 'nasdaq', '다우', 's&p', '에센피', '뉴욕', '증시'],
     widgetTypeId: 'index',
     Icon: BarChart2,
+    defaultQuery: '주요 지수 알려줘',
   },
   {
     key: 'market-overview',
@@ -44,6 +48,7 @@ const WIDGET_SHORTCUTS = [
     keywords: ['시황', '시장', '헤드라인', '뉴스', '증시뉴스', '장세', '오늘증시', '코스피', '코스닥', '나스닥', '에센피', 's&p', 'nasdaq', 'kospi', 'kosdaq', '다우', '뉴욕'],
     widgetTypeId: 'market-overview',
     Icon: Newspaper,
+    defaultQuery: '오늘의 시황 알려줘',
   },
   {
     key: 'portfolio',
@@ -51,6 +56,7 @@ const WIDGET_SHORTCUTS = [
     keywords: ['포트폴리오', '포트', '비중', '보유종목', '보유주식', '내주식', '수익률', '손익', '평가손익', '자산배분'],
     widgetTypeId: 'portfolio',
     Icon: PieChart,
+    defaultQuery: '내 포트폴리오 알려줘',
   },
   {
     key: 'watchlist',
@@ -58,6 +64,7 @@ const WIDGET_SHORTCUTS = [
     keywords: ['관심', '관심종목', '즐겨찾기', '찜', '위시'],
     widgetTypeId: 'watchlist',
     Icon: Heart,
+    defaultQuery: '내 관심종목 알려줘',
   },
   {
     key: 'trade-history',
@@ -65,7 +72,16 @@ const WIDGET_SHORTCUTS = [
     keywords: ['거래내역', '매매', '주문내역', '체결', '내역', '거래기록', '주문', '체결내역', '매수내역', '매도내역'],
     widgetTypeId: 'trade-history',
     Icon: History,
+    defaultQuery: '거래내역 알려줘',
   },
 ]
 
 export default WIDGET_SHORTCUTS
+
+export function getWidgetDefaultQuery(widgetTypeId, config = {}) {
+  if (widgetTypeId === 'stock-chart') {
+    const name = config.stockName ?? null
+    return name ? `${name} 주가 알려줘` : '주가 차트 보여줘'
+  }
+  return WIDGET_SHORTCUTS.find((s) => s.widgetTypeId === widgetTypeId)?.defaultQuery ?? null
+}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -336,6 +336,7 @@ export default function HomePage() {
                 gridRow={w.gridRow}
                 widgetTypeId={w.widgetTypeId}
                 config={w.config}
+                canDragToChat={w.widgetTypeId !== 'watchlist'}
               >
                 <Component
                   instanceId={w.instanceId}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -334,6 +334,8 @@ export default function HomePage() {
                 rowSpan={w.rowSpan}
                 gridCol={w.gridCol}
                 gridRow={w.gridRow}
+                widgetTypeId={w.widgetTypeId}
+                config={w.config}
               >
                 <Component
                   instanceId={w.instanceId}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -16,6 +16,18 @@ import { DASHBOARD_PRESETS } from '@/data/dashboardPresets'
 import { PreviewContent } from '@/components/layout/EditPanel/WidgetSizeList'
 import SectorSelectModal from '@/components/layout/SectorSelectModal'
 
+const WIDGET_TYPES_DRAGGABLE_TO_CHAT = [
+  'balance',
+  'exchange',
+  'stock-chart',
+  'stock-news',
+  'index',
+  'ranking',
+  'market-overview',
+  'portfolio',
+  'trade-history',
+]
+
 function PresetThumbnail({ widgets }) {
   return (
     <div className="bg-background h-[152px] p-1.5 grid grid-cols-6 grid-rows-4 gap-[2px]">
@@ -336,7 +348,7 @@ export default function HomePage() {
                 gridRow={w.gridRow}
                 widgetTypeId={w.widgetTypeId}
                 config={w.config}
-                canDragToChat={w.widgetTypeId !== 'watchlist'}
+                canDragToChat={WIDGET_TYPES_DRAGGABLE_TO_CHAT.includes(w.widgetTypeId)}
               >
                 <Component
                   instanceId={w.instanceId}

--- a/src/store/usePendingQueryStore.js
+++ b/src/store/usePendingQueryStore.js
@@ -1,0 +1,13 @@
+import { create } from 'zustand'
+
+const usePendingQueryStore = create((set, get) => ({
+  pendingQuery: null,
+  setPendingQuery: (text) => set({ pendingQuery: text }),
+  consumePendingQuery: () => {
+    const value = get().pendingQuery
+    set({ pendingQuery: null })
+    return value
+  },
+}))
+
+export default usePendingQueryStore

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -366,7 +366,10 @@ const useWidgetStore = create((set) => ({
   addWidgetAt: (widgetTypeId, variant, gridCol, gridRow, configOverride) =>
     set((state) => {
       if (!canPlaceAt(state.widgets, gridCol, gridRow, variant.colSpan, variant.rowSpan)) return state
-      const config = configOverride ?? getDefaultWidgetConfig(widgetTypeId)
+      const defaultConfig = getDefaultWidgetConfig(widgetTypeId)
+      const config = configOverride
+        ? { ...(defaultConfig ?? {}), ...configOverride }
+        : defaultConfig
       const newWidgets = [
         ...state.widgets,
         {

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -3,6 +3,7 @@ import { GRID_COLS, GRID_ROWS } from '@/lib/gridConstants'
 import { fromApiResponse } from './widgetApi'
 
 const STORAGE_KEY_CURRENT_PAGE = 'dashboard:currentPageId'
+const STORAGE_KEY_CURRENT_PAGE_ORDER = 'dashboard:currentPageOrder'
 const DEFAULT_STOCK_CHART_CONFIG = {
   stockCode: '055550',
   stockName: '신한지주',
@@ -219,6 +220,12 @@ function _setCurrentWidgets(state, newWidgets) {
   return { pages: newPages, widgets: newWidgets }
 }
 
+function persistCurrentPageSelection(pages, pageId) {
+  sessionStorage.setItem(STORAGE_KEY_CURRENT_PAGE, pageId)
+  const pageOrder = pages.findIndex((p) => p.id === pageId) + 1
+  if (pageOrder > 0) sessionStorage.setItem(STORAGE_KEY_CURRENT_PAGE_ORDER, String(pageOrder))
+}
+
 const useWidgetStore = create((set) => ({
   // ── 멀티 페이지 상태 ─────────────────────────────────────
   pages: INITIAL_PAGES,
@@ -245,8 +252,13 @@ const useWidgetStore = create((set) => ({
         return { pages: [emptyPage], currentPageId: 'page-1', widgets: [], isLoaded: true }
       }
       const savedPageId = sessionStorage.getItem(STORAGE_KEY_CURRENT_PAGE)
-      const restoredPage = savedPageId ? pages.find((p) => p.id === savedPageId) : null
-      const currentPage = restoredPage ?? pages[0]
+      const savedPageOrder = Number(sessionStorage.getItem(STORAGE_KEY_CURRENT_PAGE_ORDER))
+      const restoredById = savedPageId ? pages.find((p) => p.id === savedPageId) : null
+      const restoredByOrder = Number.isInteger(savedPageOrder) && savedPageOrder > 0
+        ? pages[savedPageOrder - 1] ?? null
+        : null
+      const currentPage = restoredById ?? restoredByOrder ?? pages[0]
+      persistCurrentPageSelection(pages, currentPage.id)
       return {
         pages,
         currentPageId: currentPage.id,
@@ -259,6 +271,7 @@ const useWidgetStore = create((set) => ({
   // isLoaded를 false로 되돌려 재로그인 시 서버에서 새로 불러올 수 있게 함.
   resetLayout: () => {
     sessionStorage.removeItem(STORAGE_KEY_CURRENT_PAGE)
+    sessionStorage.removeItem(STORAGE_KEY_CURRENT_PAGE_ORDER)
     set({
       pages:         INITIAL_PAGES,
       currentPageId: 'page-1',
@@ -270,10 +283,10 @@ const useWidgetStore = create((set) => ({
 
   // ── 페이지 전환 ─────────────────────────────────────────
   switchPage: (pageId) => {
-    sessionStorage.setItem(STORAGE_KEY_CURRENT_PAGE, pageId)
     set((state) => {
       const page = state.pages.find((p) => p.id === pageId)
       if (!page || page.id === state.currentPageId) return state
+      persistCurrentPageSelection(state.pages, pageId)
       return { currentPageId: pageId, widgets: page.widgets }
     })
   },
@@ -287,7 +300,7 @@ const useWidgetStore = create((set) => ({
   // ── 페이지 편집 모달에서 staged 변경사항 일괄 적용 ────────
   applyPageChanges: (newPages, newCurrentId) => {
     const currentPage = newPages.find((p) => p.id === newCurrentId) ?? newPages[0]
-    sessionStorage.setItem(STORAGE_KEY_CURRENT_PAGE, currentPage.id)
+    persistCurrentPageSelection(newPages, currentPage.id)
     set(() => ({
       pages: newPages,
       currentPageId: currentPage.id,
@@ -350,10 +363,10 @@ const useWidgetStore = create((set) => ({
     }),
 
   // 지정 좌표에 위젯 추가 (new-widget drag-to-add 용)
-  addWidgetAt: (widgetTypeId, variant, gridCol, gridRow) =>
+  addWidgetAt: (widgetTypeId, variant, gridCol, gridRow, configOverride) =>
     set((state) => {
       if (!canPlaceAt(state.widgets, gridCol, gridRow, variant.colSpan, variant.rowSpan)) return state
-      const defaultConfig = getDefaultWidgetConfig(widgetTypeId)
+      const config = configOverride ?? getDefaultWidgetConfig(widgetTypeId)
       const newWidgets = [
         ...state.widgets,
         {
@@ -364,7 +377,7 @@ const useWidgetStore = create((set) => ({
           rowSpan: variant.rowSpan,
           gridCol,
           gridRow,
-          ...(defaultConfig ? { config: defaultConfig } : {}),
+          ...(config ? { config } : {}),
         },
       ]
       return _setCurrentWidgets(state, newWidgets)


### PR DESCRIPTION
## 개요
위젯과 채팅 간 양방향 연동 규격을 통일합니다.
- Dashboard → Chat: 위젯 드래그 시 질문 메시지 매핑
- Chat → Dashboard: 채팅 인텐트/카드 기반 위젯 생성 매핑

---

## 구현 목표
- balance, exchange, stock-chart, stock-news, index, ranking, market-overview, portfolio, watchlist, trade-history
  총 10개 위젯의 양방향 매핑 정책을 일관되게 정의
- 위젯별 기본 query 생성 규칙(동적/고정/fallback) 표준화
- 채팅에서 위젯 생성 시 필요한 최소 config 표준화

---

## 매핑 기준 요약

### 1) Dashboard → Chat (위젯 드래그 시 생성 메시지)
| widgetTypeId | 매핑 메시지 규칙 |
|---|---|
| balance | `내 계좌 잔고 알려줘` |
| exchange | `현재 환율 알려줘` |
| stock-chart | `{stockName} 주가 알려줘` (없으면 `주가 차트 보여줘`) |
| stock-news | `{stockName} 종목 뉴스 알려줘` (없으면 `종목 뉴스 알려줘`) |
| index | `주요 지수 알려줘` |
| ranking | `실시간 종목 순위 알려줘` |
| market-overview | `오늘의 시황 알려줘` |
| portfolio | `내 포트폴리오 알려줘` |
| trade-history | `거래내역 알려줘` |

참고) watchlist(관심종목)은 상호작용 x

---

### 2) Chat → Dashboard (채팅에서 생성되는 위젯 매핑)
| chat 카드/인텐트 기준 | 생성 위젯(widgetTypeId) | 기본 variant 기준(정책) |
|---|---|---|
| 잔고/자산 | balance | 기본 variant |
| 환율/외환 | exchange | 기본 variant |
| 종목 시세/차트 | stock-chart | 기본 variant |
| 종목 뉴스 | stock-news | 기본 variant |
| 주요 지수 | index | 기본 variant |
| 순위/급등 | ranking | 기본 variant |
| 시황/시장 브리핑 | market-overview | 기본 variant |
| 포트폴리오 | portfolio | 기본 variant |
| 거래내역 | trade-history | 기본 variant |

참고) watchlist(관심종목)은 상호작용 x

---

## 주요 변경 포인트
- 위젯별 `defaultQuery`/query builder 정리
- Chat→Dashboard 매핑 테이블(`INFOCARD_WIDGET_MAP` 등) 확장 및 규격화
- 양방향 공통 fallback 정책 정리 (null 방지)
- 위젯 생성 시 config 전달 규칙 통일

---

## 확인 포인트
- Dashboard→Chat 드롭 시 위젯별 메시지가 의도대로 생성되는지
- Chat→Dashboard에서 10개 위젯 모두 생성 가능한지
- 종목형 위젯(stock-chart/stock-news)에서 name 없는 경우 fallback 동작
- 기존 연동 기능 회귀 없음
