### PR TITLE
fix(widget): 오늘의 시황 및 포트폴리오 렌더링 안정화

### DIFF
--- a/src/api/balance.js
+++ b/src/api/balance.js
@@ -8,6 +8,21 @@ function get(path, params) {
   return fetchWithAuth(`${path}${query}`)
 }
 
+function toArray(value) {
+  return Array.isArray(value) ? value : []
+}
+
+function normalizePortfolioData(data) {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return { items: [] }
+  }
+
+  return {
+    ...data,
+    items: toArray(data.items),
+  }
+}
+
 export const balanceApi = {
   // 예수금 조회 (통화별)
   getCashBalances: () => get('/api/balance/cash'),
@@ -46,6 +61,7 @@ export const useDomesticHoldings = ({ enabled = true } = {}) =>
     queryKey: ['balance', 'holdings', 'domestic'],
     queryFn: () => balanceApi.getDomesticHoldings(),
     enabled,
+    select: toArray,
     staleTime: 1000 * 30,
   })
 
@@ -54,6 +70,7 @@ export const useOverseasHoldings = ({ enabled = true } = {}) =>
     queryKey: ['balance', 'holdings', 'overseas'],
     queryFn: () => balanceApi.getOverseasHoldings(),
     enabled,
+    select: toArray,
     staleTime: 1000 * 30,
   })
 
@@ -78,5 +95,6 @@ export const usePortfolioData = ({ enabled = true } = {}) =>
     queryKey: ['portfolio'],
     queryFn: balanceApi.getPortfolio,
     enabled,
+    select: normalizePortfolioData,
     staleTime: 1000 * 30,
   })

--- a/src/components/layout/ChatInfoCard.jsx
+++ b/src/components/layout/ChatInfoCard.jsx
@@ -18,6 +18,27 @@ function applyArrows(children) {
   )
 }
 
+const CONDITIONAL_SECTION_HEADERS = new Set([
+  '📋 주요 이슈',
+  '📊 섹터 동향',
+  '📈 주요 종목',
+])
+
+function isSectionBoundary(line) {
+  const trimmed = line.trim()
+  return /^(🇰🇷 국내 시황|🇺🇸 해외 시황|💬\s|📋\s|📊\s|📈\s)/.test(trimmed)
+}
+
+function hasMeaningfulSectionContent(line) {
+  const trimmed = line.trim()
+
+  if (!trimmed) return false
+  if (trimmed === '•' || trimmed === '-' || trimmed === '*') return false
+  if (/^\[[^\]]+\]$/.test(trimmed)) return false
+
+  return true
+}
+
 // 📈 주요 종목 섹션에서 [KOSPI]/[KOSDAQ] 각 3개만 남김
 function hasArrow(line) {
   return line.includes('▲') || line.includes('▼') || line.includes('🔺') || line.includes('🔻')
@@ -49,8 +70,41 @@ function truncateStockSection(text) {
   return before + result.join('\n')
 }
 
+function removeEmptySummarySections(text) {
+  const lines = text.split('\n')
+  const result = []
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    const trimmed = line.trim()
+
+    if (!CONDITIONAL_SECTION_HEADERS.has(trimmed)) {
+      result.push(line)
+      continue
+    }
+
+    const sectionLines = [line]
+    let cursor = i + 1
+
+    while (cursor < lines.length && !isSectionBoundary(lines[cursor])) {
+      sectionLines.push(lines[cursor])
+      cursor++
+    }
+
+    const hasContent = sectionLines.slice(1).some(hasMeaningfulSectionContent)
+    if (hasContent) {
+      result.push(...sectionLines)
+    }
+
+    i = cursor - 1
+  }
+
+  return result.join('\n').replace(/\n{3,}/g, '\n\n')
+}
+
 export default function ChatInfoCard({ text }) {
-  const processed = truncateStockSection(text).replace(/^━+\s*$/gm, '\n\n---\n\n')
+  const processed = removeEmptySummarySections(truncateStockSection(text))
+    .replace(/^━+\s*$/gm, '\n\n---\n\n')
 
   return (
     <div className="bg-surface border border-stroke rounded-[16px] px-2.5 py-2 text-[12px] leading-relaxed text-foreground">

--- a/src/components/widgets/MarketOverviewWidget.jsx
+++ b/src/components/widgets/MarketOverviewWidget.jsx
@@ -55,8 +55,8 @@ export default function MarketOverviewWidget({ instanceId, variant = 'market-sm'
   const [tab, setTab] = useState(
     () => localStorage.getItem(STORAGE_KEY_ACTIVE_TAB) ?? config.tab ?? 'kr'
   )
-  const { krNews, usNews, isLoading } = useLatestNews(10)
-  const items = tab === 'kr' ? krNews : usNews
+  const { krDisplayNews, usDisplayNews, isLoading } = useLatestNews(10)
+  const items = tab === 'kr' ? krDisplayNews : usDisplayNews
   const openDetail = useWidgetDetailStore((s) => s.open)
   const updateWidgetConfig = useWidgetStore((s) => s.updateWidgetConfig)
 
@@ -99,8 +99,8 @@ export default function MarketOverviewWidget({ instanceId, variant = 'market-sm'
   const loading = <div className="text-widget-10 text-foreground-disabled py-2 opacity-50 group-hover:opacity-75 transition-opacity">불러오는 중...</div>
 
   if (variant === 'market-2x2') {
-    const krTop = krNews[0] ?? null
-    const usTop = usNews[0] ?? null
+    const krTop = krDisplayNews[0] ?? null
+    const usTop = usDisplayNews[0] ?? null
     const sectionTitleClass = 'text-widget-10 font-semibold text-foreground-disabled tracking-[.04em] uppercase'
     const sectionCardClass = 'flex flex-col gap-0.5 py-2 border-b border-stroke last:border-b-0 cursor-pointer pl-2 border-l-2 border-l-transparent hover:border-l-primary transition-colors'
     return (
@@ -137,9 +137,7 @@ export default function MarketOverviewWidget({ instanceId, variant = 'market-sm'
   }
 
   if (variant === 'market-wide') {
-    const todayUtc = new Date().toISOString().slice(0, 10)
-    const todayItems = items.filter((n) => n.publishedAt?.startsWith(todayUtc))
-    const wideItems = (todayItems.length > 0 ? todayItems : items).slice(0, 2)
+    const wideItems = items.slice(0, 2)
     return (
       <WidgetCard colSpan={colSpan} rowSpan={rowSpan} onDelete={onDelete} onClick={handleWidgetClick}>
         <div className="flex items-center gap-1.5 mb-1 shrink-0">

--- a/src/components/widgets/PortfolioWidget.jsx
+++ b/src/components/widgets/PortfolioWidget.jsx
@@ -35,7 +35,11 @@ function usePortfolio(enabled, topN = 3) {
     const isLoading = enabled && (sl || dl || ol || pl)
     if (isLoading) return { items: [], returnRate: null, isLoading: true }
 
-    const allHoldings = [...domestic, ...overseas]
+    const domesticList = Array.isArray(domestic) ? domestic : []
+    const overseasList = Array.isArray(overseas) ? overseas : []
+    const portfolioItemsRaw = Array.isArray(portfolio?.items) ? portfolio.items : []
+
+    const allHoldings = [...domesticList, ...overseasList]
       .filter((h) => (h.holdingQuantity ?? 0) > 0 || (h.availableQuantity ?? 0) > 0)
       .map((h) => ({
         ...h,
@@ -43,7 +47,7 @@ function usePortfolio(enabled, topN = 3) {
       }))
     const holdingByName = Object.fromEntries(allHoldings.map((h) => [h.stockName, h]))
 
-    const orderedItems = (portfolio?.items ?? []).filter((item) => item.type === 'STOCK')
+    const orderedItems = portfolioItemsRaw.filter((item) => item.type === 'STOCK')
     const normalized = orderedItems.map((item) => {
       const holding = holdingByName[item.label]
       return {

--- a/src/features/market/useLatestNews.js
+++ b/src/features/market/useLatestNews.js
@@ -1,12 +1,79 @@
 import { useQuery } from '@tanstack/react-query'
+import { useMemo } from 'react'
 import { newsApi } from '@/api/news'
 
 const KR_INDICES = ['KOSPI', 'KOSDAQ']
 const US_INDICES = ['NASDAQ', 'S&P500', 'DOW']
 const US_KEYWORDS = ['뉴욕', '미국', '나스닥', 's&p', '다우', '월가', 'fomc']
+const DATE_PREFIX_REGEX = /^(\d{4}-\d{2}-\d{2})/
 
 function asArray(value) {
   return Array.isArray(value) ? value : []
+}
+
+function getLocalDateKey(date) {
+  const yyyy = date.getFullYear()
+  const mm = String(date.getMonth() + 1).padStart(2, '0')
+  const dd = String(date.getDate()).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd}`
+}
+
+function extractPublishedDateKey(value) {
+  if (typeof value !== 'string') return ''
+
+  const trimmed = value.trim()
+  if (!trimmed) return ''
+
+  const prefixMatch = trimmed.match(DATE_PREFIX_REGEX)
+  if (prefixMatch) {
+    return prefixMatch[1]
+  }
+
+  const parsed = Date.parse(trimmed.replace(' ', 'T'))
+  if (Number.isNaN(parsed)) return ''
+
+  return getLocalDateKey(new Date(parsed))
+}
+
+function getPublishedTimestamp(value) {
+  if (typeof value !== 'string') return null
+
+  const trimmed = value.trim()
+  if (!trimmed) return null
+
+  const parsed = Date.parse(trimmed.replace(' ', 'T'))
+  if (!Number.isNaN(parsed)) {
+    return parsed
+  }
+
+  const dateKey = extractPublishedDateKey(trimmed)
+  if (!dateKey) return null
+
+  const fallbackParsed = Date.parse(`${dateKey}T00:00:00`)
+  return Number.isNaN(fallbackParsed) ? null : fallbackParsed
+}
+
+function sortLatestNews(items) {
+  return items
+    .map((item, index) => ({
+      item,
+      index,
+      timestamp: getPublishedTimestamp(item?.publishedAt ?? item?.date ?? ''),
+    }))
+    .sort((left, right) => {
+      if (left.timestamp != null && right.timestamp != null && left.timestamp !== right.timestamp) {
+        return right.timestamp - left.timestamp
+      }
+      if (left.timestamp != null && right.timestamp == null) return -1
+      if (left.timestamp == null && right.timestamp != null) return 1
+      return left.index - right.index
+    })
+    .map(({ item }) => item)
+}
+
+function selectTodayNews(items, todayKey) {
+  const todayItems = items.filter((item) => extractPublishedDateKey(item?.publishedAt ?? item?.date ?? '') === todayKey)
+  return todayItems.length > 0 ? todayItems : items
 }
 
 function inferStockIndex(item) {
@@ -88,9 +155,28 @@ export default function useLatestNews(size = 10) {
     retry: false,
   })
 
-  const all = normalizeLatestNews(data)
-  const kr  = all.filter((n) => !n.stockIndex || KR_INDICES.includes(n.stockIndex))
-  const us  = all.filter((n) => US_INDICES.includes(n.stockIndex))
+  const { all, kr, us, krDisplay, usDisplay } = useMemo(() => {
+    const normalized = sortLatestNews(normalizeLatestNews(data))
+    const krNews = normalized.filter((n) => !n.stockIndex || KR_INDICES.includes(n.stockIndex))
+    const usNews = normalized.filter((n) => US_INDICES.includes(n.stockIndex))
+    const todayKey = getLocalDateKey(new Date())
 
-  return { news: all, krNews: kr, usNews: us, isLoading, error }
+    return {
+      all: normalized,
+      kr: krNews,
+      us: usNews,
+      krDisplay: selectTodayNews(krNews, todayKey),
+      usDisplay: selectTodayNews(usNews, todayKey),
+    }
+  }, [data])
+
+  return {
+    news: all,
+    krNews: kr,
+    usNews: us,
+    krDisplayNews: krDisplay,
+    usDisplayNews: usDisplay,
+    isLoading,
+    error,
+  }
 }


### PR DESCRIPTION
## 변경 사항
- 오늘의 시황 위젯이 모든 variant에서 오늘 기사 우선 기준으로 동일한 뉴스를 표시하도록 정리
- 채팅형 오늘의 시황 카드에서 섹터 동향/주요 종목/주요 이슈가 비어 있으면 섹션 전체를 숨기도록 처리
- 포트폴리오 위젯에서 보유종목/포트폴리오 응답이 배열이 아니어도 렌더링이 깨지지 않도록 방어 로직 추가

## 검증
- pnpm eslint src/api/balance.js src/components/widgets/PortfolioWidget.jsx src/components/layout/ChatInfoCard.jsx src/features/market/useLatestNews.js src/components/widgets/MarketOverviewWidget.jsx