### PR TITLE
feat(widget, chat, dashboard): chat→dashboard DnD push-aside 및 위젯 UX 개선

### DIFF
--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -12,7 +12,7 @@ import AppHeader from './AppHeader'
 import RightPanel from './RightPanel'
 import CurrencySync from './CurrencySync'
 import WidgetDetailModal from '@/components/widgets/WidgetDetailModal'
-import useWidgetStore, { canPlaceAt, findPushAsidePlanAt } from '@/store/useWidgetStore'
+import useWidgetStore, { canPlaceAt, findPushAsidePlanAt, findPushAsidePlanForNew } from '@/store/useWidgetStore'
 import useEditModeStore from '@/store/useEditModeStore'
 import useGridStore from '@/store/useGridStore'
 import useAuthStore from '@/store/useAuthStore'
@@ -45,6 +45,7 @@ export default function AppShell() {
     addWidgetAt,
     moveWidgetTo,
     applyPushAsidePlan,
+    applyPushAsideMoves,
     setPhantom,
     clearPhantom,
     phantomWidget,
@@ -57,6 +58,8 @@ export default function AppShell() {
   const { cellWidth, cellHeight } = useGridStore()
   const pointerPos = useRef({ x: 0, y: 0 })
   const dragAnchor = useRef({ colOffset: 0, rowOffset: 0 })
+  // new-widget 드래그 시작 시 패널 카드 내 grab 위치(px). DragOverlay와 phantom 위치 동기화에 사용.
+  const newWidgetGrabOffset = useRef({ x: 0, y: 0 })
 
   // 포인터 좌표를 drag 중에만 추적 (handleDragMove에서 사용)
   // 동일 참조로 등록·해제할 수 있도록 useRef에 저장
@@ -92,6 +95,16 @@ export default function AppShell() {
 
     if (type === 'new-widget') {
       setIsDraggingNewWidget(true)
+      // 패널 카드 내 grab 위치 기록: DragOverlay top-left = cursor - grabOffset
+      const initial = active.rect.current?.initial
+      if (initial && activatorEvent && 'clientX' in activatorEvent) {
+        newWidgetGrabOffset.current = {
+          x: activatorEvent.clientX - initial.left,
+          y: activatorEvent.clientY - initial.top,
+        }
+      } else {
+        newWidgetGrabOffset.current = { x: 0, y: 0 }
+      }
     }
   }
 
@@ -124,10 +137,31 @@ export default function AppShell() {
 
     if (type === 'new-widget') {
       const { variant } = active.data.current
-      if (canPlaceAt(widgets, pointerCol, pointerRow, variant.colSpan, variant.rowSpan)) {
-        setPhantom({ gridCol: pointerCol, gridRow: pointerRow, colSpan: variant.colSpan, rowSpan: variant.rowSpan })
+      // grab offset으로 보정: DragOverlay top-left = cursor - grabOffset이므로 phantom도 동일 기준으로 계산
+      const { x: grabX, y: grabY } = newWidgetGrabOffset.current
+      const phantomCol = Math.max(1, Math.min(
+        Math.floor((x - grabX - rect.left) / (cellWidth + GRID_GAP)) + 1,
+        GRID_COLS - variant.colSpan + 1,
+      ))
+      const phantomRow = Math.max(1, Math.min(
+        Math.floor((y - grabY - rect.top) / (cellHeight + GRID_GAP)) + 1,
+        GRID_ROWS - variant.rowSpan + 1,
+      ))
+      if (canPlaceAt(widgets, phantomCol, phantomRow, variant.colSpan, variant.rowSpan)) {
+        setPhantom({ gridCol: phantomCol, gridRow: phantomRow, colSpan: variant.colSpan, rowSpan: variant.rowSpan })
       } else {
-        clearPhantom()
+        const plan = findPushAsidePlanForNew(widgets, variant.colSpan, variant.rowSpan, phantomCol, phantomRow)
+        if (plan) {
+          setPhantom({
+            gridCol: plan.targetCol,
+            gridRow: plan.targetRow,
+            colSpan: variant.colSpan,
+            rowSpan: variant.rowSpan,
+            pushAsidePlan: plan,
+          })
+        } else {
+          clearPhantom()
+        }
       }
       return
     }
@@ -193,6 +227,9 @@ export default function AppShell() {
 
     if (type === 'new-widget' && savedPhantom) {
       const { widgetTypeId, variant, widgetConfig } = active.data.current
+      if (savedPhantom.pushAsidePlan) {
+        applyPushAsideMoves(savedPhantom.pushAsidePlan.moves)
+      }
       addWidgetAt(widgetTypeId, variant, savedPhantom.gridCol, savedPhantom.gridRow, widgetConfig)
       clearPending()
       saveDashboard()

--- a/src/components/layout/ChatWidgetAdder.jsx
+++ b/src/components/layout/ChatWidgetAdder.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { Grid2X2Plus } from 'lucide-react'
 import { WIDGET_TYPES } from '@/mocks/widgets'
 import usePendingWidgetStore from '@/store/usePendingWidgetStore'
@@ -28,11 +28,34 @@ export default function ChatWidgetAdder({ msgId, widgetTypeId, variantIds }) {
   const [open, setOpen]           = useState(false)
   const [selectedId, setSelectedId] = useState(null)
   const { pendingMsgId, setPending, clearPending } = usePendingWidgetStore()
+  const containerRef = useRef(null)
 
   const widgetType = WIDGET_TYPES.find((w) => w.id === widgetTypeId)
-  if (!widgetType) return null
 
   const isPending = pendingMsgId === msgId
+
+  // 외부 클릭 시 초기 상태로 리셋 (open 또는 isPending 상태일 때)
+  useEffect(() => {
+    if (!open && !isPending) return
+    const handleClick = (e) => {
+      // React가 클릭 핸들러에서 DOM을 업데이트해 target이 이미 제거된 경우 무시
+      if (!document.body.contains(e.target)) return
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        clearPending()
+        setSelectedId(null)
+        setOpen(false)
+      }
+    }
+    document.addEventListener('click', handleClick)
+    return () => document.removeEventListener('click', handleClick)
+  }, [open, isPending, clearPending])
+
+  // 드롭 완료 등 외부에서 clearPending 호출 시 selectedId 리셋
+  useEffect(() => {
+    if (!isPending) setSelectedId(null)
+  }, [isPending])
+
+  if (!widgetType) return null
   // variantIds가 지정된 경우 해당 variant만 피커에 표시
   const variants = variantIds
     ? widgetType.variants.filter((v) => variantIds.includes(v.id))
@@ -61,7 +84,7 @@ export default function ChatWidgetAdder({ msgId, widgetTypeId, variantIds }) {
   }
 
   return (
-    <div className="flex flex-col items-start">
+    <div ref={containerRef} className="flex flex-col items-start">
       {/* 아이콘 클릭 시 안내 문구 — 타임스탬프 위로 올라옴 */}
       {open && (
         <span className="text-[9px] text-foreground-tertiary whitespace-nowrap mb-0.5 animate-bubble-in">

--- a/src/components/widgets/PortfolioWidget.jsx
+++ b/src/components/widgets/PortfolioWidget.jsx
@@ -197,8 +197,8 @@ export default function PortfolioWidget({ variant = 'portfolio-sm', colSpan = 1,
               {portfolio.isLoading ? '불러오는 중...' : '보유 종목 없음'}
             </div>
           ) : (
-            <div className="flex items-center gap-2.5 flex-1 min-h-0">
-              <div className="relative w-14 h-14 rounded-full shrink-0" style={ready && conicStops ? { background: `conic-gradient(${conicStops})` } : undefined}>
+            <div className="flex items-stretch gap-2.5 flex-1 min-h-0">
+              <div className="relative w-14 h-14 rounded-full shrink-0 self-center" style={ready && conicStops ? { background: `conic-gradient(${conicStops})` } : undefined}>
                 {(!ready || !conicStops) && <div className="absolute inset-0 rounded-full bg-surface-muted" />}
                 <div className="absolute inset-[30%] rounded-full bg-surface" />
               </div>

--- a/src/components/widgets/SortableWidgetCard.jsx
+++ b/src/components/widgets/SortableWidgetCard.jsx
@@ -40,10 +40,11 @@ export default function SortableWidgetCard({
   })
 
   // 비편집모드 전용 — 핸들 버튼 draggable (widget-to-chat)
+  // setNodeRef를 전체 카드에 연결해 DragOverlay가 위젯 카드 위치 기준으로 앵커되도록 함
   const {
     attributes: handleAttrs,
     listeners: handleListeners,
-    setNodeRef: setHandleRef,
+    setNodeRef: setWtcNodeRef,
   } = useDraggable({
     id: `wtc-handle-${instanceId}`,
     disabled: isEditMode || isDragLocked || !canDragToChat,
@@ -54,8 +55,9 @@ export default function SortableWidgetCard({
     (node) => {
       setDraggableRef(node)
       setDroppableRef(node)
+      setWtcNodeRef(node)
     },
-    [setDraggableRef, setDroppableRef],
+    [setDraggableRef, setDroppableRef, setWtcNodeRef],
   )
 
   return (
@@ -75,7 +77,6 @@ export default function SortableWidgetCard({
       {/* 비편집모드 hover 핸들 — widget-to-chat drag 진입점 */}
       {!isEditMode && canDragToChat && (
         <button
-          ref={setHandleRef}
           aria-label="채팅으로 질문하기"
           className={cn(
             'absolute top-2 right-2 z-10 p-1 rounded',

--- a/src/features/market/useLatestNews.js
+++ b/src/features/market/useLatestNews.js
@@ -12,7 +12,7 @@ export default function useLatestNews(size = 10) {
     retry: false,
   })
 
-  const all = data ?? []
+  const all = Array.isArray(data) ? data : []
   const kr  = all.filter((n) => !n.stockIndex || KR_INDICES.includes(n.stockIndex))
   const us  = all.filter((n) => US_INDICES.includes(n.stockIndex))
 

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -316,27 +316,11 @@ export default function HomePage() {
         'flex-1 min-h-0',
         isEditMode ? 'overflow-visible' : 'overflow-auto',
       )}>
-        {/* 로그인 상태이고 위젯이 없을 때 빈 상태 안내 */}
-        {isAuthenticated && isLoaded && safeWidgets.length === 0 && !isEditMode ? (
-          <div className="w-full h-full flex flex-col items-center justify-center gap-4">
-            <div className="flex flex-col items-center gap-2 text-center">
-              <LayoutGrid className="w-10 h-10 text-foreground-disabled" strokeWidth={1.5} />
-              <p className="text-sm font-semibold text-foreground">대시보드가 비어있어요</p>
-              <p className="text-xs text-foreground-disabled">원하는 위젯을 추가해 나만의 대시보드를 만들어보세요.</p>
-            </div>
-            <button
-              onClick={() => { snapshotWidgets(); enterEditMode() }}
-              className="flex items-center gap-1.5 px-4 py-2 rounded-xl bg-primary text-white text-xs font-semibold hover:bg-primary-hover transition-colors duration-150 shadow-primary-btn"
-            >
-              <Plus className="w-3.5 h-3.5" strokeWidth={2.5} />
-              위젯 추가하기
-            </button>
-          </div>
-        ) : (
+        {/* 그리드는 항상 렌더 — 빈 상태 안내는 포인터 이벤트 없는 오버레이로 표시 */}
         <div
           ref={setGridRef}
           className={cn(
-            'grid grid-cols-6 grid-rows-4 gap-[10px] w-full h-full rounded-2xl transition-[outline] duration-[150ms]',
+            'relative grid grid-cols-6 grid-rows-4 gap-[10px] w-full h-full rounded-2xl transition-[outline] duration-[150ms]',
             isDraggingNewWidget && 'outline outline-2 outline-primary',
             isDraggingNewWidget && phantomWidget && 'bg-primary-light/30',
           )}
@@ -345,6 +329,23 @@ export default function HomePage() {
             minHeight: `${MIN_GRID_HEIGHT}px`,
           }}
         >
+          {/* 로그인 상태이고 위젯이 없을 때 빈 상태 안내 */}
+          {isAuthenticated && isLoaded && safeWidgets.length === 0 && !isEditMode && !isDraggingNewWidget && (
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 pointer-events-none">
+              <div className="flex flex-col items-center gap-2 text-center">
+                <LayoutGrid className="w-10 h-10 text-foreground-disabled" strokeWidth={1.5} />
+                <p className="text-sm font-semibold text-foreground">대시보드가 비어있어요</p>
+                <p className="text-xs text-foreground-disabled">원하는 위젯을 추가해 나만의 대시보드를 만들어보세요.</p>
+              </div>
+              <button
+                onClick={() => { snapshotWidgets(); enterEditMode() }}
+                className="flex items-center gap-1.5 px-4 py-2 rounded-xl bg-primary text-white text-xs font-semibold hover:bg-primary-hover transition-colors duration-150 shadow-primary-btn pointer-events-auto"
+              >
+                <Plus className="w-3.5 h-3.5" strokeWidth={2.5} />
+                위젯 추가하기
+              </button>
+            </div>
+          )}
           {displayWidgets.map((w) => {
             if (w.instanceId === '__phantom__') {
               return (
@@ -384,7 +385,6 @@ export default function HomePage() {
             )
           })}
         </div>
-        )}
       </div>
     </div>
 

--- a/src/store/useWidgetStore.js
+++ b/src/store/useWidgetStore.js
@@ -164,6 +164,40 @@ export function findPushAsidePlanAt(widgets, activeId, targetCol, targetRow) {
   return { activeId, targetCol, targetRow, moves }
 }
 
+/* 그리드에 아직 없는 신규 위젯을 targetCol/targetRow에 추가할 때 필요한 push-aside 계획 생성.
+   findPushAsidePlanAt과 동일 로직이지만 activeId(기존 위젯) 없이 colSpan/rowSpan을 직접 받는다. */
+export function findPushAsidePlanForNew(widgets, colSpan, rowSpan, targetCol, targetRow) {
+  if (targetCol + colSpan - 1 > GRID_COLS || targetRow + rowSpan - 1 > GRID_ROWS) return null
+
+  const blockers = widgets.filter(
+    (w) => _overlap(targetCol, targetRow, colSpan, rowSpan, w.gridCol, w.gridRow, w.colSpan, w.rowSpan),
+  )
+  if (blockers.length === 0) return null
+
+  const sortedBlockers = [...blockers].sort((a, b) => {
+    const areaDiff = b.colSpan * b.rowSpan - a.colSpan * a.rowSpan
+    if (areaDiff !== 0) return areaDiff
+    const da = Math.abs(a.gridCol - targetCol) + Math.abs(a.gridRow - targetRow)
+    const db = Math.abs(b.gridCol - targetCol) + Math.abs(b.gridRow - targetRow)
+    return da - db
+  })
+
+  const blockerIds = new Set(sortedBlockers.map((w) => w.instanceId))
+  const working = widgets
+    .filter((w) => !blockerIds.has(w.instanceId))
+    .concat({ instanceId: '__ghost_new__', gridCol: targetCol, gridRow: targetRow, colSpan, rowSpan })
+
+  const moves = []
+  for (const blocker of sortedBlockers) {
+    const cell = findNearestFreeCell(working, blocker.colSpan, blocker.rowSpan, blocker.gridCol, blocker.gridRow)
+    if (!cell) return null
+    moves.push({ instanceId: blocker.instanceId, gridCol: cell.gridCol, gridRow: cell.gridRow })
+    working.push({ instanceId: blocker.instanceId, colSpan: blocker.colSpan, rowSpan: blocker.rowSpan, gridCol: cell.gridCol, gridRow: cell.gridRow })
+  }
+
+  return { targetCol, targetRow, moves }
+}
+
 /* 그리드에 해당 크기의 위젯을 배치할 빈 공간이 있는지 확인 */
 export function canFitInGrid(widgets, colSpan, rowSpan) {
   for (let r = 1; r <= GRID_ROWS - rowSpan + 1; r++) {
@@ -437,6 +471,18 @@ const useWidgetStore = create((set) => ({
       const newWidgets = state.widgets.map((w) =>
         w.instanceId === instanceId ? { ...w, gridCol, gridRow } : w,
       )
+      return _setCurrentWidgets(state, newWidgets)
+    }),
+
+  // new-widget push-aside: blockers만 계획된 좌표로 이동 (active 위젯은 addWidgetAt으로 별도 추가)
+  applyPushAsideMoves: (moves) =>
+    set((state) => {
+      if (!moves?.length) return state
+      const moveMap = new Map(moves.map((m) => [m.instanceId, m]))
+      const newWidgets = state.widgets.map((w) => {
+        const m = moveMap.get(w.instanceId)
+        return m ? { ...w, gridCol: m.gridCol, gridRow: m.gridRow } : w
+      })
       return _setCurrentWidgets(state, newWidgets)
     }),
 


### PR DESCRIPTION
## 작업 내용

- chat→dashboard DnD 시 점유 셀 push-aside 지원 (`findPushAsidePlanForNew`, `applyPushAsideMoves` 추가)
- new-widget grab offset 보정으로 DragOverlay와 phantom 위치 동기화
- widget-to-chat `setNodeRef`를 버튼 대신 전체 카드에 연결해 DragOverlay 앵커 오류 수정
- 빈 대시보드에서도 DnD 가능하도록 빈 상태 UI를 absolute 오버레이로 전환
- ChatWidgetAdder 외부 클릭 시 초기 상태 복귀 및 드롭 후 선택 리셋
- `useLatestNews` API 응답 배열 여부 방어 처리
- 포트폴리오 위젯 1x1 종목 리스트 overflow 스크롤 적용

## 연관 이슈

closes #153

## 체크리스트

- [x] 코드가 정상적으로 빌드되는지 확인했나요?
- [x] 불필요한 코드나 주석을 제거했나요?
- [x]  각 작업 내용이 잘 반영 되었나요?