### PR TITLE
fix(widget): 실시간 순위 위젯 헤더 오버플로우 시 시장(국내/해외) 버튼만 토글로 전환

### DIFF
--- a/src/components/widgets/RankingWidget.jsx
+++ b/src/components/widgets/RankingWidget.jsx
@@ -7,15 +7,11 @@ import useWidgetDetailStore from '@/store/useWidgetDetailStore'
 import useUIStore from '@/store/useUIStore'
 
 const TABS = ['거래대금', '급상승', '거래량']
-const MARKET_TABS = [
-  { key: 'kr', label: '국내' },
-  { key: 'us', label: '해외' },
-]
 
 const TAB_TO_SORT = {
   '거래대금': 'volume_value',
-  '급상승':   'rising',
-  '거래량':   'volume',
+  '급상승': 'rising',
+  '거래량': 'volume',
 }
 
 export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, rowSpan = 1, onDelete }) {
@@ -25,12 +21,39 @@ export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, r
   const [activeMarket, setActiveMarket] = useState(
     () => localStorage.getItem('rankingWidget.activeMarket') ?? 'kr'
   )
-  const open     = useWidgetDetailStore((s) => s.open)
+  const [isCompactHeader, setIsCompactHeader] = useState(false)
 
-  const handleCardClick  = () => open({ widgetTypeId: 'ranking', config: { initialSortFilter: TAB_TO_SORT[activeTab], initialMarketFilter: activeMarket } })
+  const open = useWidgetDetailStore((s) => s.open)
+  const fontSize = useUIStore((s) => s.fontSize)
+
+  const headerMeasureWrapRef = useRef(null)
+  const headerMeasureRowRef = useRef(null)
+
+  const lgListRef = useRef(null)
+  const lgFirstRowRef = useRef(null)
+  const [lgMax, setLgMax] = useState(undefined)
+
+  const handleCardClick = () => {
+    open({
+      widgetTypeId: 'ranking',
+      config: {
+        initialSortFilter: TAB_TO_SORT[activeTab],
+        initialMarketFilter: activeMarket,
+      },
+    })
+  }
+
   const handleStockClick = (e, stock) => {
     e.stopPropagation()
-    open({ widgetTypeId: 'stock-chart', config: { stockCode: stock.stockCode, stockName: stock.name, marketType: stock.marketType ?? stock.market, exchangeCode: stock.exchangeCode } })
+    open({
+      widgetTypeId: 'stock-chart',
+      config: {
+        stockCode: stock.stockCode,
+        stockName: stock.name,
+        marketType: stock.marketType ?? stock.market,
+        exchangeCode: stock.exchangeCode,
+      },
+    })
   }
 
   function handleTabChange(tab) {
@@ -43,65 +66,139 @@ export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, r
     localStorage.setItem('rankingWidget.activeMarket', market)
   }
 
+  function handleMarketToggle(e) {
+    e.stopPropagation()
+    const next = activeMarket === 'kr' ? 'us' : 'kr'
+    handleMarketChange(next)
+  }
+
   const { stocks } = useMarketRanking(TAB_TO_SORT[activeTab], activeMarket)
-  const fontSize = useUIStore((s) => s.fontSize)
 
-  const marketTabBar = (
-    <div className="ml-auto pr-1 flex gap-1.5">
-      {MARKET_TABS.map((tab) => (
-        <button
-          key={tab.key}
-          type="button"
-          onClick={(e) => { e.stopPropagation(); handleMarketChange(tab.key) }}
-          className={
-            activeMarket === tab.key
-              ? 'px-2 py-0.5 text-widget-10 font-semibold rounded-md bg-primary text-white shadow-control'
-              : 'px-2 py-0.5 text-widget-10 font-semibold rounded-md text-foreground-secondary bg-surface-muted/65 hover:bg-surface-muted hover:text-foreground transition-colors'
-          }
-        >
-          {tab.label}
-        </button>
-      ))}
-    </div>
-  )
+  // 기본은 탭 전체 노출, 실제로 한 줄이 깨질 때만 compact 헤더로 전환
+  useLayoutEffect(() => {
+    const wrapEl = headerMeasureWrapRef.current
+    const rowEl = headerMeasureRowRef.current
+    if (!wrapEl || !rowEl) return
 
-  // ── ranking-lg (2x2): 컨테이너 높이 실측 후 완전한 행만 표시 ──
-  const lgListRef = useRef(null)
-  const lgFirstRowRef = useRef(null)
-  const [lgMax, setLgMax] = useState(undefined)
+    const updateCompact = () => {
+      const available = wrapEl.clientWidth
+      const required = rowEl.scrollWidth
+      setIsCompactHeader(required > available + 1)
+    }
 
-  // lgMax가 undefined일 때(= 컨테이너가 flex-1 자연 높이) 실측 후 설정
+    updateCompact()
+
+    if (typeof ResizeObserver !== 'undefined') {
+      const ro = new ResizeObserver(updateCompact)
+      ro.observe(wrapEl)
+      ro.observe(rowEl)
+      return () => ro.disconnect()
+    }
+
+    window.addEventListener('resize', updateCompact)
+    return () => window.removeEventListener('resize', updateCompact)
+  }, [variant, fontSize, activeTab, activeMarket])
+
   useLayoutEffect(() => {
     if (lgMax !== undefined) return
     const container = lgListRef.current
     const firstRow = lgFirstRowRef.current
     if (!container || !firstRow || !stocks.length) return
+
     const containerH = container.getBoundingClientRect().height
     const rowH = firstRow.getBoundingClientRect().height
     if (rowH <= 0 || containerH <= 0) return
+
     const gapPx = 2 // gap-0.5 = 0.125rem = 2px
     const n = Math.floor(containerH / (rowH + gapPx))
     setLgMax(`${Math.floor(n * (rowH + gapPx) - gapPx)}px`)
   }, [lgMax, stocks.length])
 
+  const marketToggle = (
+    <button
+      type="button"
+      onClick={handleMarketToggle}
+      className="ml-auto px-2 py-0.5 text-widget-10 font-semibold rounded-md bg-primary text-white shadow-control whitespace-nowrap shrink-0"
+    >
+      {activeMarket === 'kr' ? '국내' : '해외'}
+    </button>
+  )
+
+  const fullMarketTabs = (
+    <div className="ml-auto flex gap-1 shrink-0">
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation()
+          handleMarketChange('kr')
+        }}
+        className={
+          activeMarket === 'kr'
+            ? 'px-2 py-0.5 text-widget-10 font-semibold rounded-md bg-primary text-white shadow-control whitespace-nowrap'
+            : 'px-2 py-0.5 text-widget-10 font-semibold rounded-md text-foreground-secondary bg-surface-muted/65 hover:bg-surface-muted hover:text-foreground transition-colors whitespace-nowrap'
+        }
+      >
+        국내
+      </button>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation()
+          handleMarketChange('us')
+        }}
+        className={
+          activeMarket === 'us'
+            ? 'px-2 py-0.5 text-widget-10 font-semibold rounded-md bg-primary text-white shadow-control whitespace-nowrap'
+            : 'px-2 py-0.5 text-widget-10 font-semibold rounded-md text-foreground-secondary bg-surface-muted/65 hover:bg-surface-muted hover:text-foreground transition-colors whitespace-nowrap'
+        }
+      >
+        해외
+      </button>
+    </div>
+  )
+
+  const fullHeaderTabs = (
+    <div className="flex gap-0.5 shrink-0 whitespace-nowrap">
+      {TABS.map((tab) => (
+        <TabChip
+          key={tab}
+          isActive={activeTab === tab}
+          onClick={(e) => {
+            e.stopPropagation()
+            handleTabChange(tab)
+          }}
+        >
+          <span className="whitespace-nowrap">{tab}</span>
+        </TabChip>
+      ))}
+    </div>
+  )
+
+  const header = (
+    <>
+      <div className="relative mb-1.5 shrink-0" ref={headerMeasureWrapRef}>
+        {/* 실측 전용: 항상 풀 탭 레이아웃의 필요 폭을 측정 */}
+        <div className="absolute inset-0 h-0 overflow-hidden pointer-events-none opacity-0">
+          <div ref={headerMeasureRowRef} className="inline-flex w-max items-center gap-1.5 whitespace-nowrap">
+            <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase whitespace-nowrap">실시간 순위</span>
+            {fullHeaderTabs}
+            {fullMarketTabs}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-1.5 min-w-0">
+          <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase whitespace-nowrap">실시간 순위</span>
+          {fullHeaderTabs}
+          {isCompactHeader ? marketToggle : fullMarketTabs}
+        </div>
+      </div>
+    </>
+  )
+
   if (variant === 'ranking-lg') {
     return (
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleCardClick}>
-        <div className="flex items-center gap-1.5 mb-1.5 shrink-0">
-          <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">실시간 순위</span>
-          <div className="flex gap-0.5">
-            {TABS.map((tab) => (
-              <TabChip
-                key={tab}
-                isActive={activeTab === tab}
-                onClick={(e) => { e.stopPropagation(); handleTabChange(tab) }}
-              >
-                {tab}
-              </TabChip>
-            ))}
-          </div>
-          {marketTabBar}
-        </div>
+        {header}
         <div
           key={fontSize}
           ref={lgListRef}
@@ -115,11 +212,11 @@ export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, r
               className="flex items-center justify-between px-1 py-1 hover:bg-surface-subtle rounded-lg transition-colors cursor-pointer shrink-0"
               onClick={(e) => handleStockClick(e, stock)}
             >
-              <div className="flex items-center gap-1.5">
+              <div className="flex items-center gap-1.5 min-w-0">
                 <span className={`text-widget-9 font-bold w-4 text-center shrink-0 ${stock.rank === 1 ? 'text-primary' : 'text-foreground-disabled'}`}>
                   {stock.rank}
                 </span>
-                <span className="text-widget-10 font-semibold text-foreground">{stock.name}</span>
+                <span className="text-widget-10 font-semibold text-foreground truncate">{stock.name}</span>
               </div>
               <PriceChange value={stock.change} className="text-widget-10" />
             </div>
@@ -129,24 +226,9 @@ export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, r
     )
   }
 
-  /* ranking-wide (default) */
   return (
     <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleCardClick}>
-      <div className="flex items-center gap-1.5 mb-1.5 shrink-0">
-        <span className="text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase">실시간 순위</span>
-        <div className="flex gap-0.5">
-          {TABS.map((tab) => (
-            <TabChip
-              key={tab}
-              isActive={activeTab === tab}
-              onClick={(e) => { e.stopPropagation(); handleTabChange(tab) }}
-            >
-              {tab}
-            </TabChip>
-          ))}
-        </div>
-        {marketTabBar}
-      </div>
+      {header}
       <div className="flex-1 min-h-0 overflow-y-auto flex flex-col">
         {stocks.map((stock) => (
           <div
@@ -154,11 +236,11 @@ export default function RankingWidget({ variant = 'ranking-wide', colSpan = 2, r
             className="flex items-center justify-between px-1.5 py-1 rounded-xl hover:bg-surface-subtle transition-colors cursor-pointer shrink-0"
             onClick={(e) => handleStockClick(e, stock)}
           >
-            <div className="flex items-center gap-1.5">
+            <div className="flex items-center gap-1.5 min-w-0">
               <span className={`text-widget-9 font-bold w-3 text-center shrink-0 ${stock.rank === 1 ? 'text-primary' : 'text-foreground-disabled'}`}>
                 {stock.rank}
               </span>
-              <span className="text-widget-10 font-semibold text-foreground">{stock.name}</span>
+              <span className="text-widget-10 font-semibold text-foreground truncate">{stock.name}</span>
             </div>
             <PriceChange value={stock.change} className="text-widget-10" />
           </div>


### PR DESCRIPTION
## 변경 내용
- 실시간 순위 위젯(`ranking-lg`, `ranking-wide`)의 헤더 동작을 수정했습니다.
- `거래대금/급상승/거래량` 탭은 화면 크기와 관계없이 항상 노출되도록 유지했습니다.
- 헤더 폭이 부족한 경우(compact)에는 시장 버튼만 `국내/해외` 단일 토글로 전환되도록 변경했습니다.
- 일반 상태에서는 `국내`, `해외` 버튼 2개가 모두 보이도록 유지했습니다.
- 헤더 실측 로직을 보정해 탭이 시장 버튼 뒤로 숨기 전에 compact 전환되도록 개선했습니다.

## 배경 / 문제
- 화면 폭이 줄어들 때 정렬 탭이 사라지거나 시장 버튼 뒤로 가려지는 UI 문제가 있었습니다.
- 기존에는 compact 전환 시 정렬 탭까지 축약되어 요구사항과 달랐습니다.

## 기대 효과
- 정렬 탭 기능(거래대금/급상승/거래량)이 항상 동일하게 동작합니다.
- 좁은 폭에서도 시장 전환 UI가 일관되고 가독성이 좋아집니다.

## 변경 파일
- `sol-lite-frontend/src/components/widgets/RankingWidget.jsx`

## 확인 사항
- [x] 정렬 탭 클릭 동작 정상
- [x] 일반 폭: `국내/해외` 2버튼 노출
- [x] 좁은 폭(compact): 시장 단일 토글 전환
- [x] `ranking-lg`, `ranking-wide` 공통 적용
