### PR TITLE
fix(notifications): 임계값 저장 시점 계산 및 유효성 검사 수정

### DIFF
--- a/src/api/notification.js
+++ b/src/api/notification.js
@@ -16,11 +16,16 @@ function patch(path) {
   return fetchWithAuth(path, { method: 'PATCH' })
 }
 
+function del(path) {
+  return fetchWithAuth(path, { method: 'DELETE' })
+}
+
 export const notificationApi = {
   getNotifications:       () => get('/api/notifications'),
   getUnreadCount:         () => get('/api/notifications/unread-count'),
   markAsRead:     (id)    => patch(`/api/notifications/${id}/read`),
   markAllAsRead:          () => patch('/api/notifications/read-all'),
+  deleteNotification: (id) => del(`/api/notifications/${id}`),
   getSettings:            () => get('/api/notifications/settings'),
   updateSettings: (body)  => put('/api/notifications/settings', body),
 }

--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -108,7 +108,7 @@ function MiniCandleChart({ className = '', candleRatio = 1, volatility = 1 }) {
     : sampledCandles.map(([cx, ht, bt, bb, lb, isUp]) => [cx, scaleY(ht), scaleY(bt), scaleY(bb), scaleY(lb), isUp])
   const lastBodyBottom = candles[candles.length - 1][3]
   return (
-    <div className={cn('h-full w-full rounded-lg bg-white p-1', className)}>
+    <div className={cn('h-full w-full rounded-lg bg-surface p-1', className)}>
       <svg viewBox="0 0 100 42" preserveAspectRatio="none" className="w-full h-full block">
         <line x1="0" y1={lastBodyBottom} x2="100" y2={lastBodyBottom} stroke="var(--color-up)" strokeWidth="0.7" strokeDasharray="1.5 1.5" vectorEffect="non-scaling-stroke" />
         {candles.map(([cx, ht, bt, bb, lb, isUp]) => {

--- a/src/components/layout/NotificationSettingsPanel.jsx
+++ b/src/components/layout/NotificationSettingsPanel.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import { X, Check } from 'lucide-react'
+import { X, Check, Loader2 } from 'lucide-react'
 import { notificationApi } from '@/api/notification'
 import useRightPanelStore from '@/store/useRightPanelStore'
 
@@ -44,11 +44,7 @@ function Header() {
 export default function NotificationSettingsPanel() {
   const setChatMode = useRightPanelStore((s) => s.setChatMode)
 
-  const [settings, setSettings] = useState({
-    priceAlertEnabled: true,
-    executionAlertEnabled: true,
-    defaultThresholdPercent: 5,
-  })
+  const [settings, setSettings] = useState(null)
   const [isCustom, setIsCustom] = useState(false)
   const [customValue, setCustomValue] = useState('')
   const [allOffWarning, setAllOffWarning] = useState(false)
@@ -131,7 +127,11 @@ export default function NotificationSettingsPanel() {
       <Header />
 
       <div className="flex-1 overflow-y-auto p-4 flex flex-col gap-4">
-        {loadError ? (
+        {!settings && !loadError ? (
+          <div className="flex-1 flex justify-center items-center">
+            <Loader2 className="w-4 h-4 text-foreground-disabled animate-spin" strokeWidth={2} />
+          </div>
+        ) : loadError ? (
           <div className="flex-1 flex flex-col items-center justify-center gap-3">
             <p className="text-[13px] text-foreground-secondary">설정을 불러오지 못했습니다.</p>
             <button

--- a/src/components/layout/NotificationSettingsPanel.jsx
+++ b/src/components/layout/NotificationSettingsPanel.jsx
@@ -99,12 +99,11 @@ export default function NotificationSettingsPanel() {
 
   function handleCustomChange(val) {
     setCustomValue(val)
-    setSettings((s) => ({ ...s, defaultThresholdPercent: parseFloat(val) || 0 }))
   }
 
   async function handleSave() {
-    const percent = settings.defaultThresholdPercent
-    if (!percent || percent < 0.01 || percent > 99.99) {
+    const percent = isCustom ? parseFloat(customValue) : settings.defaultThresholdPercent
+    if (isNaN(percent) || percent < 0.01 || percent > 99.99) {
       setSaveError('유효한 범위를 입력해주세요 (0.01 ~ 99.99)')
       return
     }

--- a/src/components/ui/NotificationCenter.jsx
+++ b/src/components/ui/NotificationCenter.jsx
@@ -27,7 +27,10 @@ function NotificationItem({ notification, onClose }) {
       markAsRead(notification.notificationId)
     }
     if (notification.notificationType === 'PRICE_ALERT' && notification.referenceId) {
-      navigate(`/invest/${notification.referenceId}`)
+      const stockName = notification.stockName
+        ?? notification.title?.match(/^(.+?)(?:\s+전일대비|\s+목표가)/)?.[1]
+        ?? null
+      navigate(`/invest/${notification.referenceId}`, { state: { stockName } })
       onClose()
     }
   }

--- a/src/components/ui/NotificationCenter.jsx
+++ b/src/components/ui/NotificationCenter.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { Bell, Settings2, CheckCheck, Loader2 } from 'lucide-react'
+import { Bell, Settings2, CheckCheck, Loader2, Trash2 } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import useAuthStore from '@/store/useAuthStore'
 import useNotificationStore from '@/store/useNotificationStore'
@@ -20,6 +20,7 @@ function timeAgo(dateStr) {
 function NotificationItem({ notification, onClose }) {
   const navigate = useNavigate()
   const markAsRead = useNotificationStore((s) => s.markAsRead)
+  const deleteNotification = useNotificationStore((s) => s.deleteNotification)
 
   function handleClick() {
     if (!notification.read) {
@@ -31,28 +32,44 @@ function NotificationItem({ notification, onClose }) {
     }
   }
 
+  function handleDelete(e) {
+    e.stopPropagation()
+    deleteNotification(notification.notificationId)
+  }
+
   return (
-    <button
-      onClick={handleClick}
-      className={`w-full text-left px-4 py-3 hover:bg-surface-muted transition-colors border-b border-stroke-subtle last:border-0 ${!notification.read ? 'bg-primary-light/50' : ''}`}
+    <div
+      className={`group relative border-b border-stroke-subtle last:border-0 ${!notification.read ? 'bg-primary-light/50' : ''}`}
     >
-      <div className="flex items-start gap-2.5">
-        <span
-          className={`mt-2 w-1.5 h-1.5 rounded-full shrink-0 ${!notification.read ? 'bg-primary' : 'bg-transparent'}`}
-        />
-        <div className="min-w-0">
-          <p className="text-[13px] font-semibold text-foreground leading-snug truncate">
-            {notification.title}
-          </p>
-          <p className="text-[12px] text-foreground-secondary mt-0.5 leading-snug">
-            {notification.message}
-          </p>
-          <p className="text-[11px] text-foreground-disabled mt-1">
-            {timeAgo(notification.createdAt)}
-          </p>
+      <button
+        onClick={handleClick}
+        className="w-full text-left px-4 py-3 pr-8 hover:bg-surface-muted transition-colors"
+      >
+        <div className="flex items-start gap-2.5">
+          <span
+            className={`mt-2 w-1.5 h-1.5 rounded-full shrink-0 ${!notification.read ? 'bg-primary' : 'bg-transparent'}`}
+          />
+          <div className="min-w-0">
+            <p className="text-[13px] font-semibold text-foreground leading-snug truncate">
+              {notification.title}
+            </p>
+            <p className="text-[12px] text-foreground-secondary mt-0.5 leading-snug">
+              {notification.message}
+            </p>
+            <p className="text-[11px] text-foreground-disabled mt-1">
+              {timeAgo(notification.createdAt)}
+            </p>
+          </div>
         </div>
-      </div>
-    </button>
+      </button>
+      <button
+        onClick={handleDelete}
+        className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-md text-foreground-disabled hover:text-foreground-secondary hover:bg-surface-muted transition-colors opacity-0 group-hover:opacity-100"
+        aria-label="알림 삭제"
+      >
+        <Trash2 className="w-3 h-3" strokeWidth={2} />
+      </button>
+    </div>
   )
 }
 

--- a/src/features/invest/useInvestMarketData.js
+++ b/src/features/invest/useInvestMarketData.js
@@ -27,9 +27,17 @@ export default function useInvestMarketData(stockCode, locationState, { activeLe
 
   const stockMeta = useMemo(() => {
     if (isDomestic) {
+      const resolvedName = locationState?.stockName
+        ?? infoQuery.data?.companyName
+        ?? infoQuery.data?.stockName
+        ?? infoQuery.data?.name
+        ?? infoQuery.data?.htsKorIsnm
+        ?? infoQuery.data?.prdtName
+        ?? baseStockMeta.name
       const resolvedMarket = infoQuery.data?.marketName ?? baseStockMeta.market
       return {
         ...baseStockMeta,
+        name: resolvedName,
         marketType: resolvedMarket,
         market: resolvedMarket,
         sector: infoQuery.data?.sector ?? baseStockMeta.sector,

--- a/src/store/useNotificationStore.js
+++ b/src/store/useNotificationStore.js
@@ -60,12 +60,15 @@ const useNotificationStore = create((set, get) => ({
   deleteNotification: (notificationId) => {
     const target = get().notifications.find((n) => n.notificationId === notificationId)
     const wasUnread = target && !target.read
+    const prevNotifications = get().notifications
+    const prevUnreadCount = get().unreadCount
     set((state) => ({
       notifications: state.notifications.filter((n) => n.notificationId !== notificationId),
       unreadCount: wasUnread ? Math.max(0, state.unreadCount - 1) : state.unreadCount,
     }))
     notificationApi.deleteNotification(notificationId).catch((err) => {
       console.warn('[Notification] 삭제 실패:', err?.message)
+      set({ notifications: prevNotifications, unreadCount: prevUnreadCount })
     })
   },
 

--- a/src/store/useNotificationStore.js
+++ b/src/store/useNotificationStore.js
@@ -57,6 +57,18 @@ const useNotificationStore = create((set, get) => ({
     })
   },
 
+  deleteNotification: (notificationId) => {
+    const target = get().notifications.find((n) => n.notificationId === notificationId)
+    const wasUnread = target && !target.read
+    set((state) => ({
+      notifications: state.notifications.filter((n) => n.notificationId !== notificationId),
+      unreadCount: wasUnread ? Math.max(0, state.unreadCount - 1) : state.unreadCount,
+    }))
+    notificationApi.deleteNotification(notificationId).catch((err) => {
+      console.warn('[Notification] 삭제 실패:', err?.message)
+    })
+  },
+
   markAllAsRead: async () => {
     try {
       await notificationApi.markAllAsRead()


### PR DESCRIPTION
## 연관된 이슈

## 작업 내용

### 1. 커스텀 임계값 저장 시점 계산 방식 수정

**문제**
`handleCustomChange()`에서 입력값이 바뀔 때마다 `setSettings()`로 `defaultThresholdPercent`를 즉시 업데이트하고 있었습니다.
사용자가 숫자를 타이핑하는 도중(예: `"1"` → `"10"` → `"10."` → `"10.5"`)에도 매번 `parseFloat`가 실행되어 중간값이 settings에 반영되었고, 저장 버튼을 누르기 전에 이미 잘못된 값이 settings 상태에 들어가는 문제가 있었습니다.

**수정 방식**
`handleCustomChange()`에서 `setSettings()` 호출을 제거하고, `handleSave()` 실행 시점에만 `customValue`를 `parseFloat`로 변환하여 사용하도록 변경했습니다.

```js
// 수정 전: 입력 중간값이 settings에 즉시 반영됨
function handleCustomChange(val) {
  setCustomValue(val)
  setSettings((s) => ({ ...s, defaultThresholdPercent: parseFloat(val) || 0 }))
}

// 수정 후: 저장 시점에만 변환
function handleCustomChange(val) {
  setCustomValue(val)
}

async function handleSave() {
  const percent = isCustom ? parseFloat(customValue) : settings.defaultThresholdPercent
  ...
}
```

**개선점**
- 입력 중 중간값이 settings 상태를 오염시키는 문제 차단
- 입력 완료 후 저장 시점에만 값이 확정되므로, 백엔드로 전송되는 값이 항상 사용자가 최종 입력한 값과 일치함

---

### 2. 유효성 검사 조건 수정

**문제**
기존 유효성 검사가 `!percent`로 작성되어 있어 `0`을 입력하면 falsy로 평가되어 에러 메시지가 표시되었습니다.
또한 `isCustom` 여부와 무관하게 항상 `settings.defaultThresholdPercent`를 참조하고 있어, 커스텀 입력값이 검사에 반영되지 않는 문제가 있었습니다.

**수정 방식**
- `!percent` → `isNaN(percent)`로 변경하여 숫자가 아닌 값(빈 문자열, 문자 등)만 차단
- percent 계산 자체를 `isCustom ? parseFloat(customValue) : settings.defaultThresholdPercent`로 변경하여 커스텀 입력값이 검사에 올바르게 반영되도록 수정

**개선점**
- `0` 입력 시 오탐 제거
- 커스텀 입력값과 프리셋 값 모두 동일한 유효성 검사 로직으로 처리

---

## 체크리스트

- [x] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항(선택)
