### PR TITLE
fix(auth): 앱 초기화 시 silentRefresh 실패 후 1회 재시도

### DIFF
--- a/src/store/useAuthStore.js
+++ b/src/store/useAuthStore.js
@@ -24,15 +24,25 @@ async function fetchUserFromServer(token) {
   }
 }
 
-async function silentRefresh() {
-  const res = await fetch('/api/auth/token/refresh', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({}),
-    credentials: 'include',
-  })
-  if (!res.ok) throw new Error('refresh failed')
-  return res.json()
+async function silentRefresh({ retryOnFail = false } = {}) {
+  const attempt = async () => {
+    const res = await fetch('/api/auth/token/refresh', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+      credentials: 'include',
+    })
+    if (!res.ok) throw new Error('refresh failed')
+    return res.json()
+  }
+
+  try {
+    return await attempt()
+  } catch (err) {
+    if (!retryOnFail) throw err
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    return attempt()
+  }
 }
 
 const useAuthStore = create((set, get) => ({
@@ -61,7 +71,7 @@ const useAuthStore = create((set, get) => ({
     if (!accessToken) {
       // 저장된 토큰 없음 — 쿠키(refresh token)가 살아있는지 silent refresh로 확인
       try {
-        const data = await silentRefresh()
+        const data = await silentRefresh({ retryOnFail: true })
         const newToken = data.accessToken
         const storage = localStorage.getItem('autoLogin') === 'true' ? localStorage : sessionStorage
         storage.setItem('accessToken', newToken)
@@ -92,7 +102,7 @@ const useAuthStore = create((set, get) => ({
 
     // 만료된 경우 refresh 시도
     try {
-      const data = await silentRefresh()
+      const data = await silentRefresh({ retryOnFail: true })
       const newToken = data.accessToken
       storage.setItem('accessToken', newToken)
       // user 정보가 없는 경우 서버에서 복구


### PR DESCRIPTION
## 작업 내용

앱 초기화(`restoreAuth`) 중 `silentRefresh`가 일시적 네트워크 오류 등으로 실패할 경우, 즉시 로그아웃 처리하지 않고 500ms 대기 후 1회 재시도하도록 수정

**근본 원인**
- access token 만료 시 `silentRefresh`가 일시적으로 실패하면 `logout()`이 호출됨
- `logout()`은 localStorage만 삭제하고 HTTP-only 쿠키(refresh token)는 건드리지 않음
- 결과적으로 실제 세션은 유효한데 클라이언트만 로그아웃 상태가 됨
- 사용자가 수동으로 새로고침하면 `silentRefresh` 재시도로 정상 복구됨

**변경 사항**
- `silentRefresh()`에 `retryOnFail` 옵션 추가
- `restoreAuth()`의 두 경로(토큰 없음, 토큰 만료)에서 모두 `retryOnFail: true`로 호출
- 재시도도 실패하면 기존과 동일하게 logout 처리

## 확인 방법

1. 로그인 후 access token 만료 대기 (또는 localStorage에서 직접 만료 처리)
2. 페이지 새로고침 시 로그인 상태가 유지되는지 확인
3. 서버 일시 오류 상황에서 자동 재시도 후 복구되는지 확인