### PR TITLE
fix(widget): market-overview 2x1 오늘 날짜 필터 및 시황 상세 탭 텍스트 수정

### DIFF
--- a/src/components/widgets/MarketOverviewWidget.jsx
+++ b/src/components/widgets/MarketOverviewWidget.jsx
@@ -137,6 +137,9 @@ export default function MarketOverviewWidget({ instanceId, variant = 'market-sm'
   }
 
   if (variant === 'market-wide') {
+    const todayUtc = new Date().toISOString().slice(0, 10)
+    const todayItems = items.filter((n) => n.publishedAt?.startsWith(todayUtc))
+    const wideItems = (todayItems.length > 0 ? todayItems : items).slice(0, 2)
     return (
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
         <div className="flex items-center gap-1.5 mb-1 shrink-0">
@@ -144,7 +147,7 @@ export default function MarketOverviewWidget({ instanceId, variant = 'market-sm'
           {tabBar}
         </div>
         <div className="flex-1 min-h-0 overflow-y-auto">
-          {isLoading ? loading : !items.length ? empty : items.slice(0, 2).map((item, i) => (
+          {isLoading ? loading : !wideItems.length ? empty : wideItems.map((item, i) => (
             <NewsCard key={item.newsId ?? i} item={item} showSummary onClickNews={handleNewsClick} />
           ))}
         </div>

--- a/src/components/widgets/detail/MarketNewsDetail.jsx
+++ b/src/components/widgets/detail/MarketNewsDetail.jsx
@@ -6,8 +6,8 @@ import { newsApi } from '@/api/news'
 import { cn } from '@/lib/cn'
 
 const TABS = [
-  { key: 'kr', label: '한국' },
-  { key: 'us', label: '미국' },
+  { key: 'kr', label: '국내' },
+  { key: 'us', label: '해외' },
 ]
 
 function HighlightedText({ text }) {


### PR DESCRIPTION
## 개요

- market-overview 2x1 위젯에서 해외 뉴스가 날짜 무관하게 2건 표시되던 문제 수정
- 시황 상세 탭 텍스트 통일 (한국/미국 → 국내/해외)

## 변경 사항

- `MarketOverviewWidget` 2x1: `publishedAt` 기준 오늘(UTC) 날짜 뉴스만 표시, 오늘 뉴스 없을 시 최신 1건 fallback
- `MarketNewsDetail`: 탭 레이블 `한국` → `국내`, `미국` → `해외`