### PR TITLE
fix(invest): 해외주식 시세 및 호가 에러 처리 정리

### DIFF
--- a/src/api/market.js
+++ b/src/api/market.js
@@ -1,8 +1,49 @@
 const BASE = '/api/market'
 const inFlightRequests = new Map()
 
+function tryParseJson(text) {
+  try {
+    return JSON.parse(text)
+  } catch {
+    return { message: text }
+  }
+}
+
+function resolveErrorMessage(data, fallbackMessage) {
+  const candidates = [
+    data?.message,
+    data?.error,
+    data?.detail,
+    data?.details,
+    data?.errorMessage,
+  ]
+
+  const resolved = candidates.find((value) => typeof value === 'string' && value.trim())
+  return resolved?.trim() || fallbackMessage
+}
+
+function createApiError(url, response, data, rawText, fallbackMessage) {
+  const error = new Error(resolveErrorMessage(data, fallbackMessage))
+  error.name = 'ApiError'
+  error.status = response.status
+  error.statusText = response.statusText
+  error.url = url
+  error.data = data
+  error.rawText = rawText
+
+  const code = data?.code ?? data?.errorCode ?? data?.resultCode ?? data?.rt_cd
+  if (code != null) {
+    error.code = code
+  }
+
+  return error
+}
+
 async function get(path, params, options = {}) {
-  const query = params ? `?${new URLSearchParams(params).toString()}` : ''
+  const filteredParams = params
+    ? Object.fromEntries(Object.entries(params).filter(([, value]) => value != null))
+    : null
+  const query = filteredParams ? `?${new URLSearchParams(filteredParams).toString()}` : ''
   const url = `${BASE}${path}${query}`
   const requestKey = `${options.method ?? 'GET'}:${url}`
 
@@ -17,18 +58,10 @@ async function get(path, params, options = {}) {
     })
 
     const text = await res.text()
-    let data = null
-
-    if (text) {
-      try {
-        data = JSON.parse(text)
-      } catch {
-        data = { message: text }
-      }
-    }
+    const data = text ? tryParseJson(text) : null
 
     if (!res.ok) {
-      throw data ?? { message: '시장 데이터를 불러오지 못했습니다.' }
+      throw createApiError(url, res, data, text, '시장 데이터를 불러오지 못했습니다.')
     }
 
     return data

--- a/src/components/invest/InvestOrderBookPanel.jsx
+++ b/src/components/invest/InvestOrderBookPanel.jsx
@@ -7,6 +7,8 @@ export default function InvestOrderBookPanel({
   currentPrice,
   changeRate,
   orderBook,
+  isLoading = false,
+  errorMessage = '',
   onSelectPrice,
   marketType,
   displayCurrency,
@@ -15,6 +17,19 @@ export default function InvestOrderBookPanel({
   const isUp = changeRate > 0
   const isDown = changeRate < 0
 
+  if (isLoading && !orderBook) {
+    return (
+      <section className="flex w-[170px] shrink-0 flex-col overflow-hidden border-r border-stroke bg-surface">
+        <div className="flex items-center justify-between border-b border-stroke px-2.5 py-2 shrink-0">
+          <span className="text-[11px] font-bold text-foreground">호가창</span>
+        </div>
+        <div className="flex flex-1 items-center justify-center px-3 py-4">
+          <span className="text-[10px] text-foreground-disabled">호가 정보를 불러오는 중입니다.</span>
+        </div>
+      </section>
+    )
+  }
+
   if (!orderBook) {
     return (
       <section className="flex w-[170px] shrink-0 flex-col overflow-hidden border-r border-stroke bg-surface">
@@ -22,7 +37,9 @@ export default function InvestOrderBookPanel({
           <span className="text-[11px] font-bold text-foreground">호가창</span>
         </div>
         <div className="flex flex-1 items-center justify-center px-3 py-4">
-          <span className="text-[10px] text-foreground-disabled">호가 정보를 불러올 수 없습니다.</span>
+          <span className="text-[10px] text-center text-danger">
+            {errorMessage || '호가 정보를 불러오지 못했습니다.'}
+          </span>
         </div>
       </section>
     )

--- a/src/components/invest/InvestOrderSection.jsx
+++ b/src/components/invest/InvestOrderSection.jsx
@@ -24,6 +24,8 @@ export default function InvestOrderSection({
   changeRate,
   defaultPrice,
   orderBook,
+  orderBookLoading,
+  orderBookErrorMessage,
   displayCurrency,
   usdRate,
 }) {
@@ -230,6 +232,8 @@ export default function InvestOrderSection({
         currentPrice={currentPrice}
         changeRate={changeRate}
         orderBook={orderBook}
+        isLoading={orderBookLoading}
+        errorMessage={orderBookErrorMessage}
         onSelectPrice={handleSelectPrice}
         marketType={marketType}
         displayCurrency={displayCurrency}

--- a/src/components/widgets/detail/StockChartDetail.jsx
+++ b/src/components/widgets/detail/StockChartDetail.jsx
@@ -18,7 +18,7 @@ const WIDGET_PERIOD_MAP = {
   '3달': { initialPeriod: 'DAILY',  initialMinuteInterval: undefined },
 }
 
-export default function StockChartDetail({ config = {}, onClose }) {
+export default function StockChartDetail({ config = {} }) {
   const stockCode     = config.stockCode ?? INVEST_STOCK.code
   const locationState = {
     stockName:    config.stockName   ?? null,
@@ -44,6 +44,8 @@ export default function StockChartDetail({ config = {}, onClose }) {
     hasMoreChartHistory,
     marketLoading,
     marketErrorMessage,
+    orderBookLoading,
+    orderBookErrorMessage,
     orderBook,
     onChartPeriodChange,
     onLoadMoreChartHistory,
@@ -114,6 +116,8 @@ export default function StockChartDetail({ config = {}, onClose }) {
           changeRate={changeRate}
           defaultPrice={currentPrice ?? stockMeta.price}
           orderBook={orderBook}
+          orderBookLoading={orderBookLoading}
+          orderBookErrorMessage={orderBookErrorMessage}
           displayCurrency={displayCurrency}
           usdRate={usdRate}
         />

--- a/src/features/invest/domestic/useMarketData.js
+++ b/src/features/invest/domestic/useMarketData.js
@@ -25,6 +25,11 @@ const STALE = {
   finance: 1000 * 60 * 60,
 }
 
+function resolveQueryErrorMessage(error, fallbackMessage) {
+  const rawMessage = typeof error?.message === 'string' ? error.message.trim() : ''
+  return rawMessage || fallbackMessage
+}
+
 function mergeSeriesByTimestamp(...seriesGroups) {
   const merged = new Map()
 
@@ -320,13 +325,22 @@ export default function useDomesticMarketData(stockCode, { enabled, activeDetail
     [chartHistorySeries, baseChartSeries],
   )
 
+  const marketError = priceQuery.error || dailyChartQuery.error || minuteChartQuery.error
+  const marketErrorMessage = resolveQueryErrorMessage(marketError, '현재 시세를 불러오지 못하고 있습니다.')
+  const dailyErrorMessage = resolveQueryErrorMessage(dailyChartQuery.error, '현재 일별 시세를 불러오지 못하고 있습니다.')
+  const minuteErrorMessage = resolveQueryErrorMessage(minuteChartQuery.error, '현재 실시간 시세를 불러오지 못하고 있습니다.')
+  const orderBookErrorMessage = resolveQueryErrorMessage(orderBookQuery.error, '현재 호가 정보를 불러오지 못하고 있습니다.')
+  const customChartErrorMessage = resolveQueryErrorMessage(customChartQuery.error, '현재 차트 데이터를 불러오지 못하고 있습니다.')
+
   const marketState = {
     isLoading: priceQuery.isLoading || dailyChartQuery.isLoading || minuteChartQuery.isLoading || orderBookQuery.isLoading,
-    errorMessage: (priceQuery.error || dailyChartQuery.error || minuteChartQuery.error || orderBookQuery.error)?.message ?? '',
+    errorMessage: marketError ? marketErrorMessage : '',
     dailyLoading: dailyChartQuery.isLoading,
-    dailyErrorMessage: dailyChartQuery.error?.message ?? '',
+    dailyErrorMessage: dailyChartQuery.error ? dailyErrorMessage : '',
     minuteLoading: minuteChartQuery.isLoading,
-    minuteErrorMessage: minuteChartQuery.error?.message ?? '',
+    minuteErrorMessage: minuteChartQuery.error ? minuteErrorMessage : '',
+    orderBookLoading: orderBookQuery.isLoading,
+    orderBookErrorMessage: orderBookQuery.error ? orderBookErrorMessage : '',
     priceData: livePrice ?? priceQuery.data ?? null,
     dailySeries: dailySeriesWithLive,
     minuteSeries: minuteSeriesWithLive,
@@ -335,7 +349,7 @@ export default function useDomesticMarketData(stockCode, { enabled, activeDetail
 
   const chartState = {
     isLoading: customChartQuery.isLoading,
-    errorMessage: customChartQuery.error?.message ?? '',
+    errorMessage: customChartQuery.error ? customChartErrorMessage : '',
     series: customSeries,
   }
 

--- a/src/features/invest/foreign/useMarketData.js
+++ b/src/features/invest/foreign/useMarketData.js
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { foreignMarketApi } from '@/api/market'
 import { DAY_MS, DEFAULT_MINUTE_INTERVAL } from '@/features/invest/constants'
 import { formatApiDate } from '@/features/invest/formatters'
@@ -17,6 +17,52 @@ const STALE = {
   minuteChart: 1000 * 30,
   dailyChart: 1000 * 60 * 5,
   orderBook: 1000 * 5,
+}
+
+function resolveQueryErrorMessage(error, fallbackMessage) {
+  const rawMessage = typeof error?.message === 'string' ? error.message.trim() : ''
+
+  if (!rawMessage) return fallbackMessage
+  if (rawMessage.startsWith('해외주식 API 호출 실패')) return fallbackMessage
+  if (rawMessage === '시장 데이터를 불러오지 못했습니다.') return fallbackMessage
+
+  return rawMessage
+}
+
+function useQueryErrorLogger(label, error, context) {
+  const lastSignatureRef = useRef('')
+
+  useEffect(() => {
+    if (!error) {
+      lastSignatureRef.current = ''
+      return
+    }
+
+    const signature = [
+      label,
+      error.url ?? '',
+      error.status ?? '',
+      error.code ?? '',
+      error.message ?? '',
+      context.stockCode,
+      context.exchcd,
+    ].join('|')
+
+    if (lastSignatureRef.current === signature) return
+    lastSignatureRef.current = signature
+
+    console.error(`[foreign-market] ${label} query failed`, {
+      ...context,
+      url: error.url ?? null,
+      status: error.status ?? null,
+      statusText: error.statusText ?? '',
+      code: error.code ?? null,
+      message: error.message ?? '',
+      data: error.data ?? null,
+      rawText: error.rawText ?? null,
+      error,
+    })
+  }, [context, error, label])
 }
 
 export default function useForeignMarketData(stockCode, exchcd, { enabled, initialPeriod, initialMinuteInterval }) {
@@ -63,6 +109,16 @@ export default function useForeignMarketData(stockCode, exchcd, { enabled, initi
     staleTime: STALE.orderBook,
   })
 
+  const errorLogContext = useMemo(() => ({
+    stockCode,
+    exchcd,
+  }), [exchcd, stockCode])
+
+  useQueryErrorLogger('price', priceQuery.error, errorLogContext)
+  useQueryErrorLogger('daily-chart', dailyChartQuery.error, errorLogContext)
+  useQueryErrorLogger('minute-chart', minuteChartQuery.error, errorLogContext)
+  useQueryErrorLogger('order-book', orderBookQuery.error, errorLogContext)
+
   const usesBaseMinuteData = selectedChartPeriod === 'MINUTE' && selectedMinuteInterval === DEFAULT_MINUTE_INTERVAL
   const needsCustomChart = enabled && !usesBaseMinuteData && selectedChartPeriod !== 'DAILY'
 
@@ -87,6 +143,12 @@ export default function useForeignMarketData(stockCode, exchcd, { enabled, initi
     staleTime: selectedChartPeriod === 'MINUTE' ? STALE.minuteChart : STALE.dailyChart,
   })
 
+  useQueryErrorLogger('custom-chart', customChartQuery.error, {
+    ...errorLogContext,
+    chartPeriod: selectedChartPeriod,
+    minuteInterval: selectedMinuteInterval,
+  })
+
   const dailySeries = normalizeForeignDailySeries(dailyChartQuery.data?.dataPoints)
   const minuteSeries = normalizeForeignMinuteSeries(minuteChartQuery.data?.dataPoints)
 
@@ -94,13 +156,22 @@ export default function useForeignMarketData(stockCode, exchcd, { enabled, initi
     ? { currentPrice: priceQuery.data.price, changeAmount: priceQuery.data.diff, changeRate: priceQuery.data.rate }
     : null
 
+  const marketError = priceQuery.error || dailyChartQuery.error || minuteChartQuery.error
+  const marketErrorMessage = resolveQueryErrorMessage(marketError, '현재 해외주식 시세를 불러오지 못하고 있습니다.')
+  const dailyErrorMessage = resolveQueryErrorMessage(dailyChartQuery.error, '현재 해외주식 일별 시세를 불러오지 못하고 있습니다.')
+  const minuteErrorMessage = resolveQueryErrorMessage(minuteChartQuery.error, '현재 해외주식 실시간 시세를 불러오지 못하고 있습니다.')
+  const orderBookErrorMessage = resolveQueryErrorMessage(orderBookQuery.error, '현재 해외주식 호가 정보를 불러오지 못하고 있습니다.')
+  const customChartErrorMessage = resolveQueryErrorMessage(customChartQuery.error, '현재 해외주식 차트 데이터를 불러오지 못하고 있습니다.')
+
   const marketState = {
     isLoading: priceQuery.isLoading || dailyChartQuery.isLoading || minuteChartQuery.isLoading || orderBookQuery.isLoading,
-    errorMessage: (priceQuery.error || dailyChartQuery.error || minuteChartQuery.error || orderBookQuery.error)?.message ?? '',
+    errorMessage: marketError ? marketErrorMessage : '',
     dailyLoading: dailyChartQuery.isLoading,
-    dailyErrorMessage: dailyChartQuery.error?.message ?? '',
+    dailyErrorMessage: dailyChartQuery.error ? dailyErrorMessage : '',
     minuteLoading: minuteChartQuery.isLoading,
-    minuteErrorMessage: minuteChartQuery.error?.message ?? '',
+    minuteErrorMessage: minuteChartQuery.error ? minuteErrorMessage : '',
+    orderBookLoading: orderBookQuery.isLoading,
+    orderBookErrorMessage: orderBookQuery.error ? orderBookErrorMessage : '',
     priceData,
     dailySeries,
     minuteSeries,
@@ -117,7 +188,7 @@ export default function useForeignMarketData(stockCode, exchcd, { enabled, initi
 
   const chartState = {
     isLoading: customChartQuery.isLoading,
-    errorMessage: customChartQuery.error?.message ?? '',
+    errorMessage: customChartQuery.error ? customChartErrorMessage : '',
     series: customSeries,
   }
 

--- a/src/features/invest/useInvestMarketData.js
+++ b/src/features/invest/useInvestMarketData.js
@@ -13,6 +13,7 @@ export default function useInvestMarketData(stockCode, locationState, { activeLe
   const baseStockMeta = resolveStockMeta(stockCode, locationState)
   const { isDomestic } = baseStockMeta
   const exchcd = isDomestic ? null : getExchcd(baseStockMeta.exchangeCode)
+  const locationStockName = locationState?.stockName
 
   const infoQuery = useQuery({
     queryKey: isDomestic
@@ -27,7 +28,7 @@ export default function useInvestMarketData(stockCode, locationState, { activeLe
 
   const stockMeta = useMemo(() => {
     if (isDomestic) {
-      const resolvedName = locationState?.stockName
+      const resolvedName = locationStockName
         ?? infoQuery.data?.companyName
         ?? infoQuery.data?.stockName
         ?? infoQuery.data?.name
@@ -55,7 +56,7 @@ export default function useInvestMarketData(stockCode, locationState, { activeLe
       market: infoQuery.data?.exchangeName ?? baseStockMeta.market,
       sector: infoQuery.data?.induname ?? baseStockMeta.sector,
     }
-  }, [baseStockMeta, infoQuery.data, isDomestic])
+  }, [baseStockMeta, exchcd, infoQuery.data, isDomestic, locationStockName])
 
   const domestic = useDomesticMarketData(stockCode, { enabled: isDomestic, activeDetailTab: activeLeftTab, initialPeriod, initialMinuteInterval })
   const foreign = useForeignMarketData(stockCode, exchcd, { enabled: !isDomestic, activeDetailTab: activeLeftTab, initialPeriod, initialMinuteInterval })
@@ -133,6 +134,8 @@ export default function useInvestMarketData(stockCode, locationState, { activeLe
     hasMoreChartHistory: active.hasMoreChartHistory ?? false,
     marketLoading: marketState.isLoading,
     marketErrorMessage: marketState.errorMessage,
+    orderBookLoading: marketState.orderBookLoading ?? false,
+    orderBookErrorMessage: marketState.orderBookErrorMessage ?? '',
     dailyRows: active.dailyRows,
     realtimeRows: active.realtimeRows,
     orderBook: active.orderBook,

--- a/src/pages/InvestPage.jsx
+++ b/src/pages/InvestPage.jsx
@@ -40,6 +40,8 @@ export default function InvestPage() {
     hasMoreChartHistory,
     marketLoading,
     marketErrorMessage,
+    orderBookLoading,
+    orderBookErrorMessage,
     dailyRows,
     realtimeRows,
     orderBook,
@@ -133,6 +135,8 @@ export default function InvestPage() {
             changeRate={changeRate}
             defaultPrice={currentPrice ?? stockMeta.price}
             orderBook={orderBook}
+            orderBookLoading={orderBookLoading}
+            orderBookErrorMessage={orderBookErrorMessage}
             displayCurrency={displayCurrency}
             usdRate={usdRate}
           />


### PR DESCRIPTION
## 변경 사항
- 해외주식 시세/차트/호가 오류 메시지를 화면용 문구로 정리
- 해외주식 API 실패 시 콘솔에 상태 코드, URL, 응답 본문을 포함한 디버깅 로그 추가
- 호가창에서 로딩 상태와 에러 상태를 분리하고 에러 색상을 공통 에러 스타일로 통일

## 검증
- pnpm eslint src/api/market.js src/features/invest/foreign/useMarketData.js src/features/invest/domestic/useMarketData.js src/features/invest/useInvestMarketData.js src/pages/InvestPage.jsx src/components/widgets/detail/StockChartDetail.jsx src/components/invest/InvestOrderSection.jsx src/components/invest/InvestOrderBookPanel.jsx