### PR TITLE
fix(qa): QA UI 수정 사항 반영

### DIFF
--- a/src/components/auth/LoginModal.jsx
+++ b/src/components/auth/LoginModal.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { Activity, X, Check, ArrowLeft } from 'lucide-react'
 import SplashScreenFill from '@/components/ui/SplashScreenFill'
 import { Input, PasswordInput } from '@/components/ui/Input'
@@ -223,9 +224,15 @@ export default function LoginModal({ onClose, initialView = 'login' }) {
     setView(initialView)
   }, [initialView])
 
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-5 pointer-events-none">
-      <div className="relative w-full max-w-[400px] bg-surface rounded-[6px] shadow-modal overflow-hidden pointer-events-auto animate-modal-in">
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[1200] flex items-center justify-center p-5 bg-transparent"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-full max-w-[400px] bg-surface rounded-[6px] shadow-modal overflow-hidden animate-modal-in"
+        onClick={(e) => e.stopPropagation()}
+      >
         {/* 모달 헤더 */}
         <div className="flex items-center justify-between px-6 pt-[22px]">
           <div className="flex items-center gap-2.5">
@@ -266,6 +273,7 @@ export default function LoginModal({ onClose, initialView = 'login' }) {
           }
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   )
 }

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -206,8 +206,8 @@ export default function AppShell() {
       }
     } else if (type === 'widget-to-chat') {
       if (over?.id === 'chat-dropzone') {
-        const { widgetTypeId, config } = active.data.current
-        const query = getWidgetDefaultQuery(widgetTypeId, config)
+        const { widgetTypeId, variantId, config } = active.data.current
+        const query = getWidgetDefaultQuery(widgetTypeId, config, variantId)
         if (query) setPendingQuery(query)
       }
     }

--- a/src/components/layout/ChatPanel.jsx
+++ b/src/components/layout/ChatPanel.jsx
@@ -645,7 +645,7 @@ function ChatSuggestions({ suggestions, activeIndex, onSelect }) {
 // DESIGN.md §16: bg-background border-stroke-input rounded-2xl px-3.5 py-2.5
 // 전송버튼: 빈 입력 → bg-surface-muted cursor-not-allowed / 입력 있음 → bg-primary
 // textarea: 입력 내용에 따라 높이 자동 증가, 최대 5줄, Shift+Enter 줄바꿈
-function ChatInput({ isDisabled = false, onSend, value = "", onChange, onSuggestionKeyDown }) {
+function ChatInput({ isDisabled = false, isSending = false, onSend, value = "", onChange, onSuggestionKeyDown }) {
   const textareaRef = useRef(null);
   const canSend = value.trim().length > 0 && !isDisabled;
 
@@ -686,7 +686,9 @@ function ChatInput({ isDisabled = false, onSend, value = "", onChange, onSuggest
         onKeyDown={handleKeyDown}
         disabled={isDisabled}
         placeholder={
-          isDisabled
+          isSending
+            ? "답변을 생성하고 있습니다..."
+            : isDisabled
             ? "로그인 후 이용하실 수 있습니다"
             : "SOL AI 어시스턴트에게 물어보세요..."
         }
@@ -1395,6 +1397,7 @@ export default function ChatPanel() {
               onSend={handleSend}
               onSuggestionKeyDown={handleSuggestionKeyDown}
               isDisabled={isTyping}
+              isSending={isTyping}
             />
           </div>
         </>

--- a/src/components/layout/ChatStockCard.jsx
+++ b/src/components/layout/ChatStockCard.jsx
@@ -310,8 +310,8 @@ export default function ChatStockCard({ stockCode, stockName, marketType, exchan
           { label: '거래량', val: stock.volume },
         ].map(({ label, val }) => (
           <div key={label} className="text-center">
-            <div className="text-widget-8 text-foreground-disabled">{label}</div>
-            <div className="text-widget-10 font-semibold text-foreground">{val}</div>
+            <div className="text-widget-9 text-foreground-disabled">{label}</div>
+            <div className="text-widget-11 font-semibold text-foreground">{val}</div>
           </div>
         ))}
       </div>

--- a/src/components/widgets/PortfolioWidget.jsx
+++ b/src/components/widgets/PortfolioWidget.jsx
@@ -1,20 +1,10 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import LockedOverlay from '@/components/ui/LockedOverlay'
 import useAuthStore from '@/store/useAuthStore'
 import useWidgetDetailStore from '@/store/useWidgetDetailStore'
 import WidgetCard from './WidgetCard'
-import { useDomesticHoldings } from '@/api/balance'
-import { extractDominantColor } from '@/lib/extractLogoColor'
-import { getStockLogoUrl } from '@/lib/stockLogo'
-
-const FALLBACK_COLORS = [
-  'var(--color-chart-1)',
-  'var(--color-chart-2)',
-  'var(--color-chart-3)',
-  'var(--color-chart-4)',
-  'var(--color-chart-5)',
-]
-const OTHER_COLOR = 'var(--color-chart-other)'
+import { useBalanceSummary, useDomesticHoldings, useOverseasHoldings, usePortfolioData } from '@/api/balance'
+import { usePortfolioColors } from '@/features/portfolio/portfolioColors'
 
 function ItemBar({ item, color, barHeight = 'h-[3px]' }) {
   return (
@@ -30,96 +20,59 @@ function ItemBar({ item, color, barHeight = 'h-[3px]' }) {
   )
 }
 
-function usePortfolioColors(items) {
-  const [colors, setColors] = useState({})
-
-  useEffect(() => {
-    if (!items?.length) {
-      setColors({})
-      return
-    }
-
-    let isCancelled = false
-
-    items.forEach(async (item, i) => {
-      const key = item.stockCode ?? `item_${i}`
-
-      if (item.type === 'OTHER') {
-        if (!isCancelled) setColors((prev) => ({ ...prev, [key]: OTHER_COLOR }))
-        return
-      }
-
-      if (!item.stockCode) {
-        if (!isCancelled) setColors((prev) => ({ ...prev, [key]: FALLBACK_COLORS[i % FALLBACK_COLORS.length] }))
-        return
-      }
-
-      const fallback = FALLBACK_COLORS[i % FALLBACK_COLORS.length]
-      const url =
-        getStockLogoUrl(item.marketType, item.stockCode) ??
-        getStockLogoUrl('KOSPI', item.stockCode) ??
-        getStockLogoUrl('KOSDAQ', item.stockCode)
-
-      if (!url) {
-        if (!isCancelled) setColors((prev) => ({ ...prev, [key]: fallback }))
-        return
-      }
-
-      const color = await extractDominantColor(url, fallback)
-      if (!isCancelled) setColors((prev) => ({ ...prev, [key]: color }))
-    })
-
-    return () => {
-      isCancelled = true
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(items?.map((item) => `${item.stockCode ?? 'none'}:${item.marketType ?? ''}:${item.type ?? ''}`))])
-
-  return colors
-}
-
 function usePortfolio(enabled, topN = 3) {
-  const { data: holdings = [], isLoading } = useDomesticHoldings({ enabled })
+  const { data: summary, isLoading: sl } = useBalanceSummary({ enabled })
+  const { data: domestic = [], isLoading: dl } = useDomesticHoldings({ enabled })
+  const { data: overseas = [], isLoading: ol } = useOverseasHoldings({ enabled })
+  const { data: portfolio, isLoading: pl } = usePortfolioData({ enabled })
 
   return useMemo(() => {
+    const isLoading = enabled && (sl || dl || ol || pl)
     if (isLoading) return { items: [], returnRate: null, isLoading: true }
 
-    const withValues = holdings
-      .map((h) => {
-        const qty = h.holdingQuantity ?? h.availableQuantity ?? 0
-        const curPrice = h.currentPrice ?? h.avgPrice ?? h.avgBuyPrice ?? 0
-        const avgPrice = h.avgPrice ?? h.avgBuyPrice ?? 0
-        return {
-          name: h.stockName ?? h.stockCode,
-          stockCode: h.stockCode ?? null,
-          marketType: h.marketType ?? null,
-          currentValue: curPrice * qty,
-          investedValue: avgPrice * qty,
-        }
-      })
-      .filter((h) => h.currentValue > 0)
-      .sort((a, b) => b.currentValue - a.currentValue)
+    const allHoldings = [...domestic, ...overseas]
+      .filter((h) => (h.holdingQuantity ?? 0) > 0 || (h.availableQuantity ?? 0) > 0)
+      .map((h) => ({
+        ...h,
+        evalKrw: Number(h.evalAmount ?? 0),
+      }))
+    const holdingByName = Object.fromEntries(allHoldings.map((h) => [h.stockName, h]))
 
-    const total = withValues.reduce((s, h) => s + h.currentValue, 0)
-    const totalInvested = withValues.reduce((s, h) => s + h.investedValue, 0)
+    const orderedItems = (portfolio?.items ?? []).filter((item) => item.type === 'STOCK')
+    const normalized = orderedItems.map((item) => {
+      const holding = holdingByName[item.label]
+      return {
+        name: item.label,
+        ratio: Number(item.weight ?? 0),
+        evalKrw: Number(holding?.evalKrw ?? 0),
+        stockCode: holding?.stockCode ?? null,
+        marketType: holding?.marketType ?? null,
+        type: 'STOCK',
+      }
+    })
 
-    if (total === 0) return { items: [], returnRate: null, isLoading: false }
+    const totalRatio = normalized.reduce((sum, item) => sum + item.ratio, 0)
+    if (totalRatio > 0 && normalized.length > 0) {
+      const rounded = normalized.map((item) => ({
+        ...item,
+        ratio: Math.round((item.ratio / totalRatio) * 100),
+      }))
+      const roundedSum = rounded.reduce((sum, item) => sum + item.ratio, 0)
+      rounded[rounded.length - 1].ratio += (100 - roundedSum)
+      normalized.splice(0, normalized.length, ...rounded)
+    }
 
-    const top = withValues.slice(0, topN)
-    const rest = withValues.slice(topN)
+    // 잔고 탭 보유종목과 동일하게 평가금액 내림차순 정렬
+    normalized.sort((a, b) => (b.evalKrw ?? 0) - (a.evalKrw ?? 0))
 
-    const items = top.map((h) => ({
-      name: h.name,
-      ratio: Math.round((h.currentValue / total) * 100),
-      stockCode: h.stockCode,
-      marketType: h.marketType,
-      type: 'STOCK',
-    }))
+    const top = normalized.slice(0, topN)
+    const rest = normalized.slice(topN)
+    const items = [...top]
 
     if (rest.length > 0) {
       items.push({
         name: '기타',
-        ratio: 100 - items.reduce((s, item) => s + item.ratio, 0),
+        ratio: Math.max(0, 100 - items.reduce((s, item) => s + item.ratio, 0)),
         stockCode: null,
         marketType: null,
         type: 'OTHER',
@@ -129,25 +82,18 @@ function usePortfolio(enabled, topN = 3) {
       if (items.length > 0) items[items.length - 1].ratio += (100 - sum)
     }
 
-    const returnRate = totalInvested > 0
-      ? ((total - totalInvested) / totalInvested) * 100
+    const returnRate = summary?.totalStockUnrealizedProfitLossRate != null
+      ? Number(summary.totalStockUnrealizedProfitLossRate)
       : 0
 
     return { items, returnRate, isLoading: false }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [holdings, isLoading])
+  }, [summary, domestic, overseas, portfolio, sl, dl, ol, pl, enabled, topN])
 }
 
-function resolveColor(item, idx, colors) {
-  if (item.type === 'OTHER') return OTHER_COLOR
-  const key = item.stockCode ?? `item_${idx}`
-  return colors[key] ?? FALLBACK_COLORS[idx % FALLBACK_COLORS.length]
-}
-
-function buildConicStops(items, colors) {
+function buildConicStops(items, getColor) {
   let start = 0
   return items.map((item, i) => {
-    const color = resolveColor(item, i, colors)
+    const color = getColor(item, i)
     const end = start + item.ratio
     const stop = `${color} ${start}% ${end}%`
     start = end
@@ -158,10 +104,10 @@ function buildConicStops(items, colors) {
 export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1, rowSpan = 1, onDelete }) {
   const { isAuthenticated, isRestoring } = useAuthStore()
   const { open } = useWidgetDetailStore()
-  const topN = variant === 'portfolio-2x2' ? 5 : 3
+  const topN = variant === 'portfolio-2x2' ? 6 : 3
   const portfolio = usePortfolio(isAuthenticated && !isRestoring, topN)
-  const colors = usePortfolioColors(portfolio.items)
-  const conicStops = useMemo(() => buildConicStops(portfolio.items, colors), [portfolio.items, colors])
+  const getColor = usePortfolioColors(portfolio.items)
+  const conicStops = useMemo(() => buildConicStops(portfolio.items, getColor), [portfolio.items, getColor])
 
   const returnRateStr = portfolio.returnRate != null
     ? `${portfolio.returnRate >= 0 ? '+' : ''}${portfolio.returnRate.toFixed(1)}%`
@@ -184,7 +130,7 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
                 {portfolio.isLoading ? '불러오는 중...' : '보유 종목 없음'}
               </div>
             ) : portfolio.items.map((item, i) => (
-              <ItemBar key={item.name} item={item} color={resolveColor(item, i, colors)} barHeight="h-[3px]" />
+              <ItemBar key={item.name} item={item} color={getColor(item, i)} barHeight="h-[3px]" />
             ))}
           </div>
         </>
@@ -211,7 +157,7 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
               </div>
               <div className="flex flex-col gap-1.5 flex-1 min-h-0 overflow-hidden">
                 {portfolio.items.map((item, i) => (
-                  <ItemBar key={item.name} item={item} color={resolveColor(item, i, colors)} barHeight="h-[4px]" />
+                  <ItemBar key={item.name} item={item} color={getColor(item, i)} barHeight="h-[4px]" />
                 ))}
               </div>
             </div>
@@ -237,7 +183,7 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
               <div className="flex flex-col gap-1 min-w-0 flex-1">
                 {portfolio.items.map((item, i) => (
                   <div key={item.name} className="flex items-center gap-1 min-w-0">
-                    <div className="w-1.5 h-1.5 rounded-full shrink-0" style={{ background: resolveColor(item, i, colors) }} />
+                    <div className="w-1.5 h-1.5 rounded-full shrink-0" style={{ background: getColor(item, i) }} />
                     <span className="text-widget-10 text-foreground-secondary tracking-tight truncate">{item.name}</span>
                   </div>
                 ))}

--- a/src/components/widgets/SortableWidgetCard.jsx
+++ b/src/components/widgets/SortableWidgetCard.jsx
@@ -19,6 +19,7 @@ export default function SortableWidgetCard({
   gridCol,
   gridRow,
   widgetTypeId,
+  variantId,
   config = {},
   canDragToChat = true,
   children,
@@ -46,7 +47,7 @@ export default function SortableWidgetCard({
   } = useDraggable({
     id: `wtc-handle-${instanceId}`,
     disabled: isEditMode || isDragLocked || !canDragToChat,
-    data: { type: 'widget-to-chat', instanceId, widgetTypeId, config },
+    data: { type: 'widget-to-chat', instanceId, widgetTypeId, variantId, config },
   })
 
   const setNodeRef = useCallback(

--- a/src/config/widgetShortcuts.js
+++ b/src/config/widgetShortcuts.js
@@ -90,7 +90,7 @@ function resolveStockName(config = {}) {
   return STOCK_NAME_BY_ID['shinhan']
 }
 
-export function getWidgetDefaultQuery(widgetTypeId, config = {}) {
+export function getWidgetDefaultQuery(widgetTypeId, config = {}, variantId) {
   if (widgetTypeId === 'stock-chart') {
     const name = resolveStockName(config)
     return `${name} 주가 알려줘`
@@ -100,7 +100,10 @@ export function getWidgetDefaultQuery(widgetTypeId, config = {}) {
     return `${name} 종목 뉴스 알려줘`
   }
   if (widgetTypeId === 'market-overview') {
-    return config.tab === 'us' ? '해외 시황 알려줘' : '국내 시황 알려줘'
+    if (variantId === 'market-2x2') return '오늘의 시황 알려줘'
+    const STORAGE_KEY = 'marketOverviewWidget.activeTab'
+    const tab = config.tab ?? localStorage.getItem(STORAGE_KEY) ?? 'kr'
+    return tab === 'us' ? '해외 시황 알려줘' : '국내 시황 알려줘'
   }
   return WIDGET_SHORTCUTS.find((s) => s.widgetTypeId === widgetTypeId)?.defaultQuery ?? null
 }

--- a/src/features/portfolio/portfolioColors.js
+++ b/src/features/portfolio/portfolioColors.js
@@ -2,8 +2,14 @@ import { useEffect, useMemo, useState } from 'react'
 import { getStockLogoUrl } from '@/lib/stockLogo'
 import { extractDominantColor } from '@/lib/extractLogoColor'
 
-const GRAY_COLOR = '#9CA3AF'
-const FALLBACK_COLORS = ['#0046FF', '#00C2A8', '#7B61FF', '#FF8C00', '#0035CC']
+const GRAY_COLOR = 'var(--color-chart-other)'
+const FALLBACK_COLORS = [
+  'var(--color-chart-1)',
+  'var(--color-chart-2)',
+  'var(--color-chart-3)',
+  'var(--color-chart-4)',
+  'var(--color-chart-5)',
+]
 
 function hashString(text) {
   let hash = 5381

--- a/src/features/portfolio/portfolioColors.js
+++ b/src/features/portfolio/portfolioColors.js
@@ -1,0 +1,84 @@
+import { useEffect, useMemo, useState } from 'react'
+import { getStockLogoUrl } from '@/lib/stockLogo'
+import { extractDominantColor } from '@/lib/extractLogoColor'
+
+const GRAY_COLOR = '#9CA3AF'
+const FALLBACK_COLORS = ['#0046FF', '#00C2A8', '#7B61FF', '#FF8C00', '#0035CC']
+
+function hashString(text) {
+  let hash = 5381
+  for (let i = 0; i < text.length; i += 1) {
+    hash = ((hash << 5) + hash) + text.charCodeAt(i)
+    hash |= 0
+  }
+  return Math.abs(hash)
+}
+
+function getStableKey(item, idx) {
+  if (item?.type === 'OTHER') return 'other'
+  if (item?.stockCode) return `stock:${item.stockCode}`
+  const label = item?.name ?? item?.label ?? `item_${idx}`
+  return `label:${String(label).trim().toLowerCase()}`
+}
+
+function getFallbackColor(item, idx) {
+  const key = getStableKey(item, idx)
+  return FALLBACK_COLORS[hashString(key) % FALLBACK_COLORS.length]
+}
+
+export function usePortfolioColors(items) {
+  const [colors, setColors] = useState({})
+
+  const depsKey = useMemo(
+    () => JSON.stringify((items ?? []).map((item, idx) => ({
+      key: getStableKey(item, idx),
+      stockCode: item?.stockCode ?? null,
+      marketType: item?.marketType ?? null,
+      type: item?.type ?? null,
+    }))),
+    [items],
+  )
+
+  useEffect(() => {
+    if (!items?.length) return
+    let cancelled = false
+
+    items.forEach(async (item, idx) => {
+      const key = getStableKey(item, idx)
+
+      if (item?.type === 'OTHER' || item?.type === 'CASH') {
+        if (!cancelled) setColors((prev) => ({ ...prev, [key]: GRAY_COLOR }))
+        return
+      }
+
+      if (!item?.stockCode) {
+        if (!cancelled) setColors((prev) => ({ ...prev, [key]: getFallbackColor(item, idx) }))
+        return
+      }
+
+      const fallback = getFallbackColor(item, idx)
+      const url =
+        getStockLogoUrl(item.marketType, item.stockCode) ??
+        getStockLogoUrl('KOSPI', item.stockCode) ??
+        getStockLogoUrl('KOSDAQ', item.stockCode)
+
+      if (!url) {
+        if (!cancelled) setColors((prev) => ({ ...prev, [key]: fallback }))
+        return
+      }
+
+      const color = await extractDominantColor(url, fallback)
+      if (!cancelled) setColors((prev) => ({ ...prev, [key]: color }))
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [depsKey]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (item, idx = 0) => {
+    const key = getStableKey(item, idx)
+    if (item?.type === 'OTHER' || item?.type === 'CASH') return GRAY_COLOR
+    return colors[key] ?? getFallbackColor(item, idx)
+  }
+}

--- a/src/lib/gridConstants.js
+++ b/src/lib/gridConstants.js
@@ -9,7 +9,7 @@ export const MIN_CELL_HEIGHT = 130
 export const MIN_GRID_WIDTH = MIN_CELL_WIDTH * GRID_COLS + GRID_GAP * (GRID_COLS - 1)
 export const MIN_GRID_HEIGHT = MIN_CELL_HEIGHT * GRID_ROWS + GRID_GAP * (GRID_ROWS - 1)
 
-export const MAX_PAGES = 5
+export const MAX_PAGES = Infinity
 
 // 대시보드 그리드 DOM 요소 참조 — AppShell에서 포인터 좌표 → grid cell 변환에 사용
 export const gridElementRef = { current: null }

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -347,6 +347,7 @@ export default function HomePage() {
                 gridCol={w.gridCol}
                 gridRow={w.gridRow}
                 widgetTypeId={w.widgetTypeId}
+                variantId={w.variantId}
                 config={w.config}
                 canDragToChat={WIDGET_TYPES_DRAGGABLE_TO_CHAT.includes(w.widgetTypeId)}
               >


### PR DESCRIPTION
## 작업 내용

- `fix(auth)`: 로그인 모달 배경 레이어 추가로 하위 인터랙션 차단
- `fix(chat)`: ChatStockCard 시가/고가/저가/거래량 텍스트 토큰 수정
- `fix(chat)`: 전송 중 placeholder 수정 및 시황 위젯 드래그 메시지 개선
- `fix(home)`: 대시보드 페이지 개수 제한 제거
- `feat(widget-ui)`: 포트폴리오 위젯 색상 추출 공통화 및 잔고 탭 기준 정렬/기타 규칙 반영

## 확인 방법

- [ ] 로그인 모달 열린 상태에서 배경 클릭 시 하위 요소 인터랙션 차단 확인
- [ ] ChatStockCard에서 시가/고가/저가/거래량 레이블 정상 표시 확인
- [ ] 채팅 전송 중 placeholder 문구 및 시황 위젯 드래그 메시지 확인
- [ ] 대시보드 페이지 제한 없이 추가 가능 확인
- [ ] 포트폴리오 위젯 잔고 탭 정렬 및 색상 정상 동작 확인