### PR TITLE
feat(nav): 홈 페이지 NavTabs 드롭다운 전환 breakpoint 확대

### DIFF
--- a/src/components/layout/NavTabs.jsx
+++ b/src/components/layout/NavTabs.jsx
@@ -75,7 +75,8 @@ export default function NavTabs() {
   const { restoreSnapshot, clearSnapshot } = useWidgetStore()
   const unsaved = useWidgetStore(hasUnsavedChanges)
   const { mutate: saveDashboard, isPending } = useDashboardSave()
-  const isCompact = useIsNavCompact()
+  const isHome = pathname === '/'
+  const isCompact = useIsNavCompact(isHome)
 
   const [pendingNav, setPendingNav] = useState(null) // { path, state }
   const [isMenuOpen, setIsMenuOpen] = useState(false)

--- a/src/hooks/useWindowWidth.js
+++ b/src/hooks/useWindowWidth.js
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react'
 
-export const COMPACT_BREAKPOINT     = 640  // MIN_DESKTOP(1280px)의 50% — 레이아웃 전환 기준
-export const NAV_COMPACT_BREAKPOINT = 640  // NavTabs 드롭다운 전환 기준
+export const COMPACT_BREAKPOINT          = 640  // MIN_DESKTOP(1280px)의 50% — 레이아웃 전환 기준
+export const NAV_COMPACT_BREAKPOINT      = 640  // NavTabs 드롭다운 전환 기준 (홈 외 페이지)
+export const NAV_COMPACT_BREAKPOINT_HOME = 760  // NavTabs 드롭다운 전환 기준 (홈 — 위젯편집 버튼 공간 확보)
 
 export default function useWindowWidth() {
   const [width, setWidth] = useState(() => window.innerWidth)
@@ -22,7 +23,8 @@ export function useIsCompact() {
   return width <= COMPACT_BREAKPOINT
 }
 
-export function useIsNavCompact() {
+export function useIsNavCompact(isHome = false) {
   const width = useWindowWidth()
-  return width <= NAV_COMPACT_BREAKPOINT
+  const breakpoint = isHome ? NAV_COMPACT_BREAKPOINT_HOME : NAV_COMPACT_BREAKPOINT
+  return width <= breakpoint
 }


### PR DESCRIPTION
## 변경 사항

- 홈 페이지에서 위젯편집 버튼 공간으로 인한 헤더 오버플로우 방지
- `NAV_COMPACT_BREAKPOINT_HOME = 760px` 추가 (홈), 기존 `NAV_COMPACT_BREAKPOINT = 640px` (홈 외 페이지) 유지
- `useIsNavCompact(isHome)` 파라미터 추가로 페이지별 breakpoint 분기

## 테스트

- [ ] 홈 페이지: 760px 이하에서 NavTabs 드롭다운 전환 확인
- [ ] 시세/주문/자산: 640px 이하에서 NavTabs 드롭다운 전환 확인