### PR TITLE
fix(dashboard): 인증 오류 및 위젯 렌더링 개선

### DIFF
--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -363,16 +363,22 @@ export function PreviewContent({ type, sectorStocks, typeIndex = 0 }) {
         </div>
       )
 
-    /* 포트폴리오 — 파이차트 1×1 */
+    /* 포트폴리오 — 도넛차트 1×1 */
     case 'portfolio-sm':
       return (
         <div className="flex flex-col h-full gap-2">
-          <span className="text-[9px] text-foreground-disabled">종목별 비중</span>
+          <div className="flex items-center justify-between shrink-0">
+            <span className="text-[9px] text-foreground-disabled">종목별 비중</span>
+            <span className="text-[10px] font-bold text-down">+5.2%</span>
+          </div>
           <div className="flex items-center gap-2.5 flex-1 min-h-0">
-            <div
-              className="w-14 h-14 rounded-full shrink-0"
-              style={{ background: 'conic-gradient(var(--color-chart-1) 0% 34%, var(--color-chart-2) 34% 54%, var(--color-chart-3) 54% 72%, var(--color-chart-4) 72% 100%)' }}
-            />
+            <div className="relative w-14 h-14 shrink-0 flex items-center justify-center">
+              <div
+                className="absolute inset-0 rounded-full"
+                style={{ background: 'conic-gradient(var(--color-chart-1) 0% 34%, var(--color-chart-2) 34% 54%, var(--color-chart-3) 54% 72%, var(--color-chart-4) 72% 100%)' }}
+              />
+              <div className="relative w-7 h-7 rounded-full bg-surface" />
+            </div>
             <div className="flex flex-col gap-1">
               {[
                 { name: '삼성', color: 'bg-chart-1' },
@@ -398,22 +404,28 @@ export function PreviewContent({ type, sectorStocks, typeIndex = 0 }) {
             <span className="text-[9px] text-foreground-disabled">종목별 비중</span>
             <span className="text-[10px] font-bold text-up">+5.2%</span>
           </div>
-          <div className="flex flex-col gap-2">
-            {[
-              { name: '삼성전자',   pct: 34, color: 'bg-chart-1' },
-              { name: 'SK하이닉스', pct: 20, color: 'bg-chart-2' },
-              { name: '기타',       pct: 46, color: 'bg-chart-4' },
-            ].map(({ name, pct, color }) => (
-              <div key={name}>
-                <div className="flex justify-between mb-0.5">
-                  <span className="text-[9px] text-foreground-secondary">{name}</span>
-                  <span className="text-[9px] font-semibold text-foreground">{pct}%</span>
+          <div className="flex items-center gap-3 flex-1 min-h-0">
+            <div className="relative w-12 h-12 shrink-0 flex items-center justify-center">
+              <div
+                className="absolute inset-0 rounded-full"
+                style={{ background: 'conic-gradient(var(--color-chart-1) 0% 34%, var(--color-chart-2) 34% 54%, var(--color-chart-3) 54% 72%, var(--color-chart-4) 72% 100%)' }}
+              />
+              <div className="relative w-6 h-6 rounded-full bg-surface" />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              {[
+                { name: '삼성전자',   pct: 34, color: 'bg-chart-1' },
+                { name: 'SK하이닉스', pct: 20, color: 'bg-chart-2' },
+                { name: 'LG에너지',   pct: 18, color: 'bg-chart-3' },
+                { name: '기타',       pct: 28, color: 'bg-chart-4' },
+              ].map(({ name, pct, color }) => (
+                <div key={name} className="flex items-center gap-1.5">
+                  <div className={`w-1.5 h-1.5 rounded-full shrink-0 ${color}`} />
+                  <span className="text-[8px] text-foreground-secondary">{name}</span>
+                  <span className="text-[8px] font-semibold text-foreground ml-auto">{pct}%</span>
                 </div>
-                <div className="h-1.5 bg-surface-muted rounded-full overflow-hidden">
-                  <div className={`h-full rounded-full ${color}`} style={{ width: `${pct}%` }} />
-                </div>
-              </div>
-            ))}
+              ))}
+            </div>
           </div>
         </div>
       )

--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -402,7 +402,7 @@ export function PreviewContent({ type, sectorStocks, typeIndex = 0 }) {
         <div className="flex flex-col h-full gap-1.5">
           <div className="flex items-center justify-between shrink-0">
             <span className="text-[9px] text-foreground-disabled">종목별 비중</span>
-            <span className="text-[10px] font-bold text-up">+5.2%</span>
+            <span className="text-[10px] font-bold text-down">+5.2%</span>
           </div>
           <div className="flex items-center gap-3 flex-1 min-h-0">
             <div className="relative w-12 h-12 shrink-0 flex items-center justify-center">

--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -369,7 +369,7 @@ export function PreviewContent({ type, sectorStocks, typeIndex = 0 }) {
         <div className="flex flex-col h-full gap-2">
           <div className="flex items-center justify-between shrink-0">
             <span className="text-[9px] text-foreground-disabled">종목별 비중</span>
-            <span className="text-[10px] font-bold text-down">+5.2%</span>
+            <span className="text-[10px] font-bold text-up">+5.2%</span>
           </div>
           <div className="flex items-center gap-2.5 flex-1 min-h-0">
             <div className="relative w-14 h-14 shrink-0 flex items-center justify-center">
@@ -402,7 +402,7 @@ export function PreviewContent({ type, sectorStocks, typeIndex = 0 }) {
         <div className="flex flex-col h-full gap-1.5">
           <div className="flex items-center justify-between shrink-0">
             <span className="text-[9px] text-foreground-disabled">종목별 비중</span>
-            <span className="text-[10px] font-bold text-down">+5.2%</span>
+            <span className="text-[10px] font-bold text-up">+5.2%</span>
           </div>
           <div className="flex items-center gap-3 flex-1 min-h-0">
             <div className="relative w-12 h-12 shrink-0 flex items-center justify-center">

--- a/src/components/layout/EditPanel/WidgetSizeList.jsx
+++ b/src/components/layout/EditPanel/WidgetSizeList.jsx
@@ -867,10 +867,13 @@ export function PreviewContent({ type, sectorStocks, typeIndex = 0 }) {
           <span className="text-[9px] text-foreground-disabled shrink-0">섹터별 비중</span>
           <div className="flex items-center gap-3 shrink-0">
             
-            <div
-              className="w-16 h-16 rounded-full shrink-0"
-              style={{ background: 'conic-gradient(var(--color-chart-1) 0% 54%, var(--color-chart-2) 54% 72%, var(--color-chart-3) 72% 87%, var(--color-chart-4) 87% 100%)' }}
-            />
+            <div className="relative w-16 h-16 shrink-0 flex items-center justify-center">
+              <div
+                className="absolute inset-0 rounded-full"
+                style={{ background: 'conic-gradient(var(--color-chart-1) 0% 54%, var(--color-chart-2) 54% 72%, var(--color-chart-3) 72% 87%, var(--color-chart-4) 87% 100%)' }}
+              />
+              <div className="relative w-8 h-8 rounded-full bg-surface" />
+            </div>
             <div>
               <div className="text-[9px] text-foreground-disabled">총 수익률</div>
               <div className="text-[17px] font-extrabold text-up leading-none">+5.2%</div>

--- a/src/components/widgets/BalanceWidget.jsx
+++ b/src/components/widgets/BalanceWidget.jsx
@@ -107,6 +107,8 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
         smooth: true,
         showSymbol: pts.length === 1,
         symbolSize: 5,
+        silent: true,
+        emphasis: { disabled: true },
         data: pts,
         lineStyle: { width: 2, color: lineColor },
         itemStyle: { color: lineColor },

--- a/src/components/widgets/BalanceWidget.jsx
+++ b/src/components/widgets/BalanceWidget.jsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import ReactECharts from 'echarts-for-react'
 import LockedOverlay from '@/components/ui/LockedOverlay'
@@ -27,8 +28,19 @@ function useBalance(enabled) {
 
   const isLoading = enabled && summaryLoading
 
+  // 조건부 return 이전에 호출 — Rules of Hooks 준수
+  // assetFlow는 React Query가 관리하므로 데이터 미변경 시 레퍼런스 안정
+  const flowPoints = useMemo(
+    () => (assetFlow?.points ?? []).map((p) => Number(p.cumulativeReturnRate ?? 0)),
+    [assetFlow],
+  )
+  const flowDates = useMemo(
+    () => (assetFlow?.points ?? []).map((p) => (p.date ?? '').slice(5).replace('-', '.')),
+    [assetFlow],
+  )
+
   if (isLoading) {
-    return { total: '-', profit: '-', profitRate: '-', invested: '-', available: '-', isProfit: true, isLoading: true, flowPoints: [] }
+    return { total: '-', profit: '-', profitRate: '-', invested: '-', available: '-', isProfit: true, isLoading: true, flowPoints, flowDates }
   }
 
   const cashList  = summary?.cashBalances ?? []
@@ -38,8 +50,6 @@ function useBalance(enabled) {
   const profitRate = Number(summary?.accountProfitLossRate ?? 0)
   const invested  = total - profit - Number(krwEntry.totalAmount ?? 0)
 
-  const flowPoints = (assetFlow?.points ?? []).map((p) => Number(p.cumulativeReturnRate ?? 0))
-  const flowDates  = (assetFlow?.points ?? []).map((p) => (p.date ?? '').slice(5).replace('-', '.'))
   const maxRate    = flowPoints.reduce((m, r) => Math.max(m, Math.abs(r)), 0)
 
   return {
@@ -60,6 +70,49 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
   const { isAuthenticated, isRestoring } = useAuthStore()
   const BALANCE = useBalance(isAuthenticated && !isRestoring)
   const open = useWidgetDetailStore((s) => s.open)
+
+  const chartOption = useMemo(() => {
+    const pts = BALANCE.flowPoints
+    if (pts.length <= 1) return null
+    const isUp = pts[pts.length - 1] >= pts[0]
+    const lineColor = isUp ? 'var(--color-up)' : 'var(--color-down)'
+    return {
+      backgroundColor: 'transparent',
+      grid: { left: 28, right: 4, top: 4, bottom: 16, containLabel: false },
+      tooltip: { show: false },
+      xAxis: {
+        type: 'category',
+        boundaryGap: false,
+        data: BALANCE.flowDates,
+        axisLine: { show: false },
+        axisTick: { show: false },
+        axisLabel: { color: 'var(--color-foreground-disabled)', fontSize: 8, margin: 4 },
+      },
+      yAxis: {
+        type: 'value',
+        scale: true,
+        splitNumber: 2,
+        axisLine: { show: false },
+        axisTick: { show: false },
+        splitLine: { show: false },
+        axisLabel: {
+          color: 'var(--color-foreground-disabled)',
+          fontSize: 8,
+          margin: 4,
+          formatter: (v) => (v >= 0 ? '+' : '') + v.toFixed(1) + '%',
+        },
+      },
+      series: [{
+        type: 'line',
+        smooth: true,
+        showSymbol: pts.length === 1,
+        symbolSize: 5,
+        data: pts,
+        lineStyle: { width: 2, color: lineColor },
+        itemStyle: { color: lineColor },
+      }],
+    }
+  }, [BALANCE.flowPoints, BALANCE.flowDates])
 
   return (
     <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={() => open({ widgetTypeId: 'balance', config: {} })}>
@@ -125,54 +178,13 @@ export default function BalanceWidget({ variant = 'balance-sm', colSpan = 1, row
           <div className="flex flex-col flex-1 min-h-0 border-t border-stroke pt-2">
             <div className="text-widget-9 text-foreground-disabled shrink-0">수익 추이 (7일)</div>
             <div className="flex-1 min-h-0 relative">
-              {BALANCE.flowPoints.length > 1 ? (() => {
-                const pts = BALANCE.flowPoints
-                const isUp = pts[pts.length - 1] >= pts[0]
-                const lineColor = isUp ? 'var(--color-up)' : 'var(--color-down)'
-                const chartOption = {
-                  backgroundColor: 'transparent',
-                  grid: { left: 28, right: 4, top: 4, bottom: 16, containLabel: false },
-                  tooltip: { show: false },
-                  xAxis: {
-                    type: 'category',
-                    boundaryGap: false,
-                    data: BALANCE.flowDates,
-                    axisLine: { show: false },
-                    axisTick: { show: false },
-                    axisLabel: { color: 'var(--color-foreground-disabled)', fontSize: 8, margin: 4 },
-                  },
-                  yAxis: {
-                    type: 'value',
-                    scale: true,
-                    splitNumber: 2,
-                    axisLine: { show: false },
-                    axisTick: { show: false },
-                    splitLine: { show: false },
-                    axisLabel: {
-                      color: 'var(--color-foreground-disabled)',
-                      fontSize: 8,
-                      margin: 4,
-                      formatter: (v) => (v >= 0 ? '+' : '') + v.toFixed(1) + '%',
-                    },
-                  },
-                  series: [{
-                    type: 'line',
-                    smooth: true,
-                    showSymbol: pts.length === 1,
-                    symbolSize: 5,
-                    data: pts,
-                    lineStyle: { width: 2, color: lineColor },
-                    itemStyle: { color: lineColor },
-                  }],
-                }
-                return (
-                  <ReactECharts
-                    option={chartOption}
-                    style={{ width: '100%', height: '100%' }}
-                    opts={{ renderer: 'svg' }}
-                  />
-                )
-              })() : (
+              {chartOption ? (
+                <ReactECharts
+                  option={chartOption}
+                  style={{ width: '100%', height: '100%' }}
+                  opts={{ renderer: 'svg' }}
+                />
+              ) : (
                 <div className="absolute inset-0 flex items-center justify-center text-widget-9 text-foreground-disabled">데이터 없음</div>
               )}
             </div>

--- a/src/components/widgets/WidgetCard.jsx
+++ b/src/components/widgets/WidgetCard.jsx
@@ -1,16 +1,28 @@
+import { useRef, useLayoutEffect } from 'react'
 import useEditModeStore from '@/store/useEditModeStore'
 import EditHandle from './EditHandle'
 import { cn } from '@/lib/cn'
 
 export default function WidgetCard({ children, className = '', onDelete, onClick }) {
   const { isEditMode, wiggleDelay, wiggleSyncKey } = useEditModeStore()
+  const animRef = useRef(null)
+
+  // key 트릭 대신 CSS 애니메이션만 명령형으로 재시작 — 자식 트리 언마운트 방지
+  // wiggleSyncKey > 0: resyncWiggle 호출 시 (drag end), 0은 editMode 진입 초기값
+  useLayoutEffect(() => {
+    if (!isEditMode || wiggleSyncKey === 0) return
+    const el = animRef.current
+    if (!el) return
+    el.style.animationName = 'none'
+    void el.getBoundingClientRect() // force reflow
+    el.style.animationName = ''
+  }, [wiggleSyncKey, isEditMode])
 
   return (
     <div className={cn('h-full', className)}>
-      {/* animation wrapper: wiggleSyncKey 변경 시 remount → 모든 위젯 animation 동시 재시작
-          relative는 EditHandle의 absolute 기준점 역할 */}
+      {/* animation wrapper: relative는 EditHandle의 absolute 기준점 역할 */}
       <div
-        key={isEditMode ? wiggleSyncKey : undefined}
+        ref={animRef}
         className={cn(
           'relative h-full',
           isEditMode

--- a/src/lib/fetchWithAuth.js
+++ b/src/lib/fetchWithAuth.js
@@ -60,7 +60,7 @@ export async function fetchWithAuth(url, options = {}) {
 
   const res = await fetch(url, { ...fetchOptions, headers, credentials: 'include' })
 
-  if (res.status !== 401 || skipAuth) {
+  if ((res.status !== 401 && res.status !== 403) || skipAuth) {
     const text = await res.text()
     const data = text ? tryParseJson(text) : null
     if (!res.ok) throw data ?? { message: '요청에 실패했습니다.' }

--- a/src/lib/fetchWithAuth.js
+++ b/src/lib/fetchWithAuth.js
@@ -107,14 +107,19 @@ export async function fetchWithAuth(url, options = {}) {
         onRefreshed(newToken)
       })
       .catch((err) => {
-        // 다른 탭이 이미 rotation 완료했는지 확인 (멀티탭 race condition)
         const latestToken =
           localStorage.getItem('accessToken') ?? sessionStorage.getItem('accessToken')
         const currentToken = useAuthStore.getState().accessToken
         if (latestToken && latestToken !== currentToken) {
+          // 멀티탭: 다른 탭이 이미 rotation 완료
           useAuthStore.setState({ accessToken: latestToken })
           onRefreshed(latestToken)
+        } else if (latestToken) {
+          // refresh 실패했지만 토큰 존재 → 현재 토큰으로 재시도
+          // (신규 발급 토큰 전파 지연, 일시적 refresh 서버 오류 등 흡수)
+          onRefreshed(latestToken)
         } else {
+          // 토큰 없음 → 완전 만료 → logout
           onRefreshFailed(err)
           useAuthStore.getState().logout({ broadcast: true })
           useAuthStore.getState().openLoginModal()


### PR DESCRIPTION
## 변경 사항

### 인증 (auth)
- 403 응답도 401과 동일하게 토큰 갱신 후 재시도 처리 (`fetchWithAuth`)
- refresh 실패 시 토큰이 존재하면 logout 대신 현재 토큰으로 재시도

### 계좌잔고 위젯 (BalanceWidget)
- line chart option 메모이제이션으로 편집 모드에서 불필요한 재애니메이션 방지
- wiggle 재동기화 시 `key` remount 대신 CSS animation 명령형 재시작으로 ECharts 트리 보존
- `silent: true` + `emphasis: { disabled: true }` 적용으로 hover 깜빡임 제거

### EditPanel 포트폴리오 미리보기
- 1x1, 2x1, 2x2 파이차트 → 도넛 차트로 전환
- 1x1 수익률 텍스트 색상 text-up 적용

## 테스트 항목
- [ ] 토큰 만료 상태에서 위젯 저장 시 자동 갱신 후 성공
- [ ] 계좌잔고 3x2 위젯 이동/추가 시 line chart 재애니메이션 없음
- [ ] line chart hover 시 깜빡임 없음
- [ ] EditPanel 포트폴리오 미리보기 도넛 모양 확인