### PR TITLE
fix(widget): 잔고 위젯 수익 추이 그래프 ECharts smooth 커브로 교체 및 축 레이블 추가

### DIFF
--- a/src/components/asset/ExchangeModal.jsx
+++ b/src/components/asset/ExchangeModal.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { X, ArrowLeftRight, Loader2 } from 'lucide-react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { exchangeApi } from '@/api/exchange'
@@ -281,13 +282,16 @@ function Row({ label, value, bold }) {
 }
 
 function Overlay({ onClose, children }) {
-  return (
-    <div className="fixed inset-0 z-[200] flex items-center justify-center">
-      {/* 딤 배경 */}
-      <div className="absolute inset-0 bg-black/30" onClick={onClose} />
-
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[1200] flex items-center justify-center p-5 bg-transparent"
+      onClick={onClose}
+    >
       {/* 모달 */}
-      <div className="relative z-10 w-[380px] bg-surface rounded-2xl shadow-modal p-6">
+      <div
+        className="relative w-[380px] bg-surface rounded-2xl shadow-modal p-6 animate-modal-in"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="flex items-center justify-between mb-5">
           <div className="flex items-center gap-2">
             <div className="w-7 h-7 rounded-[9px] bg-primary flex items-center justify-center shadow-brand-glow">
@@ -297,6 +301,7 @@ function Overlay({ onClose, children }) {
           </div>
           <button
             onClick={onClose}
+            aria-label="닫기"
             className="p-1 text-foreground-disabled hover:text-foreground transition-colors"
           >
             <X className="w-4 h-4" />
@@ -304,6 +309,7 @@ function Overlay({ onClose, children }) {
         </div>
         {children}
       </div>
-    </div>
+    </div>,
+    document.body,
   )
 }

--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -698,12 +698,26 @@ export function PreviewContent({ type, sectorStocks, typeIndex = 0 }) {
             {/* 하: 수익 추이 */}
             <div className="flex flex-col flex-1 min-h-0 border-t border-stroke pt-1">
               <div className="text-[8px] text-foreground-disabled shrink-0">수익 추이 (7일)</div>
-              <div className="flex-1 min-h-0 my-1">
-                <svg viewBox="0 0 100 30" preserveAspectRatio="none" className="w-full h-full block">
-                  <polyline points="0,27 12,23 24,25 36,18 50,14 62,10 74,7 86,4 100,1" fill="none" stroke="var(--color-up)" strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
-                </svg>
+              <div className="flex-1 min-h-0 flex mt-1">
+                {/* y축 눈금 */}
+                <div className="flex flex-col justify-between items-end pr-1 shrink-0" style={{ width: 20 }}>
+                  <span className="text-[6px] text-foreground-disabled">+3%</span>
+                  <span className="text-[6px] text-foreground-disabled">0%</span>
+                  <span className="text-[6px] text-foreground-disabled">-1%</span>
+                </div>
+                {/* 차트 영역 */}
+                <div className="flex flex-col flex-1 min-w-0">
+                  <svg viewBox="0 0 100 24" preserveAspectRatio="none" className="w-full flex-1 block">
+                    <polyline points="0,20 17,18 33,19 50,13 67,10 83,6 100,2" fill="none" stroke="var(--color-up)" strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
+                  </svg>
+                  {/* x축 날짜 */}
+                  <div className="flex justify-between">
+                    {['03.26', '03.28', '03.30', '04.01'].map((d) => (
+                      <span key={d} className="text-[6px] text-foreground-disabled">{d}</span>
+                    ))}
+                  </div>
+                </div>
               </div>
-              <div className="text-[8px] text-up text-right shrink-0">+2.61%</div>
             </div>
           </div>
         </div>

--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -700,7 +700,7 @@ export function PreviewContent({ type, sectorStocks, typeIndex = 0 }) {
               <div className="text-[8px] text-foreground-disabled shrink-0">수익 추이 (7일)</div>
               <div className="flex-1 min-h-0 flex mt-1">
                 {/* y축 눈금 */}
-                <div className="flex flex-col justify-between items-end pr-1 shrink-0" style={{ width: 20 }}>
+                <div className="flex flex-col justify-between items-end pr-1 shrink-0 w-5">
                   <span className="text-[6px] text-foreground-disabled">+3%</span>
                   <span className="text-[6px] text-foreground-disabled">0%</span>
                   <span className="text-[6px] text-foreground-disabled">-1%</span>

--- a/src/components/widgets/BalanceWidget.jsx
+++ b/src/components/widgets/BalanceWidget.jsx
@@ -139,7 +139,7 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
                     data: BALANCE.flowDates,
                     axisLine: { show: false },
                     axisTick: { show: false },
-                    axisLabel: { color: '#9CA3AF', fontSize: 8, margin: 4 },
+                    axisLabel: { color: 'var(--color-foreground-disabled)', fontSize: 8, margin: 4 },
                   },
                   yAxis: {
                     type: 'value',
@@ -149,7 +149,7 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
                     axisTick: { show: false },
                     splitLine: { show: false },
                     axisLabel: {
-                      color: '#9CA3AF',
+                      color: 'var(--color-foreground-disabled)',
                       fontSize: 8,
                       margin: 4,
                       formatter: (v) => (v >= 0 ? '+' : '') + v.toFixed(1) + '%',

--- a/src/components/widgets/BalanceWidget.jsx
+++ b/src/components/widgets/BalanceWidget.jsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
+import ReactECharts from 'echarts-for-react'
 import LockedOverlay from '@/components/ui/LockedOverlay'
 import useAuthStore from '@/store/useAuthStore'
 import useWidgetDetailStore from '@/store/useWidgetDetailStore'
@@ -38,6 +39,7 @@ function useBalance(enabled) {
   const invested  = total - profit - Number(krwEntry.totalAmount ?? 0)
 
   const flowPoints = (assetFlow?.points ?? []).map((p) => Number(p.cumulativeReturnRate ?? 0))
+  const flowDates  = (assetFlow?.points ?? []).map((p) => (p.date ?? '').slice(5).replace('-', '.'))
   const maxRate    = flowPoints.reduce((m, r) => Math.max(m, Math.abs(r)), 0)
 
   return {
@@ -49,6 +51,7 @@ function useBalance(enabled) {
     isProfit:   profit >= 0,
     isLoading:  false,
     flowPoints,
+    flowDates,
     maxRate,
   }
 }
@@ -121,48 +124,58 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
           {/* 하: 수익 추이 */}
           <div className="flex flex-col flex-1 min-h-0 border-t border-stroke pt-2">
             <div className="text-widget-9 text-foreground-disabled shrink-0">수익 추이 (7일)</div>
-            <div className="flex-1 min-h-0 relative my-2">
+            <div className="flex-1 min-h-0 relative">
               {BALANCE.flowPoints.length > 1 ? (() => {
                 const pts = BALANCE.flowPoints
-                const min = Math.min(...pts)
-                const max = Math.max(...pts)
-                const range = max - min || 1
-                const W = 100 / (pts.length - 1)
                 const isUp = pts[pts.length - 1] >= pts[0]
+                const lineColor = isUp ? 'var(--color-up)' : 'var(--color-down)'
+                const chartOption = {
+                  backgroundColor: 'transparent',
+                  grid: { left: 28, right: 4, top: 4, bottom: 16, containLabel: false },
+                  tooltip: { show: false },
+                  xAxis: {
+                    type: 'category',
+                    boundaryGap: false,
+                    data: BALANCE.flowDates,
+                    axisLine: { show: false },
+                    axisTick: { show: false },
+                    axisLabel: { color: '#9CA3AF', fontSize: 8, margin: 4 },
+                  },
+                  yAxis: {
+                    type: 'value',
+                    scale: true,
+                    splitNumber: 2,
+                    axisLine: { show: false },
+                    axisTick: { show: false },
+                    splitLine: { show: false },
+                    axisLabel: {
+                      color: '#9CA3AF',
+                      fontSize: 8,
+                      margin: 4,
+                      formatter: (v) => (v >= 0 ? '+' : '') + v.toFixed(1) + '%',
+                    },
+                  },
+                  series: [{
+                    type: 'line',
+                    smooth: true,
+                    showSymbol: pts.length === 1,
+                    symbolSize: 5,
+                    data: pts,
+                    lineStyle: { width: 2, color: lineColor },
+                    itemStyle: { color: lineColor },
+                  }],
+                }
                 return (
-                  <svg className="absolute inset-0 w-full h-full" viewBox="0 0 100 100" preserveAspectRatio="none">
-                    <polyline
-                      points={pts.map((r, i) => {
-                        const x = i * W
-                        const y = 10 + (1 - (r - min) / range) * 80
-                        return `${x},${y}`
-                      }).join(' ')}
-                      fill="none"
-                      stroke={isUp ? 'var(--color-up)' : 'var(--color-down)'}
-                      strokeWidth="2"
-                      vectorEffect="non-scaling-stroke"
-                    />
-                    {pts.map((r, i) => {
-                      const x = i * W
-                      const y = 10 + (1 - (r - min) / range) * 80
-                      return (
-                        <circle key={i} cx={x} cy={y} r="3"
-                          fill={r >= 0 ? 'var(--color-up)' : 'var(--color-down)'}
-                          vectorEffect="non-scaling-stroke"
-                        />
-                      )
-                    })}
-                  </svg>
+                  <ReactECharts
+                    option={chartOption}
+                    style={{ width: '100%', height: '100%' }}
+                    opts={{ renderer: 'svg' }}
+                  />
                 )
               })() : (
                 <div className="absolute inset-0 flex items-center justify-center text-widget-9 text-foreground-disabled">데이터 없음</div>
               )}
             </div>
-            {BALANCE.flowPoints.length > 0 && (
-              <div className={cn('text-widget-9 text-right shrink-0', BALANCE.flowPoints[BALANCE.flowPoints.length - 1] >= 0 ? 'text-up' : 'text-down')}>
-                {`${BALANCE.flowPoints[BALANCE.flowPoints.length - 1] >= 0 ? '+' : ''}${BALANCE.flowPoints[BALANCE.flowPoints.length - 1].toFixed(2)}%`}
-              </div>
-            )}
           </div>
         </div>
       ) : variant === 'balance-2x2' ? (


### PR DESCRIPTION
## 작업 내용
- 잔고 위젯 수익 추이 그래프를 ECharts 기반 smooth line으로 교체
- 수익 추이 그래프에 x축 날짜, y축 퍼센트 라벨 추가
- 편집 패널(WidgetSizeList) 미리보기 그래프도 축 라벨 형태로 정리
- 환전 모달 오버레이를 portal 기반으로 정리하고, 바깥 클릭 닫기 동작 개선
- 환전 모달 배경을 투명 처리해 레이어 겹침 이슈 완화

## 체크리스트

- [ ] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항

- 잔고 위젯 그래프 축 라벨 가독성(폰트 크기/간격) 확인 부탁드립니다.
- 환전 모달 바깥 클릭 닫기 UX가 의도한 플로우와 일치하는지 확인 부탁드립니다.
