### PR TITLE
feat(layout): 윈도우 width 반응형 compact 레이아웃

### DIFF
--- a/src/components/layout/AppHeader.jsx
+++ b/src/components/layout/AppHeader.jsx
@@ -9,6 +9,7 @@ import useEditModeStore from '@/store/useEditModeStore'
 import useWidgetStore, { hasUnsavedChanges } from '@/store/useWidgetStore'
 import { dashboardApi } from '@/api/dashboard'
 import { useDashboardSave } from '@/hooks/useDashboardSync'
+import { useIsCompact } from '@/hooks/useWindowWidth'
 import NotificationCenter from '@/components/ui/NotificationCenter'
 import { FontSizeButton, ThemeButton } from './DisplaySettingsButtons'
 import useWidgetDetailStore from '@/store/useWidgetDetailStore'
@@ -241,13 +242,14 @@ export default function AppHeader() {
   const { isEditMode } = useEditModeStore()
   const { pathname } = useLocation()
   const isHome = pathname === '/'
+  const isCompact = useIsCompact()
 
   return (
     <header className="h-header flex items-center px-4 gap-3 bg-surface border-b border-stroke shrink-0 z-50">
       <Logo />
       <NavTabs />
       <div className="flex-1" />
-      {isHome && (isEditMode ? <EditModeActions /> : <WidgetEditButton />)}
+      {isHome && !isCompact && (isEditMode ? <EditModeActions /> : <WidgetEditButton />)}
       <FontSizeButton />
       <ThemeButton />
       <NotificationCenter />

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -20,6 +20,7 @@ import usePendingWidgetStore from '@/store/usePendingWidgetStore'
 import usePendingQueryStore from '@/store/usePendingQueryStore'
 import { getWidgetDefaultQuery } from '@/config/widgetShortcuts'
 import { useDashboardLoad, useDashboardSave } from '@/hooks/useDashboardSync'
+import { useIsCompact } from '@/hooks/useWindowWidth'
 import { WIDGET_REGISTRY } from '@/components/widgets/widgetRegistry'
 import { GRID_GAP, GRID_COLS, GRID_ROWS, gridElementRef } from '@/lib/gridConstants'
 
@@ -34,6 +35,7 @@ export default function AppShell() {
   const location = useLocation()
   const navigate = useNavigate()
   const openLoginModal = useAuthStore((s) => s.openLoginModal)
+  const isCompact = useIsCompact()
   useDashboardLoad()
 
   useEffect(() => {
@@ -329,12 +331,14 @@ export default function AppShell() {
       <div className="flex flex-col h-screen overflow-hidden">
         <CurrencySync />
         <AppHeader />
-        <div className="flex flex-1 overflow-hidden">
-          <main className="relative flex-1 overflow-hidden bg-background isolate">
-            <Outlet />
-            <WidgetDetailModal />
-          </main>
-          <RightPanel />
+        <div className="flex flex-1 min-w-0 overflow-hidden">
+          {!isCompact && (
+            <main className="relative flex-1 min-w-0 overflow-hidden bg-background isolate">
+              <Outlet />
+              <WidgetDetailModal />
+            </main>
+          )}
+          <RightPanel isCompact={isCompact} />
         </div>
       </div>
       <DragOverlay>{overlayContent}</DragOverlay>

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -36,6 +36,10 @@ export default function AppShell() {
   const navigate = useNavigate()
   const openLoginModal = useAuthStore((s) => s.openLoginModal)
   const isCompact = useIsCompact()
+  const isHome = location.pathname === '/'
+  // compact + 홈: ChatPanel만 표시 / compact + 홈 외: main만 표시
+  const showMain  = !(isCompact && isHome)
+  const showPanel = !(isCompact && !isHome)
   useDashboardLoad()
 
   useEffect(() => {
@@ -332,13 +336,13 @@ export default function AppShell() {
         <CurrencySync />
         <AppHeader />
         <div className="flex flex-1 min-w-0 overflow-hidden">
-          {!isCompact && (
+          {showMain && (
             <main className="relative flex-1 min-w-0 overflow-hidden bg-background isolate">
               <Outlet />
               <WidgetDetailModal />
             </main>
           )}
-          <RightPanel isCompact={isCompact} />
+          {showPanel && <RightPanel isCompact={isCompact && isHome} />}
         </div>
       </div>
       <DragOverlay>{overlayContent}</DragOverlay>

--- a/src/components/layout/NavTabs.jsx
+++ b/src/components/layout/NavTabs.jsx
@@ -6,7 +6,7 @@ import { LAST_INVEST_PATH_KEY, LAST_INVEST_STATE_KEY } from '@/features/invest/n
 import useEditModeStore from '@/store/useEditModeStore'
 import useWidgetStore, { hasUnsavedChanges } from '@/store/useWidgetStore'
 import { useDashboardSave } from '@/hooks/useDashboardSync'
-import { useIsCompact } from '@/hooks/useWindowWidth'
+import { useIsNavCompact } from '@/hooks/useWindowWidth'
 
 const TABS = [
   { label: '홈',  path: '/' },
@@ -75,7 +75,7 @@ export default function NavTabs() {
   const { restoreSnapshot, clearSnapshot } = useWidgetStore()
   const unsaved = useWidgetStore(hasUnsavedChanges)
   const { mutate: saveDashboard, isPending } = useDashboardSave()
-  const isCompact = useIsCompact()
+  const isCompact = useIsNavCompact()
 
   const [pendingNav, setPendingNav] = useState(null) // { path, state }
   const [isMenuOpen, setIsMenuOpen] = useState(false)

--- a/src/components/layout/NavTabs.jsx
+++ b/src/components/layout/NavTabs.jsx
@@ -1,11 +1,12 @@
-import { useState } from 'react'
-import { X } from 'lucide-react'
+import { useState, useEffect, useRef } from 'react'
+import { X, ChevronDown } from 'lucide-react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { cn } from '@/lib/cn'
 import { LAST_INVEST_PATH_KEY, LAST_INVEST_STATE_KEY } from '@/features/invest/navigation'
 import useEditModeStore from '@/store/useEditModeStore'
 import useWidgetStore, { hasUnsavedChanges } from '@/store/useWidgetStore'
 import { useDashboardSave } from '@/hooks/useDashboardSync'
+import { useIsCompact } from '@/hooks/useWindowWidth'
 
 const TABS = [
   { label: '홈',  path: '/' },
@@ -74,11 +75,33 @@ export default function NavTabs() {
   const { restoreSnapshot, clearSnapshot } = useWidgetStore()
   const unsaved = useWidgetStore(hasUnsavedChanges)
   const { mutate: saveDashboard, isPending } = useDashboardSave()
+  const isCompact = useIsCompact()
 
   const [pendingNav, setPendingNav] = useState(null) // { path, state }
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const menuRef = useRef(null)
 
   const isActive = (path) =>
     path === '/' ? pathname === '/' : pathname.startsWith(path)
+
+  const activeTab = TABS.find(({ path }) => isActive(path))
+
+  // 외부 클릭 시 메뉴 닫기
+  useEffect(() => {
+    if (!isMenuOpen) return
+    function handleClickOutside(e) {
+      if (menuRef.current && !menuRef.current.contains(e.target)) {
+        setIsMenuOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [isMenuOpen])
+
+  // compact 해제 시 메뉴 닫기
+  useEffect(() => {
+    if (!isCompact) setIsMenuOpen(false)
+  }, [isCompact])
 
   function doNavigate({ path, state }) {
     navigate(path, state ? { state } : undefined)
@@ -127,22 +150,52 @@ export default function NavTabs() {
 
   return (
     <>
-      <nav className="flex items-center gap-0.5 bg-background rounded-xl p-1">
-        {TABS.map(({ label, path }) => (
+      {isCompact ? (
+        <div ref={menuRef} className="relative">
           <button
-            key={path}
-            onClick={() => handleTabClick(path)}
-            className={cn(
-              'px-4 py-1.5 text-[12px] rounded-lg transition-colors duration-150',
-              isActive(path)
-                ? 'bg-surface text-foreground font-semibold shadow-sm'
-                : 'text-foreground-disabled hover:text-foreground-secondary',
-            )}
+            onClick={() => setIsMenuOpen((v) => !v)}
+            className="flex items-center gap-1 px-3 py-1.5 text-[12px] rounded-xl bg-background text-foreground font-semibold"
           >
-            {label}
+            {activeTab?.label ?? '메뉴'}
+            <ChevronDown className={cn('w-3 h-3 transition-transform duration-150', isMenuOpen && 'rotate-180')} />
           </button>
-        ))}
-      </nav>
+          {isMenuOpen && (
+            <div className="absolute top-full left-0 mt-1 w-20 bg-surface rounded-xl shadow-modal border border-stroke z-[60] py-1 overflow-hidden">
+              {TABS.map(({ label, path }) => (
+                <button
+                  key={path}
+                  onClick={() => { setIsMenuOpen(false); handleTabClick(path) }}
+                  className={cn(
+                    'w-full px-3 py-2 text-[12px] text-left transition-colors duration-150',
+                    isActive(path)
+                      ? 'text-foreground font-semibold bg-surface-muted'
+                      : 'text-foreground-disabled hover:text-foreground-secondary hover:bg-surface-muted',
+                  )}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      ) : (
+        <nav className="flex items-center gap-0.5 bg-background rounded-xl p-1">
+          {TABS.map(({ label, path }) => (
+            <button
+              key={path}
+              onClick={() => handleTabClick(path)}
+              className={cn(
+                'px-4 py-1.5 text-[12px] rounded-lg transition-colors duration-150',
+                isActive(path)
+                  ? 'bg-surface text-foreground font-semibold shadow-sm'
+                  : 'text-foreground-disabled hover:text-foreground-secondary',
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </nav>
+      )}
 
       {pendingNav && (
         <NavConfirmModal

--- a/src/components/layout/RightPanel.jsx
+++ b/src/components/layout/RightPanel.jsx
@@ -1,3 +1,4 @@
+import { cn } from '@/lib/cn'
 import useEditModeStore from '@/store/useEditModeStore'
 import useRightPanelStore from '@/store/useRightPanelStore'
 import EditPanel from './EditPanel'
@@ -5,14 +6,17 @@ import ChatPanel from './ChatPanel'
 import AccountSettingsPanel from './AccountSettingsPanel'
 import NotificationSettingsPanel from './NotificationSettingsPanel'
 
-export default function RightPanel() {
+export default function RightPanel({ isCompact = false }) {
   const { isEditMode } = useEditModeStore()
   const mode = useRightPanelStore((s) => s.mode)
 
   if (isEditMode) return <EditPanel />
 
   return (
-    <aside className="w-chat-panel flex flex-col bg-surface border-l border-stroke shrink-0">
+    <aside className={cn(
+      'flex flex-col bg-surface border-stroke shrink-0',
+      isCompact ? 'flex-1 border-t' : 'w-chat-panel border-l',
+    )}>
       {mode === 'account-settings' ? (
         <AccountSettingsPanel />
       ) : mode === 'notification-settings' ? (

--- a/src/hooks/useWindowWidth.js
+++ b/src/hooks/useWindowWidth.js
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react'
+
+export const COMPACT_BREAKPOINT = 640   // MIN_DESKTOP(1280px)의 50%
+
+export default function useWindowWidth() {
+  const [width, setWidth] = useState(() => window.innerWidth)
+
+  useEffect(() => {
+    function handleResize() {
+      setWidth(window.innerWidth)
+    }
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
+
+  return width
+}
+
+export function useIsCompact() {
+  const width = useWindowWidth()
+  return width <= COMPACT_BREAKPOINT
+}

--- a/src/hooks/useWindowWidth.js
+++ b/src/hooks/useWindowWidth.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 
-export const COMPACT_BREAKPOINT = 768   // MIN_DESKTOP(1280px)의 약 60%
+export const COMPACT_BREAKPOINT     = 640  // MIN_DESKTOP(1280px)의 50% — 레이아웃 전환 기준
+export const NAV_COMPACT_BREAKPOINT = 640  // NavTabs 드롭다운 전환 기준
 
 export default function useWindowWidth() {
   const [width, setWidth] = useState(() => window.innerWidth)
@@ -19,4 +20,9 @@ export default function useWindowWidth() {
 export function useIsCompact() {
   const width = useWindowWidth()
   return width <= COMPACT_BREAKPOINT
+}
+
+export function useIsNavCompact() {
+  const width = useWindowWidth()
+  return width <= NAV_COMPACT_BREAKPOINT
 }

--- a/src/hooks/useWindowWidth.js
+++ b/src/hooks/useWindowWidth.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 
-export const COMPACT_BREAKPOINT = 640   // MIN_DESKTOP(1280px)의 50%
+export const COMPACT_BREAKPOINT = 768   // MIN_DESKTOP(1280px)의 약 60%
 
 export default function useWindowWidth() {
   const [width, setWidth] = useState(() => window.innerWidth)

--- a/src/index.css
+++ b/src/index.css
@@ -239,7 +239,6 @@
 }
 
 html {
-  min-width: 1280px; /* desktop-only: 최소 창 너비, 미만 시 수평 스크롤 */
   font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/src/pages/AssetPage.jsx
+++ b/src/pages/AssetPage.jsx
@@ -644,7 +644,8 @@ export function AssetContent() {
   if (!isRestoring && !isAuthenticated) return <AuthGuard />
 
   return (
-    <div className="flex flex-col h-full overflow-hidden bg-surface">
+    <div className="h-full overflow-x-auto bg-surface">
+    <div className="flex flex-col h-full min-w-[900px] bg-surface">
 
       {/* 환전 모달 */}
       {showExchange && (
@@ -675,6 +676,7 @@ export function AssetContent() {
         <HoldingsPanel data={data} />
       </div>
 
+    </div>
     </div>
   )
 }

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -176,7 +176,7 @@ export default function HomePage() {
 
   return (
     <>
-    <div className="flex flex-col h-full overflow-hidden p-3 gap-2.5">
+    <div className="flex flex-col h-full min-w-0 overflow-hidden p-3 gap-2.5">
       {/* 서브바 */}
       <div className="flex items-center justify-between shrink-0 px-1 min-h-7">
         <div className="flex items-center gap-2 min-w-0">


### PR DESCRIPTION
## 변경 내용

브라우저 window width에 따라 레이아웃을 동적으로 전환하는 기능 구현.

### 브레이크포인트

| 상수 | 값 | 용도 |
|---|---|---|
| `COMPACT_BREAKPOINT` | 640px (min-desktop 1280px의 50%) | 레이아웃 전환 기준 |
| `NAV_COMPACT_BREAKPOINT` | 640px | NavTabs 드롭다운 전환 기준 |

### 동작

**레이아웃 전환 (640px 기준)**
- 홈 + compact: 대시보드 숨김, ChatPanel 전체 너비로 표시, 위젯 편집 버튼 숨김
- 시세/주문/자산 + compact: ChatPanel 숨김, 메인 콘텐츠 유지

**NavTabs 전환 (640px 기준)**
- 일반: 홈/시세/주문/자산 탭 인라인 표시
- compact: 현재 페이지명 + 드롭다운 토글로 전환, 외부 클릭 시 닫힘

**기타**
- `html { min-width: 1280px }` 제거 — 좁은 창 허용
- 자산 페이지 가로 스크롤 적용 (`min-w-[900px]`)
- `useWindowWidth` / `useIsCompact` / `useIsNavCompact` 훅 추가