### PR TITLE
feat: 관심종목 위젯에 실시간 시세 반영

### DIFF
--- a/src/components/widgets/WatchlistWidget.jsx
+++ b/src/components/widgets/WatchlistWidget.jsx
@@ -11,6 +11,7 @@ import WatchlistEditModal from './WatchlistEditModal'
 import { useWatchlist, watchlistApi } from '@/api/watchlist'
 import useWidgetDetailStore from '@/store/useWidgetDetailStore'
 import { isForeignMarketType } from '@/features/invest/formatters'
+import useWatchlistQuote from '@/features/market/useWatchlistQuote'
 
 const EXCHANGE_CODE_BY_MARKET_TYPE = { NASDAQ: 'NAS', NYSE: 'NYS', AMEX: 'AMS' }
 
@@ -36,6 +37,44 @@ function useWatchlistMutations() {
   })
 
   return { add, remove }
+}
+
+function WatchlistWideRow({ item, onStockClick }) {
+  const resolvedItem = useWatchlistQuote(item)
+
+  return (
+    <div
+      onClick={(e) => onStockClick(e, resolvedItem)}
+      className="flex items-center justify-between gap-2 cursor-pointer pl-1.5 border-l-2 border-l-transparent hover:border-l-primary transition-colors"
+    >
+      <div className="flex items-center gap-2 min-w-0">
+        <StockAvatar name={resolvedItem.stockName ?? resolvedItem.stockCode} stockCode={resolvedItem.stockCode} marketType={resolvedItem.marketType} size="sm" />
+        <span className="text-widget-10 font-medium text-foreground truncate">{resolvedItem.stockName}</span>
+      </div>
+      <div className="flex items-center gap-1.5 shrink-0">
+        {fmtPrice(resolvedItem.currentPrice, resolvedItem.marketType) && (
+          <span className="text-widget-10 font-semibold text-foreground tabular-nums">
+            {fmtPrice(resolvedItem.currentPrice, resolvedItem.marketType)}
+          </span>
+        )}
+        <PriceChange value={resolvedItem.changeRate} className="text-widget-9 font-medium" />
+      </div>
+    </div>
+  )
+}
+
+function WatchlistCompactRow({ item, onStockClick }) {
+  const resolvedItem = useWatchlistQuote(item)
+
+  return (
+    <div
+      onClick={(e) => onStockClick(e, resolvedItem)}
+      className="flex items-center justify-between cursor-pointer pl-1.5 border-l-2 border-l-transparent hover:border-l-primary transition-colors"
+    >
+      <span className="text-widget-10 font-medium text-foreground truncate">{resolvedItem.stockName}</span>
+      <PriceChange value={resolvedItem.changeRate} className="text-widget-9 font-semibold shrink-0" />
+    </div>
+  )
 }
 
 export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1, rowSpan = 1, onDelete }) {
@@ -107,24 +146,11 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
             {isError
               ? <span className="text-widget-10 text-foreground-disabled">불러오기에 실패했습니다</span>
               : list.length > 0 ? list.map((item) => (
-              <div
+              <WatchlistWideRow
                 key={item.stockCode}
-                onClick={(e) => handleStockClick(e, item)}
-                className="flex items-center justify-between gap-2 cursor-pointer pl-1.5 border-l-2 border-l-transparent hover:border-l-primary transition-colors"
-              >
-                <div className="flex items-center gap-2 min-w-0">
-                  <StockAvatar name={item.stockName ?? item.stockCode} stockCode={item.stockCode} marketType={item.marketType} size="sm" />
-                  <span className="text-widget-10 font-medium text-foreground truncate">{item.stockName}</span>
-                </div>
-                <div className="flex items-center gap-1.5 shrink-0">
-                  {fmtPrice(item.currentPrice, item.marketType) && (
-                    <span className="text-widget-10 font-semibold text-foreground tabular-nums">
-                      {fmtPrice(item.currentPrice, item.marketType)}
-                    </span>
-                  )}
-                  <PriceChange value={item.changeRate} className="text-widget-9 font-medium" />
-                </div>
-              </div>
+                item={item}
+                onStockClick={handleStockClick}
+              />
             )) : (
               <div className="flex-1 flex items-center justify-center text-widget-9 text-foreground-disabled">관심 종목 없음</div>
             )}
@@ -148,14 +174,11 @@ export default function WatchlistWidget({ variant = 'watchlist-sm', colSpan = 1,
           {isError
             ? <span className="text-widget-10 text-foreground-disabled">불러오기에 실패했습니다</span>
             : list.length > 0 ? list.map((item) => (
-            <div
+            <WatchlistCompactRow
               key={item.stockCode}
-              onClick={(e) => handleStockClick(e, item)}
-              className="flex items-center justify-between cursor-pointer pl-1.5 border-l-2 border-l-transparent hover:border-l-primary transition-colors"
-            >
-              <span className="text-widget-10 font-medium text-foreground truncate">{item.stockName}</span>
-              <PriceChange value={item.changeRate} className="text-widget-9 font-semibold shrink-0" />
-            </div>
+              item={item}
+              onStockClick={handleStockClick}
+            />
           )) : (
             <div className="flex-1 flex items-center justify-center text-widget-9 text-foreground-disabled">관심 종목 없음</div>
           )}

--- a/src/components/widgets/detail/WatchlistDetail.jsx
+++ b/src/components/widgets/detail/WatchlistDetail.jsx
@@ -7,6 +7,7 @@ import { useWatchlist, watchlistApi } from '@/api/watchlist'
 import useAuthStore from '@/store/useAuthStore'
 import useWidgetDetailStore from '@/store/useWidgetDetailStore'
 import useSparkline from '@/features/market/useSparkline'
+import useWatchlistQuote from '@/features/market/useWatchlistQuote'
 import { isForeignMarketType } from '@/features/invest/formatters'
 import { cn } from '@/lib/cn'
 
@@ -31,36 +32,37 @@ function fmtChange(change, marketType) {
 }
 
 function WatchlistRow({ item, onStockClick, onRemove }) {
-  const isOverseas = isForeignMarketType(item.marketType)
-  const changeAmt  = fmtChange(item.change ?? item.changeAmount, item.marketType)
-  const isUp       = (item.changeRate ?? 0) >= 0
+  const resolvedItem = useWatchlistQuote(item)
+  const isOverseas = isForeignMarketType(resolvedItem.marketType)
+  const changeAmt  = fmtChange(resolvedItem.change ?? resolvedItem.changeAmount, resolvedItem.marketType)
+  const isUp       = (resolvedItem.changeRate ?? 0) >= 0
 
-  const exchangeCode = item.exchangeCode ?? EXCHANGE_CODE_BY_MARKET_TYPE[item.marketType] ?? null
-  const { data: sparkData = [] } = useSparkline(item.stockCode, item.marketType, exchangeCode)
+  const exchangeCode = resolvedItem.exchangeCode ?? EXCHANGE_CODE_BY_MARKET_TYPE[resolvedItem.marketType] ?? null
+  const { data: sparkData = [] } = useSparkline(resolvedItem.stockCode, resolvedItem.marketType, exchangeCode)
 
   return (
     <button
-      onClick={() => onStockClick(item)}
+      onClick={() => onStockClick(resolvedItem)}
       className="w-full text-left flex items-center gap-3 px-8 py-3 border-b border-stroke last:border-b-0 hover:bg-surface-muted transition-colors group"
     >
       {/* 로고 */}
       <StockAvatar
-        name={item.stockName}
-        stockCode={item.stockCode}
-        marketType={item.marketType}
+        name={resolvedItem.stockName}
+        stockCode={resolvedItem.stockCode}
+        marketType={resolvedItem.marketType}
         size="md"
       />
 
       {/* 종목명 + 코드 */}
       <div className="flex-1 flex flex-col gap-0.5 min-w-0">
         <span className="text-[13px] font-semibold text-foreground truncate leading-tight">
-          {item.stockName}
+          {resolvedItem.stockName}
         </span>
         <div className="flex items-center gap-1.5">
-          <span className="text-[10px] text-foreground-disabled">{item.stockCode}</span>
+          <span className="text-[10px] text-foreground-disabled">{resolvedItem.stockCode}</span>
           {isOverseas && (
             <span className="text-[9px] font-medium text-foreground-disabled bg-surface-subtle rounded px-1 py-px">
-              {item.marketType}
+              {resolvedItem.marketType}
             </span>
           )}
         </div>
@@ -76,7 +78,7 @@ function WatchlistRow({ item, onStockClick, onRemove }) {
       {/* 현재가 */}
       <div className="w-[96px] text-right">
         <span className="text-[13px] font-bold text-foreground tabular-nums">
-          {fmtPrice(item.currentPrice, item.marketType)}
+          {fmtPrice(resolvedItem.currentPrice, resolvedItem.marketType)}
         </span>
       </div>
 
@@ -88,7 +90,7 @@ function WatchlistRow({ item, onStockClick, onRemove }) {
         {changeAmt && (
           <span className="text-[12px] font-semibold">{changeAmt}</span>
         )}
-        <PriceChange value={item.changeRate} className="text-[11px] font-medium" />
+        <PriceChange value={resolvedItem.changeRate} className="text-[11px] font-medium" />
       </div>
 
       {/* 삭제 버튼 */}

--- a/src/features/market/useWatchlistQuote.js
+++ b/src/features/market/useWatchlistQuote.js
@@ -1,0 +1,71 @@
+import { useMemo } from 'react'
+import useStompSubscription from '@/hooks/useStompSubscription'
+import { isForeignMarketType } from '@/features/invest/formatters'
+
+function toFiniteNumber(value) {
+  const numeric = Number(value)
+  return Number.isFinite(numeric) ? numeric : null
+}
+
+function resolveDirection(sign, fallbackValue = 0) {
+  if (sign != null) {
+    const normalizedSign = String(sign)
+    if (['4', '5'].includes(normalizedSign)) return -1
+    if (['1', '2'].includes(normalizedSign)) return 1
+    if (normalizedSign === '3') return 0
+  }
+
+  const numeric = Number(fallbackValue)
+  if (!Number.isFinite(numeric)) return 0
+  return Math.sign(numeric)
+}
+
+function buildQuotePatch(raw, marketType) {
+  if (!raw) return null
+
+  const isForeign = isForeignMarketType(marketType)
+  const currentPrice = toFiniteNumber(raw.currentPrice ?? raw.price)
+  const changeRate = isForeign
+    ? toFiniteNumber(raw.changeRate ?? raw.rate)
+    : toFiniteNumber(raw.changeRate ?? raw.drate ?? raw.rate)
+  const rawChangeAmount = isForeign
+    ? toFiniteNumber(raw.changeAmount ?? raw.diff ?? raw.change)
+    : toFiniteNumber(raw.changeAmount ?? raw.change ?? raw.diff)
+  const direction = resolveDirection(raw.sign, changeRate ?? rawChangeAmount)
+  const changeAmount = rawChangeAmount == null ? null : direction * Math.abs(rawChangeAmount)
+  const volume = toFiniteNumber(raw.volume)
+
+  const patch = {}
+  if (currentPrice != null && currentPrice > 0) patch.currentPrice = currentPrice
+  if (changeRate != null) patch.changeRate = changeRate
+  if (changeAmount != null) {
+    patch.changeAmount = changeAmount
+    patch.change = changeAmount
+  }
+  if (volume != null) patch.volume = volume
+
+  return Object.keys(patch).length > 0 ? patch : null
+}
+
+export default function useWatchlistQuote(item) {
+  const marketType = item?.marketType ?? null
+  const isForeign = isForeignMarketType(marketType)
+  const topic = item?.stockCode
+    ? (isForeign ? `/topic/foreign/quote/${item.stockCode}` : `/topic/stock/trade/${item.stockCode}`)
+    : null
+
+  const liveQuote = useStompSubscription(topic)
+
+  return useMemo(() => {
+    if (!item) return null
+
+    const basePatch = buildQuotePatch(item, marketType)
+    const livePatch = buildQuotePatch(liveQuote, marketType)
+
+    return {
+      ...item,
+      ...(basePatch ?? {}),
+      ...(livePatch ?? {}),
+    }
+  }, [item, liveQuote, marketType])
+}


### PR DESCRIPTION
## 요약
- 관심종목 위젯과 상세 목록에 실시간 시세를 반영했습니다.
- STOMP 구독 데이터를 관심종목 항목에 병합하는 `useWatchlistQuote` 훅을 추가했습니다.
- 위젯 행 클릭 시 최신 시세가 반영된 종목 정보를 상세 패널로 전달합니다.

## 변경 파일
- src/components/widgets/WatchlistWidget.jsx
- src/components/widgets/detail/WatchlistDetail.jsx
- src/features/market/useWatchlistQuote.js

## 검증
- pnpm exec eslint src/components/widgets/WatchlistWidget.jsx src/components/widgets/detail/WatchlistDetail.jsx src/features/market/useWatchlistQuote.js