### PR TITLE
fix(chat): 위젯 드래그 시 stockCode/stockName 힌트 전달 및 채팅 차트 카드 개선

### DIFF
--- a/src/api/chat.js
+++ b/src/api/chat.js
@@ -1,10 +1,14 @@
 import { fetchWithAuth } from '@/lib/fetchWithAuth'
 
 export const chatApi = {
-  sendMessage: (message) =>
+  sendMessage: (message, stockCode = null, stockName = null) =>
     fetchWithAuth('/chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ message }),
+      body: JSON.stringify({
+        message,
+        ...(stockCode ? { stock_code_hint: stockCode } : {}),
+        ...(stockName ? { stock_name_hint: stockName } : {}),
+      }),
     }),
 }

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -208,7 +208,7 @@ export default function AppShell() {
       if (over?.id === 'chat-dropzone') {
         const { widgetTypeId, variantId, config } = active.data.current
         const query = getWidgetDefaultQuery(widgetTypeId, config, variantId)
-        if (query) setPendingQuery(query)
+        if (query) setPendingQuery(query.text, query.stockCode, query.stockName)
       }
     }
   }

--- a/src/components/layout/ChatPanel.jsx
+++ b/src/components/layout/ChatPanel.jsx
@@ -1042,7 +1042,7 @@ export default function ChatPanel() {
     }
   }, []);
 
-  const handleSend = useCallback(async (text) => {
+  const handleSend = useCallback(async (text, stockCode = null, stockName = null) => {
     const userMsg = {
       id: Date.now(),
       role: "user",
@@ -1053,7 +1053,7 @@ export default function ChatPanel() {
     setIsTyping(true);
 
     try {
-      const data = await chatApi.sendMessage(text);
+      const data = await chatApi.sendMessage(text, stockCode, stockName);
       lastFailedTextRef.current = null;
 
       const INFO_CARD_TYPES = ['index', 'ranking', 'balance', 'exchange_rate', 'market_overview', 'portfolio', 'trade_history', 'trade-history'];
@@ -1118,7 +1118,7 @@ export default function ChatPanel() {
         ]);
       }
     } catch {
-      lastFailedTextRef.current = text;
+      lastFailedTextRef.current = { text, stockCode, stockName };
       setMessages((prev) => [
         ...prev,
         {
@@ -1137,16 +1137,16 @@ export default function ChatPanel() {
   // 대시보드 위젯 → 채팅 드롭 시 자동 질의 전송
   useEffect(() => {
     if (!pendingQuery || !isAuthenticated) return
-    const query = pendingQuery
+    const { text, stockCode, stockName } = pendingQuery
     consumePendingQuery()
-    handleSend(query)
+    handleSend(text, stockCode, stockName)
   }, [pendingQuery, isAuthenticated, consumePendingQuery, handleSend])
 
   const handleRetry = useCallback(() => {
-    const text = lastFailedTextRef.current;
-    if (!text) return;
+    const failed = lastFailedTextRef.current;
+    if (!failed) return;
     setMessages((prev) => prev.filter((m) => !m.isError));
-    handleSend(text);
+    handleSend(failed.text, failed.stockCode, failed.stockName);
   }, [handleSend]);
 
   const handlePinClose = useCallback((messageId, sourceOrderId) => {

--- a/src/components/layout/ChatStockCard.jsx
+++ b/src/components/layout/ChatStockCard.jsx
@@ -267,7 +267,7 @@ export default function ChatStockCard({ stockCode, stockName, marketType, exchan
           <div>
             <div className="text-widget-13 font-bold text-foreground">{stockName}</div>
             <div className="text-widget-9 text-foreground-disabled">
-              {stockCode}{marketType ? ` · ${marketType}` : ''}
+              {stockCode}
             </div>
           </div>
         </div>

--- a/src/config/widgetShortcuts.js
+++ b/src/config/widgetShortcuts.js
@@ -90,20 +90,22 @@ function resolveStockName(config = {}) {
   return STOCK_NAME_BY_ID['shinhan']
 }
 
+// 반환값: { text: string, stockCode: string | null }
 export function getWidgetDefaultQuery(widgetTypeId, config = {}, variantId) {
   if (widgetTypeId === 'stock-chart') {
     const name = resolveStockName(config)
-    return `${name} 주가 알려줘`
+    return { text: `${name} 주가 알려줘`, stockCode: config.stockCode ?? null, stockName: config.stockName ?? null }
   }
   if (widgetTypeId === 'stock-news') {
     const name = resolveStockName(config)
-    return `${name} 종목 뉴스 알려줘`
+    return { text: `${name} 종목 뉴스 알려줘`, stockCode: config.stockCode ?? null, stockName: config.stockName ?? null }
   }
   if (widgetTypeId === 'market-overview') {
-    if (variantId === 'market-2x2') return '오늘의 시황 알려줘'
+    if (variantId === 'market-2x2') return { text: '오늘의 시황 알려줘', stockCode: null }
     const STORAGE_KEY = 'marketOverviewWidget.activeTab'
     const tab = config.tab ?? localStorage.getItem(STORAGE_KEY) ?? 'kr'
-    return tab === 'us' ? '해외 시황 알려줘' : '국내 시황 알려줘'
+    return { text: tab === 'us' ? '해외 시황 알려줘' : '국내 시황 알려줘', stockCode: null }
   }
-  return WIDGET_SHORTCUTS.find((s) => s.widgetTypeId === widgetTypeId)?.defaultQuery ?? null
+  const defaultQuery = WIDGET_SHORTCUTS.find((s) => s.widgetTypeId === widgetTypeId)?.defaultQuery ?? null
+  return defaultQuery ? { text: defaultQuery, stockCode: null } : null
 }

--- a/src/config/widgetShortcuts.js
+++ b/src/config/widgetShortcuts.js
@@ -90,7 +90,7 @@ function resolveStockName(config = {}) {
   return STOCK_NAME_BY_ID['shinhan']
 }
 
-// 반환값: { text: string, stockCode: string | null }
+// 반환값: { text: string, stockCode: string | null, stockName: string | null }
 export function getWidgetDefaultQuery(widgetTypeId, config = {}, variantId) {
   if (widgetTypeId === 'stock-chart') {
     const name = resolveStockName(config)
@@ -101,11 +101,11 @@ export function getWidgetDefaultQuery(widgetTypeId, config = {}, variantId) {
     return { text: `${name} 종목 뉴스 알려줘`, stockCode: config.stockCode ?? null, stockName: config.stockName ?? null }
   }
   if (widgetTypeId === 'market-overview') {
-    if (variantId === 'market-2x2') return { text: '오늘의 시황 알려줘', stockCode: null }
+    if (variantId === 'market-2x2') return { text: '오늘의 시황 알려줘', stockCode: null, stockName: null }
     const STORAGE_KEY = 'marketOverviewWidget.activeTab'
     const tab = config.tab ?? localStorage.getItem(STORAGE_KEY) ?? 'kr'
-    return { text: tab === 'us' ? '해외 시황 알려줘' : '국내 시황 알려줘', stockCode: null }
+    return { text: tab === 'us' ? '해외 시황 알려줘' : '국내 시황 알려줘', stockCode: null, stockName: null }
   }
   const defaultQuery = WIDGET_SHORTCUTS.find((s) => s.widgetTypeId === widgetTypeId)?.defaultQuery ?? null
-  return defaultQuery ? { text: defaultQuery, stockCode: null } : null
+  return defaultQuery ? { text: defaultQuery, stockCode: null, stockName: null } : null
 }

--- a/src/store/usePendingQueryStore.js
+++ b/src/store/usePendingQueryStore.js
@@ -1,8 +1,8 @@
 import { create } from 'zustand'
 
 const usePendingQueryStore = create((set, get) => ({
-  pendingQuery: null,
-  setPendingQuery: (text) => set({ pendingQuery: text }),
+  pendingQuery: null,   // { text: string, stockCode: string | null, stockName: string | null }
+  setPendingQuery: (text, stockCode = null, stockName = null) => set({ pendingQuery: { text, stockCode, stockName } }),
   consumePendingQuery: () => {
     const value = get().pendingQuery
     set({ pendingQuery: null })


### PR DESCRIPTION
## 연관 이슈
* Closes #141 


## 작업 내용

시세 위젯을 채팅으로 드래그 앤 드롭할 때 AI가 종목을 정확히 인식하지 못하는 문제 수정.
기존에는 AI가 종목명을 KOSPI200 + NASDAQ100 CSV에서만 조회하여 비KOSPI200 종목(예: 세진중공업)의 경우 "종목명을 정확히 입력해 주세요" 에러가 반환됨.

## 구현 방식 및 설계

### 1. pendingQuery 구조 변경 (`widgetShortcuts.js`, `usePendingQueryStore.js`, `AppShell.jsx`)

- `getWidgetDefaultQuery()`가 기존 `string` 반환에서 `{ text, stockCode, stockName }` 객체 반환으로 변경
- `stock-chart`, `stock-news` 위젯만 `stockCode` / `stockName` 포함, 나머지는 `null`
- `setPendingQuery(text, stockCode, stockName)` 시그니처로 store 수정
- `AppShell`에서 query 객체를 구조 분해하여 store에 전달

### 2. sendMessage 힌트 파라미터 추가 (`chat.js`, `ChatPanel.jsx`)

- `chatApi.sendMessage(message, stockCode, stockName)` 시그니처로 변경
- `stockCode` / `stockName`이 있을 때만 `stock_code_hint`, `stock_name_hint`를 request body에 포함
- `handleSend(text, stockCode, stockName)` 시그니처 변경
- `lastFailedTextRef`에 `{ text, stockCode, stockName }` 형태로 저장하여 retry 시 hint 보존
- `pendingQuery` useEffect 및 `handleRetry`에서 힌트 구조 분해 적용

### 3. 채팅 차트 카드 UI 수정 (`ChatStockCard.jsx`)

- 종목코드 옆 `· marketType` 표시 제거
- 국내 주식은 AI 응답에 `market_type`이 없어 NASDAQ만 표시되는 불일치 문제가 있었음
- `marketType` prop 자체는 유지 (해외 주식 API 분기, 매수/매도 기능에 사용)

## 체크리스트

- [ ] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항

- `usePendingQueryStore`의 `pendingQuery` 타입이 `string`에서 객체로 변경됨 — 해당 store를 사용하는 다른 컴포넌트에서 호환성 문제 없는지 확인 필요
- 비KOSPI200 종목 응답이 느린 현상은 이번 변경과 무관. Spring 백엔드가 비KOSPI200 종목 일봉 데이터를 DB가 아닌 LS 외부 API로 조회하기 때문