### PR TITLE
fix(widget-portfolio): 파이차트/색상 추출 안정화 및 잔고 탭 색상 로직 통일

### DIFF
--- a/src/components/widgets/PortfolioWidget.jsx
+++ b/src/components/widgets/PortfolioWidget.jsx
@@ -20,6 +20,11 @@ function ItemBar({ item, color, barHeight = 'h-[3px]' }) {
   )
 }
 
+function parseRatio(value) {
+  const n = typeof value === 'string' ? parseFloat(value) : Number(value)
+  return Number.isFinite(n) && n > 0 ? n : 0
+}
+
 function usePortfolio(enabled, topN = 3) {
   const { data: summary, isLoading: sl } = useBalanceSummary({ enabled })
   const { data: domestic = [], isLoading: dl } = useDomesticHoldings({ enabled })
@@ -43,7 +48,7 @@ function usePortfolio(enabled, topN = 3) {
       const holding = holdingByName[item.label]
       return {
         name: item.label,
-        ratio: Number(item.weight ?? 0),
+        ratio: parseRatio(item.weight),
         evalKrw: Number(holding?.evalKrw ?? 0),
         stockCode: holding?.stockCode ?? null,
         marketType: holding?.marketType ?? null,
@@ -91,10 +96,16 @@ function usePortfolio(enabled, topN = 3) {
 }
 
 function buildConicStops(items, getColor) {
+  const total = items.reduce((sum, item) => sum + (Number.isFinite(item.ratio) ? item.ratio : 0), 0)
+  if (!Number.isFinite(total) || total <= 0) {
+    return '#0046FF 0% 100%'
+  }
+
   let start = 0
   return items.map((item, i) => {
     const color = getColor(item, i)
-    const end = start + item.ratio
+    const slice = (item.ratio / total) * 100
+    const end = start + slice
     const stop = `${color} ${start}% ${end}%`
     start = end
     return stop
@@ -104,9 +115,9 @@ function buildConicStops(items, getColor) {
 export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1, rowSpan = 1, onDelete }) {
   const { isAuthenticated, isRestoring } = useAuthStore()
   const { open } = useWidgetDetailStore()
-  const topN = variant === 'portfolio-2x2' ? 6 : 3
+  const topN = 5
   const portfolio = usePortfolio(isAuthenticated && !isRestoring, topN)
-  const getColor = usePortfolioColors(portfolio.items)
+  const { getColor, ready } = usePortfolioColors(portfolio.items)
   const conicStops = useMemo(() => buildConicStops(portfolio.items, getColor), [portfolio.items, getColor])
 
   const returnRateStr = portfolio.returnRate != null
@@ -124,7 +135,7 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
               <span className={`text-widget-10 font-semibold ${returnRateColor}`}>{returnRateStr}</span>
             )}
           </div>
-          <div className="flex flex-col gap-1 flex-1 min-h-0 overflow-hidden">
+          <div className="flex flex-col gap-1 flex-1 min-h-0 overflow-y-auto pr-1">
             {portfolio.isLoading || portfolio.items.length === 0 ? (
               <div className="flex-1 flex items-center justify-center text-widget-9 text-foreground-disabled">
                 {portfolio.isLoading ? '불러오는 중...' : '보유 종목 없음'}
@@ -146,7 +157,8 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
           ) : (
             <div className="flex flex-col flex-1 gap-3 min-h-0">
               <div className="flex items-center gap-3 shrink-0">
-                <div className="relative w-16 h-16 rounded-full shrink-0" style={{ background: `conic-gradient(${conicStops})` }}>
+                <div className="relative w-16 h-16 rounded-full shrink-0" style={ready && conicStops ? { background: `conic-gradient(${conicStops})` } : undefined}>
+                  {(!ready || !conicStops) && <div className="absolute inset-0 rounded-full bg-surface-muted" />}
                   <div className="absolute inset-[28%] rounded-full bg-surface" />
                 </div>
                 <div>
@@ -155,7 +167,7 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
                   <div className="text-widget-9 text-foreground-disabled mt-0.5">+4,280,000원</div>
                 </div>
               </div>
-              <div className="flex flex-col gap-1.5 flex-1 min-h-0 overflow-hidden">
+              <div className="flex flex-col gap-1.5 flex-1 min-h-0 overflow-y-auto pr-1">
                 {portfolio.items.map((item, i) => (
                   <ItemBar key={item.name} item={item} color={getColor(item, i)} barHeight="h-[4px]" />
                 ))}
@@ -177,10 +189,11 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
             </div>
           ) : (
             <div className="flex items-center gap-2.5 flex-1 min-h-0">
-              <div className="relative w-14 h-14 rounded-full shrink-0" style={{ background: `conic-gradient(${conicStops})` }}>
+              <div className="relative w-14 h-14 rounded-full shrink-0" style={ready && conicStops ? { background: `conic-gradient(${conicStops})` } : undefined}>
+                {(!ready || !conicStops) && <div className="absolute inset-0 rounded-full bg-surface-muted" />}
                 <div className="absolute inset-[30%] rounded-full bg-surface" />
               </div>
-              <div className="flex flex-col gap-1 min-w-0 flex-1">
+              <div className="flex flex-col gap-1 min-w-0 flex-1 min-h-0 overflow-y-auto pr-1">
                 {portfolio.items.map((item, i) => (
                   <div key={item.name} className="flex items-center gap-1 min-w-0">
                     <div className="w-1.5 h-1.5 rounded-full shrink-0" style={{ background: getColor(item, i) }} />

--- a/src/components/widgets/PortfolioWidget.jsx
+++ b/src/components/widgets/PortfolioWidget.jsx
@@ -20,6 +20,11 @@ function ItemBar({ item, color, barHeight = 'h-[3px]' }) {
   )
 }
 
+function parseRatio(value) {
+  const n = typeof value === 'string' ? parseFloat(value) : Number(value)
+  return Number.isFinite(n) && n > 0 ? n : 0
+}
+
 function usePortfolio(enabled, topN = 3) {
   const { data: summary, isLoading: sl } = useBalanceSummary({ enabled })
   const { data: domestic = [], isLoading: dl } = useDomesticHoldings({ enabled })
@@ -43,7 +48,7 @@ function usePortfolio(enabled, topN = 3) {
       const holding = holdingByName[item.label]
       return {
         name: item.label,
-        ratio: Number(item.weight ?? 0),
+        ratio: parseRatio(item.weight),
         evalKrw: Number(holding?.evalKrw ?? 0),
         stockCode: holding?.stockCode ?? null,
         marketType: holding?.marketType ?? null,
@@ -91,11 +96,18 @@ function usePortfolio(enabled, topN = 3) {
 }
 
 function buildConicStops(items, getColor) {
+  const safeItems = (items ?? []).map((item, i) => ({
+    ...item,
+    ratio: parseRatio(item.ratio),
+    color: getColor(item, i),
+  }))
+  const total = safeItems.reduce((sum, item) => sum + item.ratio, 0)
+  if (!Number.isFinite(total) || total <= 0) return ''
+
   let start = 0
-  return items.map((item, i) => {
-    const color = getColor(item, i)
-    const end = start + item.ratio
-    const stop = `${color} ${start}% ${end}%`
+  return safeItems.map((item) => {
+    const end = start + (item.ratio / total) * 100
+    const stop = `${item.color} ${start.toFixed(3)}% ${end.toFixed(3)}%`
     start = end
     return stop
   }).join(', ')
@@ -104,9 +116,8 @@ function buildConicStops(items, getColor) {
 export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1, rowSpan = 1, onDelete }) {
   const { isAuthenticated, isRestoring } = useAuthStore()
   const { open } = useWidgetDetailStore()
-  const topN = variant === 'portfolio-2x2' ? 6 : 3
-  const portfolio = usePortfolio(isAuthenticated && !isRestoring, topN)
-  const getColor = usePortfolioColors(portfolio.items)
+  const portfolio = usePortfolio(isAuthenticated && !isRestoring, 5)
+  const { getColor, ready } = usePortfolioColors(portfolio.items)
   const conicStops = useMemo(() => buildConicStops(portfolio.items, getColor), [portfolio.items, getColor])
 
   const returnRateStr = portfolio.returnRate != null
@@ -124,7 +135,7 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
               <span className={`text-widget-10 font-semibold ${returnRateColor}`}>{returnRateStr}</span>
             )}
           </div>
-          <div className="flex flex-col gap-1 flex-1 min-h-0 overflow-hidden">
+          <div className="flex flex-col gap-1 flex-1 min-h-0 overflow-y-auto">
             {portfolio.isLoading || portfolio.items.length === 0 ? (
               <div className="flex-1 flex items-center justify-center text-widget-9 text-foreground-disabled">
                 {portfolio.isLoading ? '불러오는 중...' : '보유 종목 없음'}
@@ -146,7 +157,8 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
           ) : (
             <div className="flex flex-col flex-1 gap-3 min-h-0">
               <div className="flex items-center gap-3 shrink-0">
-                <div className="relative w-16 h-16 rounded-full shrink-0" style={{ background: `conic-gradient(${conicStops})` }}>
+                <div className="relative w-16 h-16 rounded-full shrink-0" style={ready && conicStops ? { background: `conic-gradient(${conicStops})` } : undefined}>
+                  {(!ready || !conicStops) && <div className="absolute inset-0 rounded-full bg-surface-muted" />}
                   <div className="absolute inset-[28%] rounded-full bg-surface" />
                 </div>
                 <div>
@@ -155,7 +167,7 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
                   <div className="text-widget-9 text-foreground-disabled mt-0.5">+4,280,000원</div>
                 </div>
               </div>
-              <div className="flex flex-col gap-1.5 flex-1 min-h-0 overflow-hidden">
+              <div className="flex flex-col gap-1.5 flex-1 min-h-0 overflow-y-auto">
                 {portfolio.items.map((item, i) => (
                   <ItemBar key={item.name} item={item} color={getColor(item, i)} barHeight="h-[4px]" />
                 ))}
@@ -177,10 +189,11 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
             </div>
           ) : (
             <div className="flex items-center gap-2.5 flex-1 min-h-0">
-              <div className="relative w-14 h-14 rounded-full shrink-0" style={{ background: `conic-gradient(${conicStops})` }}>
+              <div className="relative w-14 h-14 rounded-full shrink-0" style={ready && conicStops ? { background: `conic-gradient(${conicStops})` } : undefined}>
+                {(!ready || !conicStops) && <div className="absolute inset-0 rounded-full bg-surface-muted" />}
                 <div className="absolute inset-[30%] rounded-full bg-surface" />
               </div>
-              <div className="flex flex-col gap-1 min-w-0 flex-1">
+              <div className="flex flex-col gap-1 min-w-0 flex-1 min-h-0 overflow-y-auto">
                 {portfolio.items.map((item, i) => (
                   <div key={item.name} className="flex items-center gap-1 min-w-0">
                     <div className="w-1.5 h-1.5 rounded-full shrink-0" style={{ background: getColor(item, i) }} />

--- a/src/components/widgets/PortfolioWidget.jsx
+++ b/src/components/widgets/PortfolioWidget.jsx
@@ -20,11 +20,6 @@ function ItemBar({ item, color, barHeight = 'h-[3px]' }) {
   )
 }
 
-function parseRatio(value) {
-  const n = typeof value === 'string' ? parseFloat(value) : Number(value)
-  return Number.isFinite(n) && n > 0 ? n : 0
-}
-
 function usePortfolio(enabled, topN = 3) {
   const { data: summary, isLoading: sl } = useBalanceSummary({ enabled })
   const { data: domestic = [], isLoading: dl } = useDomesticHoldings({ enabled })
@@ -48,7 +43,7 @@ function usePortfolio(enabled, topN = 3) {
       const holding = holdingByName[item.label]
       return {
         name: item.label,
-        ratio: parseRatio(item.weight),
+        ratio: Number(item.weight ?? 0),
         evalKrw: Number(holding?.evalKrw ?? 0),
         stockCode: holding?.stockCode ?? null,
         marketType: holding?.marketType ?? null,
@@ -96,16 +91,10 @@ function usePortfolio(enabled, topN = 3) {
 }
 
 function buildConicStops(items, getColor) {
-  const total = items.reduce((sum, item) => sum + (Number.isFinite(item.ratio) ? item.ratio : 0), 0)
-  if (!Number.isFinite(total) || total <= 0) {
-    return '#0046FF 0% 100%'
-  }
-
   let start = 0
   return items.map((item, i) => {
     const color = getColor(item, i)
-    const slice = (item.ratio / total) * 100
-    const end = start + slice
+    const end = start + item.ratio
     const stop = `${color} ${start}% ${end}%`
     start = end
     return stop
@@ -115,9 +104,9 @@ function buildConicStops(items, getColor) {
 export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1, rowSpan = 1, onDelete }) {
   const { isAuthenticated, isRestoring } = useAuthStore()
   const { open } = useWidgetDetailStore()
-  const topN = 5
+  const topN = variant === 'portfolio-2x2' ? 6 : 3
   const portfolio = usePortfolio(isAuthenticated && !isRestoring, topN)
-  const { getColor, ready } = usePortfolioColors(portfolio.items)
+  const getColor = usePortfolioColors(portfolio.items)
   const conicStops = useMemo(() => buildConicStops(portfolio.items, getColor), [portfolio.items, getColor])
 
   const returnRateStr = portfolio.returnRate != null
@@ -135,7 +124,7 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
               <span className={`text-widget-10 font-semibold ${returnRateColor}`}>{returnRateStr}</span>
             )}
           </div>
-          <div className="flex flex-col gap-1 flex-1 min-h-0 overflow-y-auto pr-1">
+          <div className="flex flex-col gap-1 flex-1 min-h-0 overflow-hidden">
             {portfolio.isLoading || portfolio.items.length === 0 ? (
               <div className="flex-1 flex items-center justify-center text-widget-9 text-foreground-disabled">
                 {portfolio.isLoading ? '불러오는 중...' : '보유 종목 없음'}
@@ -157,8 +146,7 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
           ) : (
             <div className="flex flex-col flex-1 gap-3 min-h-0">
               <div className="flex items-center gap-3 shrink-0">
-                <div className="relative w-16 h-16 rounded-full shrink-0" style={ready && conicStops ? { background: `conic-gradient(${conicStops})` } : undefined}>
-                  {(!ready || !conicStops) && <div className="absolute inset-0 rounded-full bg-surface-muted" />}
+                <div className="relative w-16 h-16 rounded-full shrink-0" style={{ background: `conic-gradient(${conicStops})` }}>
                   <div className="absolute inset-[28%] rounded-full bg-surface" />
                 </div>
                 <div>
@@ -167,7 +155,7 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
                   <div className="text-widget-9 text-foreground-disabled mt-0.5">+4,280,000원</div>
                 </div>
               </div>
-              <div className="flex flex-col gap-1.5 flex-1 min-h-0 overflow-y-auto pr-1">
+              <div className="flex flex-col gap-1.5 flex-1 min-h-0 overflow-hidden">
                 {portfolio.items.map((item, i) => (
                   <ItemBar key={item.name} item={item} color={getColor(item, i)} barHeight="h-[4px]" />
                 ))}
@@ -189,11 +177,10 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
             </div>
           ) : (
             <div className="flex items-center gap-2.5 flex-1 min-h-0">
-              <div className="relative w-14 h-14 rounded-full shrink-0" style={ready && conicStops ? { background: `conic-gradient(${conicStops})` } : undefined}>
-                {(!ready || !conicStops) && <div className="absolute inset-0 rounded-full bg-surface-muted" />}
+              <div className="relative w-14 h-14 rounded-full shrink-0" style={{ background: `conic-gradient(${conicStops})` }}>
                 <div className="absolute inset-[30%] rounded-full bg-surface" />
               </div>
-              <div className="flex flex-col gap-1 min-w-0 flex-1 min-h-0 overflow-y-auto pr-1">
+              <div className="flex flex-col gap-1 min-w-0 flex-1">
                 {portfolio.items.map((item, i) => (
                   <div key={item.name} className="flex items-center gap-1 min-w-0">
                     <div className="w-1.5 h-1.5 rounded-full shrink-0" style={{ background: getColor(item, i) }} />

--- a/src/features/portfolio/portfolioColors.js
+++ b/src/features/portfolio/portfolioColors.js
@@ -1,15 +1,9 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { getStockLogoUrl } from '@/lib/stockLogo'
 import { extractDominantColor } from '@/lib/extractLogoColor'
 
-const GRAY_COLOR = 'var(--color-chart-other)'
-const FALLBACK_COLORS = [
-  'var(--color-chart-1)',
-  'var(--color-chart-2)',
-  'var(--color-chart-3)',
-  'var(--color-chart-4)',
-  'var(--color-chart-5)',
-]
+const GRAY_COLOR = '#9CA3AF'
+const FALLBACK_COLORS = ['#0046FF', '#00C2A8', '#7B61FF', '#FF8C00', '#0035CC']
 
 function hashString(text) {
   let hash = 5381
@@ -34,6 +28,7 @@ function getFallbackColor(item, idx) {
 
 export function usePortfolioColors(items) {
   const [colors, setColors] = useState({})
+  const [ready, setReady] = useState(false)
 
   const depsKey = useMemo(
     () => JSON.stringify((items ?? []).map((item, idx) => ({
@@ -46,20 +41,19 @@ export function usePortfolioColors(items) {
   )
 
   useEffect(() => {
-    if (!items?.length) return
+    if (!items?.length) { setReady(true); return }
     let cancelled = false
+    setReady(false)
 
-    items.forEach(async (item, idx) => {
+    Promise.all(items.map(async (item, idx) => {
       const key = getStableKey(item, idx)
 
       if (item?.type === 'OTHER' || item?.type === 'CASH') {
-        if (!cancelled) setColors((prev) => ({ ...prev, [key]: GRAY_COLOR }))
-        return
+        return [key, GRAY_COLOR]
       }
 
       if (!item?.stockCode) {
-        if (!cancelled) setColors((prev) => ({ ...prev, [key]: getFallbackColor(item, idx) }))
-        return
+        return [key, getFallbackColor(item, idx)]
       }
 
       const fallback = getFallbackColor(item, idx)
@@ -68,23 +62,25 @@ export function usePortfolioColors(items) {
         getStockLogoUrl('KOSPI', item.stockCode) ??
         getStockLogoUrl('KOSDAQ', item.stockCode)
 
-      if (!url) {
-        if (!cancelled) setColors((prev) => ({ ...prev, [key]: fallback }))
-        return
-      }
+      if (!url) return [key, fallback]
 
       const color = await extractDominantColor(url, fallback)
-      if (!cancelled) setColors((prev) => ({ ...prev, [key]: color }))
+      return [key, color]
+    })).then((entries) => {
+      if (!cancelled) {
+        setColors(Object.fromEntries(entries))
+        setReady(true)
+      }
     })
 
-    return () => {
-      cancelled = true
-    }
+    return () => { cancelled = true }
   }, [depsKey]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  return (item, idx = 0) => {
+  const getColor = useCallback((item, idx = 0) => {
     const key = getStableKey(item, idx)
     if (item?.type === 'OTHER' || item?.type === 'CASH') return GRAY_COLOR
     return colors[key] ?? getFallbackColor(item, idx)
-  }
+  }, [colors])
+
+  return { getColor, ready }
 }

--- a/src/features/portfolio/portfolioColors.js
+++ b/src/features/portfolio/portfolioColors.js
@@ -1,9 +1,15 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { getStockLogoUrl } from '@/lib/stockLogo'
 import { extractDominantColor } from '@/lib/extractLogoColor'
 
-const GRAY_COLOR = '#9CA3AF'
-const FALLBACK_COLORS = ['#0046FF', '#00C2A8', '#7B61FF', '#FF8C00', '#0035CC']
+const GRAY_COLOR = 'var(--color-chart-other)'
+const FALLBACK_COLORS = [
+  'var(--color-chart-1)',
+  'var(--color-chart-2)',
+  'var(--color-chart-3)',
+  'var(--color-chart-4)',
+  'var(--color-chart-5)',
+]
 
 function hashString(text) {
   let hash = 5381
@@ -28,7 +34,6 @@ function getFallbackColor(item, idx) {
 
 export function usePortfolioColors(items) {
   const [colors, setColors] = useState({})
-  const [ready, setReady] = useState(false)
 
   const depsKey = useMemo(
     () => JSON.stringify((items ?? []).map((item, idx) => ({
@@ -41,19 +46,20 @@ export function usePortfolioColors(items) {
   )
 
   useEffect(() => {
-    if (!items?.length) { setReady(true); return }
+    if (!items?.length) return
     let cancelled = false
-    setReady(false)
 
-    Promise.all(items.map(async (item, idx) => {
+    items.forEach(async (item, idx) => {
       const key = getStableKey(item, idx)
 
       if (item?.type === 'OTHER' || item?.type === 'CASH') {
-        return [key, GRAY_COLOR]
+        if (!cancelled) setColors((prev) => ({ ...prev, [key]: GRAY_COLOR }))
+        return
       }
 
       if (!item?.stockCode) {
-        return [key, getFallbackColor(item, idx)]
+        if (!cancelled) setColors((prev) => ({ ...prev, [key]: getFallbackColor(item, idx) }))
+        return
       }
 
       const fallback = getFallbackColor(item, idx)
@@ -62,25 +68,23 @@ export function usePortfolioColors(items) {
         getStockLogoUrl('KOSPI', item.stockCode) ??
         getStockLogoUrl('KOSDAQ', item.stockCode)
 
-      if (!url) return [key, fallback]
+      if (!url) {
+        if (!cancelled) setColors((prev) => ({ ...prev, [key]: fallback }))
+        return
+      }
 
       const color = await extractDominantColor(url, fallback)
-      return [key, color]
-    })).then((entries) => {
-      if (!cancelled) {
-        setColors(Object.fromEntries(entries))
-        setReady(true)
-      }
+      if (!cancelled) setColors((prev) => ({ ...prev, [key]: color }))
     })
 
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+    }
   }, [depsKey]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  const getColor = useCallback((item, idx = 0) => {
+  return (item, idx = 0) => {
     const key = getStableKey(item, idx)
     if (item?.type === 'OTHER' || item?.type === 'CASH') return GRAY_COLOR
     return colors[key] ?? getFallbackColor(item, idx)
-  }, [colors])
-
-  return { getColor, ready }
+  }
 }

--- a/src/lib/extractLogoColor.js
+++ b/src/lib/extractLogoColor.js
@@ -4,6 +4,9 @@
  */
 export async function extractDominantColor(url, fallback = '#0046FF') {
   return new Promise((resolve) => {
+    const clamp8 = (v) => Math.max(0, Math.min(255, Number(v) || 0))
+    const isValidHex = (hex) => /^#[0-9a-fA-F]{6}$/.test(hex)
+
     const img = new Image()
     img.crossOrigin = 'anonymous'
     img.onload = () => {
@@ -23,15 +26,16 @@ export async function extractDominantColor(url, fallback = '#0046FF') {
           if (r > 235 && g > 235 && b > 235) continue // 흰색 계열
           if (r < 20 && g < 20 && b < 20) continue    // 검정 계열
           // 16단위로 버킷팅
-          const key = `${Math.round(r / 16) * 16},${Math.round(g / 16) * 16},${Math.round(b / 16) * 16}`
+          const key = `${Math.floor(r / 16) * 16},${Math.floor(g / 16) * 16},${Math.floor(b / 16) * 16}`
           buckets[key] = (buckets[key] || 0) + 1
         }
 
         const top = Object.entries(buckets).sort((a, b) => b[1] - a[1])[0]
         if (!top) return resolve(fallback)
 
-        const [r, g, b] = top[0].split(',').map(Number)
+        const [r, g, b] = top[0].split(',').map((v) => clamp8(v))
         const hex = '#' + [r, g, b].map((v) => v.toString(16).padStart(2, '0')).join('')
+        if (!isValidHex(hex)) return resolve(fallback)
         resolve(hex)
       } catch {
         resolve(fallback)

--- a/src/pages/AssetPage.jsx
+++ b/src/pages/AssetPage.jsx
@@ -2,8 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ArrowLeftRight } from 'lucide-react'
 import ReactECharts from 'echarts-for-react'
-import { getStockLogoUrl } from '@/lib/stockLogo'
-import { extractDominantColor } from '@/lib/extractLogoColor'
+import { usePortfolioColors } from '@/features/portfolio/portfolioColors'
 import StockAvatar from '@/components/ui/StockAvatar'
 import { cn } from '@/lib/cn'
 import ExchangeModal from '@/components/asset/ExchangeModal'
@@ -356,55 +355,12 @@ function AssetFlowCard({ data, assetFlowRange, onChangeAssetFlowRange }) {
   )
 }
 
-// ── 로고 대표색 추출 훅 ───────────────────────────────────────────
-const CASH_COLOR = '#9CA3AF'
-const FALLBACK_COLORS = ['#0046FF', '#00C2A8', '#7B61FF', '#FF8C00', '#0035CC']
-
-function useLogoColors(items) {
-  const [colors, setColors] = useState({})
-  const [ready, setReady] = useState(false)
-
-  useEffect(() => {
-    if (!items?.length) { setReady(true); return }
-    let isCancelled = false
-    setReady(false)
-
-    Promise.all(items.map(async (item, i) => {
-      const key = item.stockCode ?? `cash_${i}`
-      if (item.type === 'CASH') return [key, CASH_COLOR]
-      if (!item.stockCode) return [key, FALLBACK_COLORS[i % FALLBACK_COLORS.length]]
-      const url =
-        getStockLogoUrl(item.marketType, item.stockCode) ??
-        getStockLogoUrl('KOSPI', item.stockCode) ??
-        getStockLogoUrl('KOSDAQ', item.stockCode)
-      if (!url) return [key, FALLBACK_COLORS[i % FALLBACK_COLORS.length]]
-      const color = await extractDominantColor(url, FALLBACK_COLORS[i % FALLBACK_COLORS.length])
-      return [key, color]
-    })).then((entries) => {
-      if (!isCancelled) {
-        setColors(Object.fromEntries(entries))
-        setReady(true)
-      }
-    })
-
-    return () => { isCancelled = true }
-  // items 배열 내용 변화 감지를 위해 JSON 직렬화
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(items?.map((i) => i.stockCode))])
-
-  const getColor = (item, idx) => {
-    const key = item.stockCode ?? `cash_${idx}`
-    return colors[key] ?? FALLBACK_COLORS[idx % FALLBACK_COLORS.length]
-  }
-
-  return { getColor, ready }
-}
 
 // ── 포트폴리오 파이차트 패널 (하단 좌) ───────────────────────────
 function PortfolioPanel({ data }) {
   const { portfolioItems } = data
 
-  const { getColor, ready } = useLogoColors(portfolioItems)
+  const { getColor, ready } = usePortfolioColors(portfolioItems)
   const hasItems = portfolioItems.length > 0
 
   const sortedItems = [...portfolioItems].sort((a, b) => b.weight - a.weight)

--- a/src/pages/AssetPage.jsx
+++ b/src/pages/AssetPage.jsx
@@ -2,7 +2,8 @@ import { useState, useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ArrowLeftRight } from 'lucide-react'
 import ReactECharts from 'echarts-for-react'
-import { usePortfolioColors } from '@/features/portfolio/portfolioColors'
+import { getStockLogoUrl } from '@/lib/stockLogo'
+import { extractDominantColor } from '@/lib/extractLogoColor'
 import StockAvatar from '@/components/ui/StockAvatar'
 import { cn } from '@/lib/cn'
 import ExchangeModal from '@/components/asset/ExchangeModal'
@@ -355,12 +356,55 @@ function AssetFlowCard({ data, assetFlowRange, onChangeAssetFlowRange }) {
   )
 }
 
+// ── 로고 대표색 추출 훅 ───────────────────────────────────────────
+const CASH_COLOR = '#9CA3AF'
+const FALLBACK_COLORS = ['#0046FF', '#00C2A8', '#7B61FF', '#FF8C00', '#0035CC']
+
+function useLogoColors(items) {
+  const [colors, setColors] = useState({})
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    if (!items?.length) { setReady(true); return }
+    let isCancelled = false
+    setReady(false)
+
+    Promise.all(items.map(async (item, i) => {
+      const key = item.stockCode ?? `cash_${i}`
+      if (item.type === 'CASH') return [key, CASH_COLOR]
+      if (!item.stockCode) return [key, FALLBACK_COLORS[i % FALLBACK_COLORS.length]]
+      const url =
+        getStockLogoUrl(item.marketType, item.stockCode) ??
+        getStockLogoUrl('KOSPI', item.stockCode) ??
+        getStockLogoUrl('KOSDAQ', item.stockCode)
+      if (!url) return [key, FALLBACK_COLORS[i % FALLBACK_COLORS.length]]
+      const color = await extractDominantColor(url, FALLBACK_COLORS[i % FALLBACK_COLORS.length])
+      return [key, color]
+    })).then((entries) => {
+      if (!isCancelled) {
+        setColors(Object.fromEntries(entries))
+        setReady(true)
+      }
+    })
+
+    return () => { isCancelled = true }
+  // items 배열 내용 변화 감지를 위해 JSON 직렬화
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(items?.map((i) => i.stockCode))])
+
+  const getColor = (item, idx) => {
+    const key = item.stockCode ?? `cash_${idx}`
+    return colors[key] ?? FALLBACK_COLORS[idx % FALLBACK_COLORS.length]
+  }
+
+  return { getColor, ready }
+}
 
 // ── 포트폴리오 파이차트 패널 (하단 좌) ───────────────────────────
 function PortfolioPanel({ data }) {
   const { portfolioItems } = data
 
-  const { getColor, ready } = usePortfolioColors(portfolioItems)
+  const { getColor, ready } = useLogoColors(portfolioItems)
   const hasItems = portfolioItems.length > 0
 
   const sortedItems = [...portfolioItems].sort((a, b) => b.weight - a.weight)


### PR DESCRIPTION
## 변경 요약
- 포트폴리오 위젯(1x1/2x1/2x2) 비중 표시를 `상위 5개 + 기타`로 통일
- wide/2x2(및 sm 리스트 영역) 아이템 잘림 이슈를 스크롤(`overflow-y-auto`)로 개선
- 포트폴리오 위젯 파이차트 렌더 안정화
  - 비중값 파싱/정규화 강화(`NaN` 유입 방지)
  - conic-gradient stop 계산 안전화
  - 로딩 전 회색 플레이스홀더 → 색상 추출 완료 후 차트 전환
- 색상 추출 실패 케이스 보강
  - 대표색 추출 버킷 계산 안정화(`round` → `floor`)
  - RGB clamp 및 hex 유효성 검증 추가
  - 실패 시 fallback 색상으로 일관 처리
- 잔고 탭(AssetPage) 파이차트 색상 로직을 위젯과 동일한 공통 훅(`usePortfolioColors`)으로 통일

## 주요 파일
- `src/components/widgets/PortfolioWidget.jsx`
- `src/features/portfolio/portfolioColors.js`
- `src/lib/extractLogoColor.js`
- `src/pages/AssetPage.jsx`

## QA 체크리스트
- [x] 포트폴리오 위젯(sm/2x2) 도넛 차트 표시
- [x] 색상 추출 전 회색 플레이스홀더 표시 후 색상 전환
- [x] 6개 이상 보유 시 `5개 + 기타` 슬라이스 표시
- [x] wide/2x2 아이템 스크롤 동작
- [x] 잔고 탭 파이차트가 위젯과 동일 색상 추출 로직 사용

## 참고
- 포트폴리오 위젯 수익률과 잔고 탭 헤더 수익률은 현재 지표 정의가 다릅니다.
  - 위젯: `totalStockUnrealizedProfitLossRate` (보유주식 기준)
  - 잔고 헤더: `accountProfitLossRate` (계좌 전체 기준)
