### PR TITLE
fix(auth): token 복원 시 user 정보 누락되면 서버에서 재조회

### DIFF
--- a/src/store/useAuthStore.js
+++ b/src/store/useAuthStore.js
@@ -12,6 +12,18 @@ function isTokenExpired(token) {
   }
 }
 
+async function fetchUserFromServer(token) {
+  try {
+    const res = await fetch('/api/users/me', {
+      headers: { Authorization: `Bearer ${token}` },
+      credentials: 'include',
+    })
+    return res.ok ? await res.json() : null
+  } catch {
+    return null
+  }
+}
+
 async function silentRefresh() {
   const res = await fetch('/api/auth/token/refresh', {
     method: 'POST',
@@ -53,11 +65,7 @@ const useAuthStore = create((set, get) => ({
         const newToken = data.accessToken
         const storage = localStorage.getItem('autoLogin') === 'true' ? localStorage : sessionStorage
         storage.setItem('accessToken', newToken)
-        const userRes = await fetch('/api/users/me', {
-          headers: { Authorization: `Bearer ${newToken}` },
-          credentials: 'include',
-        })
-        const user = userRes.ok ? await userRes.json() : null
+        const user = await fetchUserFromServer(newToken)
         if (user) storage.setItem('user', JSON.stringify(user))
         set({ isAuthenticated: true, user, accessToken: newToken, isRestoring: false })
         applyThemeFromServer()
@@ -68,9 +76,15 @@ const useAuthStore = create((set, get) => ({
     }
 
     const userStr = localStorage.getItem('user') ?? sessionStorage.getItem('user')
-    const user = userStr ? JSON.parse(userStr) : null
+    let user = userStr ? JSON.parse(userStr) : null
+    const storage = localStorage.getItem('accessToken') ? localStorage : sessionStorage
 
     if (!isTokenExpired(accessToken)) {
+      // user 정보가 없는 경우 서버에서 복구
+      if (!user) {
+        user = await fetchUserFromServer(accessToken)
+        if (user) storage.setItem('user', JSON.stringify(user))
+      }
       set({ isAuthenticated: true, user, accessToken, isRestoring: false })
       applyThemeFromServer()
       return
@@ -80,8 +94,12 @@ const useAuthStore = create((set, get) => ({
     try {
       const data = await silentRefresh()
       const newToken = data.accessToken
-      const storage = localStorage.getItem('accessToken') ? localStorage : sessionStorage
       storage.setItem('accessToken', newToken)
+      // user 정보가 없는 경우 서버에서 복구
+      if (!user) {
+        user = await fetchUserFromServer(newToken)
+        if (user) storage.setItem('user', JSON.stringify(user))
+      }
       set({ isAuthenticated: true, user, accessToken: newToken, isRestoring: false })
       applyThemeFromServer()
     } catch {


### PR DESCRIPTION
## 관련 이슈

Closes #163

## 변경 내용

`restoreAuth`에서 `accessToken`은 있지만 `user`가 storage에 없을 때 `/api/users/me`로 user 정보를 재조회하도록 수정.

- `fetchUserFromServer(token)` 헬퍼 함수 추출
- token 유효(만료 전) 경로: user null이면 서버 재조회 후 storage 저장
- token 만료 후 refresh 성공 경로: user null이면 서버 재조회 후 storage 저장
- token 없음(silent refresh) 경로: 기존 inline fetch를 헬퍼로 교체

## 버그 원인

개발 중 401 → refresh 실패 → `logout()` → silent refresh 성공 순서에서 `/api/users/me`가 실패하면 `accessToken`만 storage에 남는 상태가 됨. 이후 페이지 새로고침 시 `isAuthenticated: true, user: null` 불일치 상태가 되어 헤더에 로그인/회원가입 버튼이 노출되면서 위젯은 정상 렌더링되는 현상 발생.