### PR TITLE
fix(auth): HMR 및 storage 초기화 시 인증 상태 복원 불가 버그 수정

### DIFF
--- a/src/store/useAuthStore.js
+++ b/src/store/useAuthStore.js
@@ -45,7 +45,22 @@ const useAuthStore = create((set, get) => ({
       localStorage.getItem('accessToken') ?? sessionStorage.getItem('accessToken')
 
     if (!accessToken) {
-      set({ isRestoring: false })
+      // 저장된 토큰 없음 — 쿠키(refresh token)가 살아있는지 silent refresh로 확인
+      try {
+        const data = await silentRefresh()
+        const newToken = data.accessToken
+        sessionStorage.setItem('accessToken', newToken)
+        const userRes = await fetch('/api/users/me', {
+          headers: { Authorization: `Bearer ${newToken}` },
+          credentials: 'include',
+        })
+        const user = userRes.ok ? await userRes.json() : null
+        if (user) sessionStorage.setItem('user', JSON.stringify(user))
+        set({ isAuthenticated: true, user, accessToken: newToken, isRestoring: false })
+        applyThemeFromServer()
+      } catch {
+        set({ isRestoring: false })
+      }
       return
     }
 

--- a/src/store/useAuthStore.js
+++ b/src/store/useAuthStore.js
@@ -36,6 +36,8 @@ const useAuthStore = create((set, get) => ({
     const storage = autoLogin ? localStorage : sessionStorage
     storage.setItem('accessToken', accessToken)
     storage.setItem('user', JSON.stringify(user))
+    if (autoLogin) localStorage.setItem('autoLogin', 'true')
+    else localStorage.removeItem('autoLogin')
     set({ isAuthenticated: true, user, accessToken })
   },
 
@@ -49,13 +51,14 @@ const useAuthStore = create((set, get) => ({
       try {
         const data = await silentRefresh()
         const newToken = data.accessToken
-        sessionStorage.setItem('accessToken', newToken)
+        const storage = localStorage.getItem('autoLogin') === 'true' ? localStorage : sessionStorage
+        storage.setItem('accessToken', newToken)
         const userRes = await fetch('/api/users/me', {
           headers: { Authorization: `Bearer ${newToken}` },
           credentials: 'include',
         })
         const user = userRes.ok ? await userRes.json() : null
-        if (user) sessionStorage.setItem('user', JSON.stringify(user))
+        if (user) storage.setItem('user', JSON.stringify(user))
         set({ isAuthenticated: true, user, accessToken: newToken, isRestoring: false })
         applyThemeFromServer()
       } catch {
@@ -90,6 +93,7 @@ const useAuthStore = create((set, get) => ({
   logout: ({ broadcast = true } = {}) => {
     localStorage.removeItem('accessToken')
     localStorage.removeItem('user')
+    localStorage.removeItem('autoLogin')
     localStorage.removeItem('ui:theme')
     sessionStorage.removeItem('accessToken')
     sessionStorage.removeItem('user')


### PR DESCRIPTION
## 개요

close #156

개발 환경에서 코드 수정 시 또는 자동로그인 미체크 상태로 새 탭 열 때 실제 로그인 상태임에도 헤더에 로그인/회원가입 버튼이 표시되는 버그 수정.

## 원인

### HMR로 인한 Zustand store 재초기화

Vite HMR은 코드 수정 시 변경된 모듈만 교체하는데, 이 과정에서 Zustand store가 재실행되어 `isAuthenticated: false`로 리셋됨. `restoreAuth`는 앱 마운트 시에만 호출되므로 HMR 후 재호출되지 않음.

### storage 기반 인증 판단의 구조적 문제

기존 `restoreAuth`는 localStorage/sessionStorage에 `accessToken`이 없으면 무조건 로그아웃 처리. 그러나 실제 인증 근거인 httpOnly 쿠키(refresh token)는 storage와 독립적으로 유지됨.

- 자동로그인 미체크 + 새 탭: sessionStorage는 탭 간 공유 안 됨 → 새 탭에서 항상 로그아웃 UI
- HMR: store 재초기화 후 `restoreAuth` 미호출 → storage는 있어도 store가 false

## 수정 내용

**`src/store/useAuthStore.js`**

**1. storage가 없을 때 쿠키 기반 silent refresh 시도**

storage에 토큰이 없어도 바로 포기하지 않고, httpOnly 쿠키로 `/api/auth/token/refresh` 호출. 성공 시 `/api/users/me`로 유저 정보 조회 후 인증 상태 복원.

**2. autoLogin 플래그 보존**

silent refresh 성공 후 어느 storage에 저장할지 판단하기 위해 `autoLogin` 여부를 localStorage에 별도 기록.

- `setAuth`: autoLogin이면 `localStorage.setItem('autoLogin', 'true')`, 아니면 `removeItem`
- `restoreAuth` no-token 브랜치: `autoLogin` 플래그 참조해 localStorage 또는 sessionStorage 선택
- `logout`: `localStorage.removeItem('autoLogin')` 추가

## 변경 전후 동작 비교

| | storage 삭제 시 (변경 전) | storage 삭제 시 (변경 후) |
|---|---|---|
| 자동로그인 미체크 | 로그아웃 됨 | 로그아웃 안 되고 sessionStorage에 복구 |
| 자동로그인 체크 | 로그아웃 됨 | 로그아웃 안 되고 localStorage에 복구 |

## 검증 방법

1. 자동로그인 미체크로 로그인
2. 개발자도구 → Application → Session Storage 전체 삭제
3. 페이지 새로고침
4. 헤더에 유저 이름 표시 확인 (기존: 로그인 버튼 표시)

자동로그인 체크 케이스는 Local Storage의 `accessToken`, `user`, `autoLogin` 키 삭제 후 동일하게 확인.