### PR TITLE
fix(asset): 자산흐름 차트 splitLine 다크모드 대응

### DIFF
--- a/src/pages/AssetPage.jsx
+++ b/src/pages/AssetPage.jsx
@@ -8,6 +8,7 @@ import StockAvatar from '@/components/ui/StockAvatar'
 import { cn } from '@/lib/cn'
 import ExchangeModal from '@/components/asset/ExchangeModal'
 import useAuthStore from '@/store/useAuthStore'
+import useUIStore from '@/store/useUIStore'
 import useWidgetDetailStore from '@/store/useWidgetDetailStore'
 import { useMyAccount } from '@/api/account'
 import { useAssetPage } from '@/features/asset/useAssetPage'
@@ -212,6 +213,8 @@ function AssetFlowCard({ data, assetFlowRange, onChangeAssetFlowRange }) {
   const [mode, setMode] = useState('assets')
   const [chartOpacity, setChartOpacity] = useState(1)
   const pendingMode = useRef(null)
+  const theme = useUIStore((s) => s.theme)
+  const splitLineColor = theme === 'dark' ? '#252836' : '#F2F4F7'
 
   function handleModeChange(newMode) {
     if (newMode === mode) return
@@ -273,7 +276,7 @@ function AssetFlowCard({ data, assetFlowRange, onChangeAssetFlowRange }) {
       splitNumber: 3,
       axisLine: { show: false },
       axisTick: { show: false },
-      splitLine: { lineStyle: { color: '#F2F4F7' } },
+      splitLine: { lineStyle: { color: splitLineColor } },
       axisLabel: {
         color: '#9CA3AF',
         fontSize: 10,


### PR DESCRIPTION
## 연관 이슈
* Closes #131 


## 작업 내용
- 다크모드에서 자산흐름 차트의 splitLine(가로 기준선)이 밝은 색(#F2F4F7)으로 고정되어 있어 두드러지는 문제 수정
- useUIStore의 theme 값을 읽어 다크모드일 때 #252836(InvestStockChart DARK_COLORS.grid와 동일), 라이트모드일 때 #F2F4F7
  적용


## 체크리스트
- [x] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [x] 필요한 코드나 주석을 제거했나요?