### PR TITLE
fix(widget-ui): 위젯 헤더 액션 정렬 통일(dnd handle이랑 겹치는 문제 해결)

### DIFF
--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronLeft } from 'lucide-react'
+import { ChevronDown, ChevronLeft, Settings2 } from 'lucide-react'
 import { useDraggable } from '@dnd-kit/core'
 import { cn } from '@/lib/cn'
 import useGridStore from '@/store/useGridStore'
@@ -255,9 +255,9 @@ export function PreviewContent({ type, sectorStocks, typeIndex = 0 }) {
           ]
       return (
         <div className="flex flex-col h-full gap-1.5">
-          <div className="flex items-center justify-between shrink-0">
+          <div className="flex items-center gap-1.5 shrink-0">
             <span className="text-[9px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">실시간 순위</span>
-            <div className="flex gap-1.5 justify-end">
+            <div className="flex gap-1.5">
             {['거래금', '급상승', '거래량'].map((tab, i) => (
               <span key={tab} className={`text-[9px] font-semibold px-1.5 py-0.5 rounded-full ${i === 0 ? 'bg-primary-light text-primary' : 'text-foreground-disabled'}`}>{tab}</span>
             ))}
@@ -301,9 +301,9 @@ export function PreviewContent({ type, sectorStocks, typeIndex = 0 }) {
           ]
       return (
         <div className="flex flex-col h-full gap-1.5">
-          <div className="flex items-center justify-between shrink-0">
+          <div className="flex items-center gap-1.5 shrink-0">
             <span className="text-[9px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">실시간 순위</span>
-            <div className="flex gap-1.5 justify-end">
+            <div className="flex gap-1.5">
             {['거래금', '급상승', '거래량'].map((tab, i) => (
               <span key={tab} className={`text-[9px] font-semibold px-1.5 py-0.5 rounded-full ${i === 0 ? 'bg-primary-light text-primary' : 'text-foreground-disabled'}`}>{tab}</span>
             ))}
@@ -328,7 +328,10 @@ export function PreviewContent({ type, sectorStocks, typeIndex = 0 }) {
     case 'index-sm':
       return (
         <div className="flex flex-col h-full">
-          <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">주요 지수</span>
+          <div className="flex items-center gap-1 shrink-0">
+            <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">주요 지수</span>
+            <Settings2 className="w-2.5 h-2.5 text-foreground-disabled" />
+          </div>
           <div className="flex-1 flex flex-col justify-center items-center text-center min-h-0">
             <div className="text-[8px] text-foreground-disabled">KOSPI</div>
             <div className="text-[15px] font-extrabold text-foreground leading-tight">2,685.42</div>
@@ -341,7 +344,10 @@ export function PreviewContent({ type, sectorStocks, typeIndex = 0 }) {
     case 'index-wide':
       return (
         <div className="flex flex-col h-full gap-1">
-          <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">주요 지수</span>
+          <div className="flex items-center gap-1 shrink-0">
+            <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">주요 지수</span>
+            <Settings2 className="w-2.5 h-2.5 text-foreground-disabled" />
+          </div>
           <div className="flex flex-1 min-h-0 divide-x divide-stroke">
             {[
               { name: 'KOSPI',  val: '2,685', chg: '+0.46%', up: true  },
@@ -429,7 +435,7 @@ export function PreviewContent({ type, sectorStocks, typeIndex = 0 }) {
     case 'market-sm':
       return (
         <div className="flex flex-col h-full">
-          <div className="flex items-center justify-between mb-1 shrink-0">
+          <div className="flex items-center gap-1 shrink-0 mb-1">
             <span className="text-[9px] font-semibold text-foreground-disabled uppercase tracking-[.04em]">오늘의 시황</span>
             <div className="flex gap-1">
               <span className="px-1.5 py-px text-[7px] font-semibold rounded bg-primary text-white">국내</span>
@@ -448,7 +454,7 @@ export function PreviewContent({ type, sectorStocks, typeIndex = 0 }) {
     case 'market-wide':
       return (
         <div className="flex flex-col h-full">
-          <div className="flex items-center justify-between mb-1 shrink-0">
+          <div className="flex items-center gap-1 shrink-0 mb-1">
             <span className="text-[9px] font-semibold text-foreground-disabled uppercase tracking-[.04em]">오늘의 시황</span>
             <div className="flex gap-1">
               <span className="px-1.5 py-px text-[7px] font-semibold rounded bg-primary text-white">국내</span>
@@ -487,7 +493,10 @@ export function PreviewContent({ type, sectorStocks, typeIndex = 0 }) {
 
       return (
         <div className="flex flex-col h-full gap-1">
-          <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">관심종목</span>
+          <div className="flex items-center gap-1 shrink-0">
+            <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">관심종목</span>
+            <Settings2 className="w-2.5 h-2.5 text-foreground-disabled" />
+          </div>
           <div className="flex flex-col gap-1.5">
             {watchData.map(({ name, chg, up }) => (
               <div key={name} className="flex items-center justify-between">
@@ -518,7 +527,10 @@ export function PreviewContent({ type, sectorStocks, typeIndex = 0 }) {
 
       return (
         <div className="flex flex-col h-full gap-1">
-          <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">관심종목</span>
+          <div className="flex items-center gap-1 shrink-0">
+            <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">관심종목</span>
+            <Settings2 className="w-2.5 h-2.5 text-foreground-disabled" />
+          </div>
           <div className="flex flex-col gap-1.5">
             {watchData.map(({ name, code, price, chg, up }) => (
               <div key={name} className="flex items-center justify-between gap-2">
@@ -777,7 +789,10 @@ export function PreviewContent({ type, sectorStocks, typeIndex = 0 }) {
     case 'index-3x1':
       return (
         <div className="flex flex-col h-full gap-1">
-          <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">주요 지수</span>
+          <div className="flex items-center gap-1 shrink-0">
+            <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">주요 지수</span>
+            <Settings2 className="w-2.5 h-2.5 text-foreground-disabled" />
+          </div>
           <div className="flex flex-1 min-h-0 divide-x divide-stroke">
             {[
               { name: 'KOSPI',  val: '2,685.42', chg: '+0.46%', up: true  },
@@ -798,7 +813,10 @@ export function PreviewContent({ type, sectorStocks, typeIndex = 0 }) {
     case 'index-2x2':
       return (
         <div className="flex flex-col h-full gap-2">
-          <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">주요 지수</span>
+          <div className="flex items-center gap-1 shrink-0">
+            <span className="text-[9px] font-semibold text-foreground-disabled shrink-0">주요 지수</span>
+            <Settings2 className="w-2.5 h-2.5 text-foreground-disabled" />
+          </div>
           <div className="flex flex-col justify-center gap-2.5 flex-1">
             {[
               { name: 'KOSPI',  val: '2,685.42', chg: '+0.46%', up: true  },
@@ -949,7 +967,7 @@ export function PreviewContent({ type, sectorStocks, typeIndex = 0 }) {
 
       return (
         <div className="flex flex-col h-full">
-          <div className="flex items-center justify-between mb-1 shrink-0">
+          <div className="flex items-center gap-1 shrink-0 mb-1">
             <span className="text-[9px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 뉴스</span>
             <span className="flex items-center gap-0.5 text-[8px] font-semibold text-primary shrink-0">
               {name}
@@ -979,7 +997,7 @@ export function PreviewContent({ type, sectorStocks, typeIndex = 0 }) {
 
       return (
         <div className="flex flex-col h-full">
-          <div className="flex items-center justify-between mb-1 shrink-0">
+          <div className="flex items-center gap-1 shrink-0 mb-1">
             <span className="text-[9px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 뉴스</span>
             <span className="flex items-center gap-0.5 text-[8px] font-semibold text-primary shrink-0">
               {name}
@@ -1019,7 +1037,7 @@ export function PreviewContent({ type, sectorStocks, typeIndex = 0 }) {
 
       return (
         <div className="flex flex-col h-full">
-          <div className="flex items-center justify-between mb-1 shrink-0">
+          <div className="flex items-center gap-1 shrink-0 mb-1">
             <span className="text-[9px] font-semibold text-foreground-disabled tracking-[.04em] uppercase">종목별 뉴스</span>
             <span className="flex items-center gap-0.5 text-[8px] font-semibold text-primary shrink-0">
               {name}
@@ -1051,8 +1069,12 @@ export function PreviewContent({ type, sectorStocks, typeIndex = 0 }) {
     case 'market-2x2':
       return (
         <div className="flex flex-col h-full">
-          <div className="flex items-center justify-between mb-1 shrink-0">
+          <div className="flex items-center gap-1 shrink-0 mb-1">
             <span className="text-[9px] font-semibold text-foreground-disabled uppercase tracking-[.04em]">오늘의 시황</span>
+            <div className="flex gap-1">
+              <span className="px-1.5 py-px text-[7px] font-semibold rounded bg-primary text-white">국내</span>
+              <span className="px-1.5 py-px text-[7px] font-semibold rounded text-foreground-disabled">해외</span>
+            </div>
           </div>
           <div className="flex flex-col flex-1 min-h-0 gap-2">
             <div>

--- a/src/components/widgets/BalanceWidget.jsx
+++ b/src/components/widgets/BalanceWidget.jsx
@@ -205,7 +205,7 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
           </div>
           {BALANCE.isLoading
             ? <div className="text-widget-11 text-foreground-disabled mt-1">-</div>
-            : <div className={`text-widget-11 font-semibold mt-1 ${BALANCE.isProfit ? 'text-up' : 'text-down'}`}>{BALANCE.isProfit ? '▲' : '▼'} {BALANCE.profit} ({BALANCE.profitRate})</div>
+            : <div className={`text-widget-10 font-semibold mt-1 ${BALANCE.isProfit ? 'text-up' : 'text-down'}`}>{BALANCE.isProfit ? '▲' : '▼'} {BALANCE.profit} ({BALANCE.profitRate})</div>
           }
         </div>
       )}

--- a/src/components/widgets/IndexWidget.jsx
+++ b/src/components/widgets/IndexWidget.jsx
@@ -96,8 +96,8 @@ export default function IndexWidget({ instanceId, variant = 'index-wide', colSpa
     return (
       <>
         <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={(e) => handleIndexClick(e, shown.code)}>
-          <div className="flex items-center justify-between shrink-0">
-            <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">주요 지수</span>
+          <div className="flex items-center gap-1.5 shrink-0">
+            <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase shrink-0">주요 지수</span>
             <SettingsButton onClick={() => setIsConfigOpen(true)} />
           </div>
           <div className="relative flex-1 flex flex-col justify-center items-center text-center min-h-0 group">
@@ -123,8 +123,8 @@ export default function IndexWidget({ instanceId, variant = 'index-wide', colSpa
     return (
       <>
         <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-          <div className="flex items-center justify-between shrink-0">
-            <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">주요 지수</span>
+          <div className="flex items-center gap-1.5 shrink-0">
+            <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase shrink-0">주요 지수</span>
             <SettingsButton onClick={() => setIsConfigOpen(true)} />
           </div>
           <div className="flex flex-1 min-h-0 divide-x divide-stroke mt-1">
@@ -158,8 +158,8 @@ export default function IndexWidget({ instanceId, variant = 'index-wide', colSpa
     return (
       <>
         <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-          <div className="flex items-center justify-between mb-2 shrink-0">
-            <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">주요 지수</span>
+          <div className="flex items-center gap-1.5 mb-2 shrink-0">
+            <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase shrink-0">주요 지수</span>
             <SettingsButton onClick={() => setIsConfigOpen(true)} />
           </div>
           <div className="flex flex-col flex-1 justify-center gap-3">
@@ -193,8 +193,8 @@ export default function IndexWidget({ instanceId, variant = 'index-wide', colSpa
   return (
     <>
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete}>
-        <div className="flex items-center justify-between shrink-0">
-          <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">주요 지수</span>
+        <div className="flex items-center gap-1.5 shrink-0">
+          <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase shrink-0">주요 지수</span>
           <SettingsButton onClick={() => setIsConfigOpen(true)} />
         </div>
         <div className="flex flex-1 min-h-0 divide-x divide-stroke mt-1">

--- a/src/components/widgets/MarketOverviewWidget.jsx
+++ b/src/components/widgets/MarketOverviewWidget.jsx
@@ -105,7 +105,7 @@ export default function MarketOverviewWidget({ instanceId, variant = 'market-sm'
     const sectionCardClass = 'flex flex-col gap-0.5 py-2 border-b border-stroke last:border-b-0 cursor-pointer pl-2 border-l-2 border-l-transparent hover:border-l-primary transition-colors'
     return (
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
-        <div className="flex items-center justify-between mb-1 shrink-0">
+        <div className="flex items-center gap-1.5 mb-1 shrink-0">
           <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">오늘의 시황</span>
         </div>
         <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-2">
@@ -139,7 +139,7 @@ export default function MarketOverviewWidget({ instanceId, variant = 'market-sm'
   if (variant === 'market-wide') {
     return (
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
-        <div className="flex items-center justify-between mb-1 shrink-0">
+        <div className="flex items-center gap-1.5 mb-1 shrink-0">
           <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">오늘의 시황</span>
           {tabBar}
         </div>
@@ -155,7 +155,7 @@ export default function MarketOverviewWidget({ instanceId, variant = 'market-sm'
   /* market-sm */
   return (
     <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
-      <div className="flex items-center justify-between mb-1 shrink-0">
+      <div className="flex items-center gap-1.5 mb-1 shrink-0">
         <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">오늘의 시황</span>
         {tabBar}
       </div>

--- a/src/components/widgets/RankingWidget.jsx
+++ b/src/components/widgets/RankingWidget.jsx
@@ -60,7 +60,7 @@ export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, r
   if (variant === 'ranking-lg') {
     return (
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleCardClick}>
-        <div className="flex items-center justify-between mb-1.5 shrink-0">
+        <div className="flex items-center gap-1.5 mb-1.5 shrink-0">
           <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">실시간 순위</span>
           <div className="flex gap-0.5">
             {TABS.map((tab) => (
@@ -103,7 +103,7 @@ export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, r
   /* ranking-wide (default) */
   return (
     <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleCardClick}>
-      <div className="flex items-center justify-between mb-1.5 shrink-0">
+      <div className="flex items-center gap-1.5 mb-1.5 shrink-0">
         <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">실시간 순위</span>
         <div className="flex gap-0.5">
           {TABS.map((tab) => (

--- a/src/components/widgets/StockNewsWidget.jsx
+++ b/src/components/widgets/StockNewsWidget.jsx
@@ -121,7 +121,7 @@ export default function StockNewsWidget({ instanceId, variant = 'stock-news-sm',
   if (variant === 'stock-news-2x2') {
     return (
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
-        <div className="flex items-center justify-between gap-1 mb-1 shrink-0 min-w-0">
+        <div className="flex items-center gap-1.5 mb-1 shrink-0 min-w-0">
           <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase whitespace-nowrap shrink-0">종목별 뉴스</span>
           {chip}
         </div>
@@ -138,7 +138,7 @@ export default function StockNewsWidget({ instanceId, variant = 'stock-news-sm',
   if (variant === 'stock-news-wide') {
     return (
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
-        <div className="flex items-center justify-between gap-1 mb-1 shrink-0 min-w-0">
+        <div className="flex items-center gap-1.5 mb-1 shrink-0 min-w-0">
           <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase whitespace-nowrap shrink-0">종목별 뉴스</span>
           {chip}
         </div>
@@ -155,7 +155,7 @@ export default function StockNewsWidget({ instanceId, variant = 'stock-news-sm',
   /* stock-news-sm */
   return (
     <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
-      <div className="flex items-center justify-between gap-1 mb-1 shrink-0 min-w-0">
+      <div className="flex items-center gap-1.5 mb-1 shrink-0 min-w-0">
         <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase whitespace-nowrap shrink-0">종목별 뉴스</span>
         {chip}
       </div>

--- a/src/components/widgets/WatchlistWidget.jsx
+++ b/src/components/widgets/WatchlistWidget.jsx
@@ -99,8 +99,8 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
     return (
       <>
         <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
-          <div className="flex items-center justify-between mb-2 shrink-0">
-            <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">관심 종목</span>
+          <div className="flex items-center gap-1.5 mb-2 shrink-0">
+            <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase shrink-0">관심종목</span>
             {editBtn}
           </div>
           <div className="flex-1 flex flex-col gap-1 min-h-0 overflow-y-auto">
@@ -140,8 +140,8 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
   return (
     <>
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
-        <div className="flex items-center justify-between mb-2 shrink-0">
-          <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">관심 종목</span>
+        <div className="flex items-center gap-1.5 mb-2 shrink-0">
+          <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase shrink-0">관심종목</span>
           {editBtn}
         </div>
         <div className="flex-1 flex flex-col gap-1 min-h-0 overflow-y-auto">


### PR DESCRIPTION
## 변경 배경
dnd handle이랑 겹치는 문제 해결

## 주요 변경
### 1) 위젯 헤더 액션 배치 통일
아래 위젯에서 헤더 컨트롤을 제목 텍스트 옆으로 이동했습니다.
- 주요 지수: 설정 버튼 → `주요 지수` 옆
- 관심종목: 편집 버튼 → `관심종목` 옆
- 종목별 뉴스: 종목 선택 드롭다운 → `종목별 뉴스` 옆
- 오늘의 시황: `국내/해외` 탭 → `오늘의 시황` 옆
- 실시간 순위: `거래대금/급상승/거래량` 탭 → `실시간 순위` 옆

### 2) EditPanel 미리보기 동기화
실제 위젯과 동일한 헤더 구조가 보이도록 미리보기 레이아웃을 맞췄습니다.
- 주요 지수 / 관심종목 / 종목별 뉴스 / 오늘의 시황 / 실시간 순위 프리뷰 반영

## 수정 파일(이번 작업 범위)
- `src/components/widgets/IndexWidget.jsx`
- `src/components/widgets/WatchlistWidget.jsx`
- `src/components/widgets/StockNewsWidget.jsx`
- `src/components/widgets/MarketOverviewWidget.jsx`
- `src/components/widgets/RankingWidget.jsx`
- `src/components/layout/EditPanel/WidgetSizeList.jsx`

## QA 체크
- [x] 실제 위젯에서 헤더 액션이 제목 옆에 표시되는지 확인
- [x] EditPanel 미리보기에서도 동일 배치로 표시되는지 확인
- [x] 각 액션(설정/탭 변경/드롭다운) 클릭 동작 영향 없는지 확인